### PR TITLE
fix(race-condition): enforce-init hook refactor to use individual file tracking

### DIFF
--- a/internal/embedded/hooks/enforce-init.sh
+++ b/internal/embedded/hooks/enforce-init.sh
@@ -19,7 +19,10 @@ session_id=$(json_val session_id)
 # Fallback: $PPID is the Claude Code process PID (POSIX — the parent that forked this shell).
 # Stable for the session lifetime since all hook invocations share the same parent process.
 STATE_DIR="/tmp/liza-init-gate-${session_id:-ppid-$PPID}"
-mkdir -p "$STATE_DIR" 2>/dev/null
+if ! mkdir -p "$STATE_DIR" 2>/dev/null; then
+  echo "enforce-init: cannot create state dir $STATE_DIR, failing open" >&2
+  exit 0
+fi
 
 # Fast path: gate already cleared.
 if [[ -f "$STATE_DIR/CLEARED" ]]; then


### PR DESCRIPTION
I've been running into race conditions, and claude has been very diligent in trying to determine why the enforce hook isn't working.  `sed` and `mv` are not atomic operations, so this change relies on `touch` and the existence of the file `[[ -f ]]` as proof the enforce-init hook conditions are met.

It also allows ToolSearch, which claude requires in order to determine it needs to use the Read tool to read files.  

