### PR TITLE
fix(git-internal): force C locale for git subprocess to avoid non-English error messages breaking BranchExists

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,6 +3,7 @@ package git
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -26,10 +27,24 @@ func New(projectRoot string) *Git {
 	}
 }
 
+// gitEnv returns the current environment with LC_ALL=C forced, so git output
+// is always in English regardless of the system locale.
+func gitEnv() []string {
+	env := os.Environ()
+	for i, e := range env {
+		if strings.HasPrefix(e, "LC_ALL=") {
+			env[i] = "LC_ALL=C"
+			return env
+		}
+	}
+	return append(env, "LC_ALL=C")
+}
+
 // exec runs a git command in the project root and returns output
 func (g *Git) exec(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = g.projectRoot
+	cmd.Env = gitEnv()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %v failed: %w\nOutput: %s", args, err, output)
@@ -41,6 +56,7 @@ func (g *Git) exec(args ...string) (string, error) {
 func (g *Git) execInDir(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = gitEnv()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %v failed: %w\nOutput: %s", args, err, output)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/liza-mas/liza/internal/testhelpers"
 )
 
+func TestGitEnv_ForcesLCAllC(t *testing.T) {
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+
+	env := gitEnv()
+
+	var lcAll string
+	for _, e := range env {
+		if strings.HasPrefix(e, "LC_ALL=") {
+			lcAll = e
+		}
+	}
+	if lcAll != "LC_ALL=C" {
+		t.Errorf("gitEnv() LC_ALL = %q, want %q", lcAll, "LC_ALL=C")
+	}
+}
+
 func TestNew(t *testing.T) {
 	repoDir := setupTestRepo(t)
 
@@ -76,6 +92,25 @@ func TestBranchExists(t *testing.T) {
 	}
 	if exists {
 		t.Error("BranchExists(nonexistent) = true, want false")
+	}
+}
+
+func TestBranchExists_NonEnglishLocale(t *testing.T) {
+	// Regression test: BranchExists must return (false, nil) for a missing branch
+	// even when the parent process has a non-English locale set. gitEnv() forces
+	// LC_ALL=C on the git subprocess so the error message is always in English.
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	t.Setenv("LANG", "fr_FR.UTF-8")
+
+	repoDir := setupTestRepo(t)
+	git := New(repoDir)
+
+	exists, err := git.BranchExists("nonexistent-branch")
+	if err != nil {
+		t.Fatalf("BranchExists() error = %v (locale may not be forced to C)", err)
+	}
+	if exists {
+		t.Error("BranchExists() = true, want false")
 	}
 }
 

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -31,6 +31,7 @@ func (g *Git) FetchFromLocal(wtPath string, branch string) error {
 func (g *Git) RebaseOnto(wtPath string, baseBranch string) error {
 	cmd := exec.Command("git", "rebase", baseBranch)
 	cmd.Dir = wtPath
+	cmd.Env = gitEnv()
 	rawOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		out := string(rawOutput)


### PR DESCRIPTION
# Bug: `BranchExists` fails on non-English git locales

## Summary

When running Liza on a system with a non-English locale (e.g. `LANG=fr_FR.UTF-8`), agents
cannot claim tasks. The root cause is that `BranchExists` parses a git error message that
is locale-dependent and therefore only matches the English variant.

## Affected code

`internal/git/git.go`, function `BranchExists` (line ~68):

```go
func (g *Git) BranchExists(branch string) (bool, error) {
    _, err := g.exec("rev-parse", "--verify", "refs/heads/"+branch)
    if err != nil {
        errMsg := err.Error()
        if strings.Contains(errMsg, "unknown revision") ||
            strings.Contains(errMsg, "not a valid ref") ||
            strings.Contains(errMsg, "Needed a single revision") {  // ← English only
            return false, nil
        }
        return false, err
    }
    return true, nil
}
```

When the queried branch does not exist, `git rev-parse --verify` exits with code 128 and
prints an error. The function checks the error text to distinguish "branch not found" from
a genuine failure. The string `"Needed a single revision"` is git's English message for
this case. In French, git outputs:

```
fatal : Une seule révision attendue
```

Note the **space before the colon** — standard French punctuation — which also means a
naive `"fatal:"` prefix check would not help here.

Because the French message matches none of the expected strings, `BranchExists` returns
`(false, err)` instead of `(false, nil)`, propagating an error up the call stack.

## Impact

Any caller that treats the error as fatal will break. The two direct callers in
`internal/ops/claim_task.go` (lines 377 and 412) do exactly that, returning an error that
prevents the claim from proceeding. Agents running in a French (or other non-English)
locale cannot claim tasks.

## Reproduction

```bash
LANG=fr_FR.UTF-8 liza claim-task <task-id> <agent-id>
# → fails; same command with LANG=C succeeds
```

## Example

On a local project, on my machine:
```bash
henry@henry-ThinkPad-T14-Gen-5:~/workspace/mcp-score$ liza claim-task epp-2 epic-planner-1
Error: failed to check branch existence: git [rev-parse --verify refs/heads/task/epp-2] failed: exit status 128
Output: fatal : Une seule révision attendue
```

```bash
henry@henry-ThinkPad-T14-Gen-5:~/workspace/mcp-score$ LC_ALL=C liza claim-task epp-2 epic-planner-1
IMPLEMENTING: epp-2 by epic-planner-1 (from DRAFT_EPIC_PLAN)
  worktree: .worktrees/epp-2
  base_commit: cdbc378dbd4cb24041b0e8c5d316614edaf60a00
  lease_expires: 2026-04-04T12:56:55Z
```

## Root cause

`g.exec(...)` inherits the process environment, so git picks up the system locale and
translates its output. Liza then parses that translated output with English-only string
matching.

## Proposed fix

Force the C locale for all git subprocesses so that output is always in English,
regardless of the system locale. This is the standard approach used by tools like
`git log --format` parsers.

In the `exec` helper (or in `BranchExists` directly), set `LC_ALL=C` in the subprocess
environment before running git:

```go
cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C", "LANGUAGE=")
```

This is safe: it only affects the subprocess; the parent process locale is unchanged.

An alternative — checking the exit code (128) instead of the message text — is fragile
because exit code 128 is git's generic "fatal error" code and could mask unrelated
failures (e.g. a corrupt repository).

## Related tests

`internal/git/git_test.go:59` (`TestBranchExists`) covers the non-existent branch path
but runs in the developer's locale, so it does not catch this regression. A test that
explicitly sets a non-English locale (or mocks the subprocess output) would be needed to
prevent recurrence.
