### PR TITLE
fix: treat SUPERSEDED as satisfied dependency

### DIFF
--- a/internal/commands/claim_task_test.go
+++ b/internal/commands/claim_task_test.go
@@ -61,6 +61,17 @@ func TestClaimTaskCommand(t *testing.T) {
 			wantWorktree:  true,
 		},
 		{
+			name:          "claim READY task with superseded dependency",
+			taskID:        "task-3",
+			agentID:       "coder-1",
+			taskStatus:    models.TaskStatusReady,
+			hasWorktree:   false,
+			hasDependency: true,
+			depStatus:     models.TaskStatusSuperseded,
+			wantErr:       false,
+			wantWorktree:  true,
+		},
+		{
 			name:          "claim REJECTED task by same coder",
 			taskID:        "task-4",
 			agentID:       "coder-1",

--- a/internal/models/diagnostics.go
+++ b/internal/models/diagnostics.go
@@ -41,17 +41,17 @@ func GetCoderWorkDiagnostics(state *State, pr PipelineResolver) string {
 	blockedByDeps := 0
 	inProgress := 0
 
-	mergedIDs := make(map[string]bool)
+	satisfiedIDs := make(map[string]bool)
 	for _, task := range state.Tasks {
-		if task.Status == TaskStatusMerged {
-			mergedIDs[task.ID] = true
+		if task.Status == TaskStatusMerged || task.Status == TaskStatusSuperseded {
+			satisfiedIDs[task.ID] = true
 		}
 	}
 
 	for _, task := range state.Tasks {
 		// Pipeline path: use resolver to classify statuses dynamically.
 		if task.RolePair != "" && pr != nil {
-			if isBlockedByDepsPipeline(&task, pr, mergedIDs) {
+			if isBlockedByDepsPipeline(&task, pr, satisfiedIDs) {
 				blockedByDeps++
 			}
 			if isInProgressPipeline(&task, pr) {
@@ -66,7 +66,7 @@ func GetCoderWorkDiagnostics(state *State, pr PipelineResolver) string {
 			task.Status == TaskStatusIntegrationFailed {
 			hasUnsatisfiedDeps := false
 			for _, depID := range task.DependsOn {
-				if !mergedIDs[depID] {
+				if !satisfiedIDs[depID] {
 					hasUnsatisfiedDeps = true
 					break
 				}
@@ -97,7 +97,7 @@ func GetCoderWorkDiagnostics(state *State, pr PipelineResolver) string {
 
 // isBlockedByDepsPipeline checks if a pipeline task is in an initial/rejected status
 // with unsatisfied dependencies.
-func isBlockedByDepsPipeline(task *Task, pr PipelineResolver, mergedIDs map[string]bool) bool {
+func isBlockedByDepsPipeline(task *Task, pr PipelineResolver, satisfiedIDs map[string]bool) bool {
 	initial, err := pr.InitialStatus(task.RolePair)
 	if err != nil {
 		return false
@@ -110,7 +110,7 @@ func isBlockedByDepsPipeline(task *Task, pr PipelineResolver, mergedIDs map[stri
 		return false
 	}
 	for _, depID := range task.DependsOn {
-		if !mergedIDs[depID] {
+		if !satisfiedIDs[depID] {
 			return true
 		}
 	}

--- a/internal/models/diagnostics_test.go
+++ b/internal/models/diagnostics_test.go
@@ -96,6 +96,17 @@ func TestCountClaimableTasks(t *testing.T) {
 			role: RoleCoder,
 			want: 1,
 		},
+		{
+			name: "superseded dependency satisfied",
+			state: &State{
+				Tasks: []Task{
+					{ID: "t1", Status: TaskStatusReady, Type: TaskTypeCoding, RolePair: "coding-pair", DependsOn: []string{"t2"}},
+					{ID: "t2", Status: TaskStatusSuperseded, Type: TaskTypeCoding, RolePair: "coding-pair"},
+				},
+			},
+			role: RoleCoder,
+			want: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -237,6 +248,16 @@ func TestGetCoderWorkDiagnostics(t *testing.T) {
 				},
 			},
 			wantContains: []string{"No claimable tasks", "2 in progress"},
+		},
+		{
+			name: "superseded dependency not counted as blocked",
+			state: &State{
+				Tasks: []Task{
+					{ID: "t1", Status: TaskStatusReady, Type: TaskTypeCoding, RolePair: "coding-pair", DependsOn: []string{"t2"}},
+					{ID: "t2", Status: TaskStatusSuperseded, Type: TaskTypeCoding, RolePair: "coding-pair"},
+				},
+			},
+			wantContains: []string{"Found 1 claimable task(s)"},
 		},
 		{
 			name: "both blocked and in-progress reported",

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -465,13 +465,15 @@ func IsExecutingStatus(task *Task, pr PipelineResolver) bool {
 	return err == nil && task.Status == executing
 }
 
-// checkDependencies returns true if all dependencies of the task are satisfied (MERGED).
+// checkDependencies returns true if all dependencies of the task are satisfied
+// (MERGED or SUPERSEDED). ABANDONED is terminal but not satisfying — the work
+// was dropped, not completed or replaced.
 func checkDependencies(t *Task, allTasks []Task) bool {
 	if allTasks != nil && len(t.DependsOn) > 0 {
 		for _, depID := range t.DependsOn {
 			depSatisfied := false
 			for _, task := range allTasks {
-				if task.ID == depID && task.Status == TaskStatusMerged {
+				if task.ID == depID && (task.Status == TaskStatusMerged || task.Status == TaskStatusSuperseded) {
 					depSatisfied = true
 					break
 				}

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -211,6 +211,20 @@ func TestIsClaimable(t *testing.T) {
 			t.Error("met dependency should allow claim")
 		}
 	})
+
+	t.Run("superseded dependency satisfies claim", func(t *testing.T) {
+		allTasks := []Task{
+			{ID: "dep-1", Status: TaskStatusSuperseded},
+		}
+		task := &Task{
+			RolePair:  "coding-pair",
+			Status:    "DRAFT_CODE",
+			DependsOn: []string{"dep-1"},
+		}
+		if !task.IsClaimable("coder", allTasks, pr) {
+			t.Error("superseded dependency should allow claim")
+		}
+	})
 }
 
 func TestIsClaimable_SentinelAssignedToReturnsFalse(t *testing.T) {

--- a/internal/ops/claim_task.go
+++ b/internal/ops/claim_task.go
@@ -327,7 +327,7 @@ func unmetDependencies(task *models.Task, state *models.State) []string {
 	var unmet []string
 	for _, depID := range task.DependsOn {
 		depTask := state.FindTask(depID)
-		if depTask == nil || depTask.Status != models.TaskStatusMerged {
+		if depTask == nil || (depTask.Status != models.TaskStatusMerged && depTask.Status != models.TaskStatusSuperseded) {
 			unmet = append(unmet, depID)
 		}
 	}

--- a/internal/statevalidate/validate_deps.go
+++ b/internal/statevalidate/validate_deps.go
@@ -10,10 +10,10 @@ import (
 
 // validateDependencies checks referential integrity and ordering constraints
 // for task dependencies: every depends_on entry must reference an existing task,
-// executing tasks must have all dependencies in MERGED status, and the
-// dependency graph must be acyclic. Prevents agents from starting work on tasks
-// whose prerequisites are incomplete and detects dependency cycles that would
-// deadlock the scheduler.
+// executing tasks must have all dependencies in MERGED or SUPERSEDED status, and
+// the dependency graph must be acyclic. Prevents agents from starting work on
+// tasks whose prerequisites are incomplete and detects dependency cycles that
+// would deadlock the scheduler.
 func validateDependencies(state *models.State, projectRoot string, skipSpecFileCheck bool, resolver *pipeline.Resolver, cfg *pipeline.PipelineConfig) error {
 	taskIDs := buildTaskIDSet(state.Tasks)
 	sc := newStatusClassifier(resolver, cfg)
@@ -30,17 +30,17 @@ func validateDependencies(state *models.State, projectRoot string, skipSpecFileC
 			}
 		}
 
-		// Executing tasks must have all dependencies MERGED
+		// Executing tasks must have all dependencies satisfied (MERGED or SUPERSEDED)
 		if sc.IsExecuting(task.Status) {
 			var unmet []string
 			for _, depID := range task.DependsOn {
 				depTask := state.FindTask(depID)
-				if depTask != nil && depTask.Status != models.TaskStatusMerged {
+				if depTask != nil && depTask.Status != models.TaskStatusMerged && depTask.Status != models.TaskStatusSuperseded {
 					unmet = append(unmet, depID)
 				}
 			}
 			if len(unmet) > 0 {
-				return fmt.Errorf("executing task %s has unmet dependencies: %s (must be MERGED)", task.ID, strings.Join(unmet, ", "))
+				return fmt.Errorf("executing task %s has unmet dependencies: %s (must be MERGED or SUPERSEDED)", task.ID, strings.Join(unmet, ", "))
 			}
 		}
 	}

--- a/internal/statevalidate/validate_pipeline_test.go
+++ b/internal/statevalidate/validate_pipeline_test.go
@@ -342,3 +342,45 @@ func TestValidateDependencies_ExecutingUnmetDeps(t *testing.T) {
 		t.Errorf("Error = %q, want to contain 'unmet dependencies'", err.Error())
 	}
 }
+
+func TestValidateDependencies_SupersededDepSatisfied(t *testing.T) {
+	cfg := loadTestConfig(t)
+	resolver := pipeline.NewResolver(cfg)
+	state := testhelpers.CreateValidState()
+	now := time.Now().UTC()
+	assignee := "coder-1"
+	worktree := ".worktrees/task-exec"
+	baseCommit := "abc123"
+	leaseExpires := now.Add(30 * time.Minute)
+
+	// dep-task is SUPERSEDED — should satisfy dependency
+	state.Tasks = []models.Task{
+		{
+			ID:          "dep-task",
+			Description: "Superseded dependency task",
+			Status:      models.TaskStatusSuperseded,
+			Priority:    1,
+			Created:     now,
+			RolePair:    "coding-pair",
+		},
+		{
+			ID:           "task-exec",
+			Description:  "Executing task depending on superseded task",
+			Status:       models.TaskStatus("IMPLEMENTING_CODE"),
+			Priority:     1,
+			Created:      now,
+			RolePair:     "coding-pair",
+			AssignedTo:   &assignee,
+			Worktree:     &worktree,
+			BaseCommit:   &baseCommit,
+			LeaseExpires: &leaseExpires,
+			DependsOn:    []string{"dep-task"},
+		},
+	}
+	state.Sprint.Scope.Planned = []string{"dep-task", "task-exec"}
+
+	err := validateDependencies(state, "", true, resolver, cfg)
+	if err != nil {
+		t.Fatalf("SUPERSEDED dependency should satisfy requirement, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Dependency checks only accepted `MERGED`, causing tasks with `SUPERSEDED` dependencies to stay stuck in `DRAFT_CODE` (fixes #5)
- Fixed all four locations: `validate_deps.go`, `task.go` (`checkDependencies`), `claim_task.go` (`unmetDependencies`), `diagnostics.go` (blocked-by-deps counter)
- Added tests covering each fix location

## Test plan
- [x] Red test confirmed bug before fix (`TestValidateDependencies_SupersededDepSatisfied`)
- [x] Red test confirmed bug at claim level (`TestClaimTaskCommand/claim_READY_task_with_superseded_dependency`)
- [x] All 3431 tests pass (3427 pre-existing + 4 new)
- [ ] Verify in live multi-agent run that superseded dependencies unblock downstream tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)