### PR TITLE
fix(git): force C locale for all git subprocesses

### DIFF
--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/liza-mas/liza/internal/db"
 	"github.com/liza-mas/liza/internal/embedded"
+	gitpkg "github.com/liza-mas/liza/internal/gitenv"
 	"github.com/liza-mas/liza/internal/models"
 	"github.com/liza-mas/liza/internal/paths"
 	"github.com/liza-mas/liza/internal/pipeline"
@@ -731,7 +731,7 @@ func InitCommandWithConfig(params InitParams) error {
 
 // validateBranchName checks that name is a valid git branch name.
 func validateBranchName(name string) error {
-	cmd := exec.Command("git", "check-ref-format", "--branch", name)
+	cmd := gitpkg.Command("check-ref-format", "--branch", name)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("not a valid git branch name: %s", strings.TrimSpace(string(output)))
 	}
@@ -739,12 +739,12 @@ func validateBranchName(name string) error {
 }
 
 func createIntegrationBranch(name string) error {
-	cmd := exec.Command("git", "rev-parse", "--verify", name)
+	cmd := gitpkg.Command("rev-parse", "--verify", name)
 	if err := cmd.Run(); err == nil {
 		return nil
 	}
 
-	cmd = exec.Command("git", "branch", name, "HEAD")
+	cmd = gitpkg.Command("branch", name, "HEAD")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git branch failed: %w: %s", err, string(output))

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,9 +3,9 @@ package git
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
+
+	"github.com/liza-mas/liza/internal/gitenv"
 )
 
 // Git provides git operations for worktree management
@@ -27,24 +27,10 @@ func New(projectRoot string) *Git {
 	}
 }
 
-// gitEnv returns the current environment with LC_ALL=C forced, so git output
-// is always in English regardless of the system locale.
-func gitEnv() []string {
-	env := os.Environ()
-	for i, e := range env {
-		if strings.HasPrefix(e, "LC_ALL=") {
-			env[i] = "LC_ALL=C"
-			return env
-		}
-	}
-	return append(env, "LC_ALL=C")
-}
-
 // exec runs a git command in the project root and returns output
 func (g *Git) exec(args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmd := gitenv.Command(args...)
 	cmd.Dir = g.projectRoot
-	cmd.Env = gitEnv()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %v failed: %w\nOutput: %s", args, err, output)
@@ -54,9 +40,8 @@ func (g *Git) exec(args ...string) (string, error) {
 
 // execInDir runs a git command in a specific directory
 func (g *Git) execInDir(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmd := gitenv.Command(args...)
 	cmd.Dir = dir
-	cmd.Env = gitEnv()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %v failed: %w\nOutput: %s", args, err, output)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,13 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/liza-mas/liza/internal/gitenv"
 	"github.com/liza-mas/liza/internal/testhelpers"
 )
 
 func TestGitEnv_ForcesLCAllC(t *testing.T) {
 	t.Setenv("LC_ALL", "fr_FR.UTF-8")
 
-	env := gitEnv()
+	env := gitenv.Env()
 
 	var lcAll string
 	for _, e := range env {
@@ -19,7 +20,7 @@ func TestGitEnv_ForcesLCAllC(t *testing.T) {
 		}
 	}
 	if lcAll != "LC_ALL=C" {
-		t.Errorf("gitEnv() LC_ALL = %q, want %q", lcAll, "LC_ALL=C")
+		t.Errorf("gitenv.Env() LC_ALL = %q, want %q", lcAll, "LC_ALL=C")
 	}
 }
 
@@ -97,7 +98,7 @@ func TestBranchExists(t *testing.T) {
 
 func TestBranchExists_NonEnglishLocale(t *testing.T) {
 	// Regression test: BranchExists must return (false, nil) for a missing branch
-	// even when the parent process has a non-English locale set. gitEnv() forces
+	// even when the parent process has a non-English locale set. Env() forces
 	// LC_ALL=C on the git subprocess so the error message is always in English.
 	t.Setenv("LC_ALL", "fr_FR.UTF-8")
 	t.Setenv("LANG", "fr_FR.UTF-8")

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -2,8 +2,9 @@ package git
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
+
+	"github.com/liza-mas/liza/internal/gitenv"
 )
 
 // RebaseConflictError indicates a merge conflict during git rebase.
@@ -29,9 +30,8 @@ func (g *Git) FetchFromLocal(wtPath string, branch string) error {
 // Must be called from within a worktree context.
 // Returns *RebaseConflictError for merge conflicts, generic error for other failures.
 func (g *Git) RebaseOnto(wtPath string, baseBranch string) error {
-	cmd := exec.Command("git", "rebase", baseBranch)
+	cmd := gitenv.Command("rebase", baseBranch)
 	cmd.Dir = wtPath
-	cmd.Env = gitEnv()
 	rawOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		out := string(rawOutput)

--- a/internal/gitenv/gitenv.go
+++ b/internal/gitenv/gitenv.go
@@ -1,0 +1,28 @@
+// Package gitenv provides locale-safe environment for git subprocesses.
+package gitenv
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Env returns the current environment with LC_ALL=C forced, so git output
+// is always in English regardless of the system locale.
+func Env() []string {
+	env := os.Environ()
+	for i, e := range env {
+		if strings.HasPrefix(e, "LC_ALL=") {
+			env[i] = "LC_ALL=C"
+			return env
+		}
+	}
+	return append(env, "LC_ALL=C")
+}
+
+// Command creates an exec.Cmd for git with LC_ALL=C forced.
+func Command(args ...string) *exec.Cmd {
+	cmd := exec.Command("git", args...)
+	cmd.Env = Env()
+	return cmd
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -3,11 +3,12 @@ package paths
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/liza-mas/liza/internal/gitenv"
 )
 
 // Standard path components used throughout Liza
@@ -164,7 +165,7 @@ func GlobalLizaDir() (string, error) {
 // In a worktree: returns the main repo directory (parent of .git common dir)
 func GetProjectRoot() (string, error) {
 	// Get the toplevel directory
-	toplevelCmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	toplevelCmd := gitenv.Command("rev-parse", "--show-toplevel")
 	toplevelOut, err := toplevelCmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("not a git repository or git command failed: %w", err)
@@ -172,7 +173,7 @@ func GetProjectRoot() (string, error) {
 	toplevel := strings.TrimSpace(string(toplevelOut))
 
 	// Get the common git directory
-	commonDirCmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	commonDirCmd := gitenv.Command("rev-parse", "--git-common-dir")
 	commonDirOut, err := commonDirCmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get git common dir: %w", err)

--- a/internal/statevalidate/validate.go
+++ b/internal/statevalidate/validate.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/liza-mas/liza/internal/db"
+	"github.com/liza-mas/liza/internal/gitenv"
 	"github.com/liza-mas/liza/internal/models"
 	"github.com/liza-mas/liza/internal/pipeline"
 )
@@ -106,7 +106,7 @@ func checkSpecFileExists(projectRoot, specRef, integrationBranch string) error {
 	// If git is not on PATH or the branch doesn't exist, this falls through
 	// gracefully to the "file not found" error below.
 	if integrationBranch != "" && projectRoot != "" && !filepath.IsAbs(specFile) {
-		cmd := exec.Command("git", "cat-file", "-e", integrationBranch+":"+specFile)
+		cmd := gitenv.Command("cat-file", "-e", integrationBranch+":"+specFile)
 		cmd.Dir = projectRoot
 		if err := cmd.Run(); err == nil {
 			return nil

--- a/internal/testhelpers/git.go
+++ b/internal/testhelpers/git.go
@@ -1,9 +1,10 @@
 package testhelpers
 
 import (
-	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/liza-mas/liza/internal/gitenv"
 )
 
 // MustGit runs a git command and fails the test if it errors.
@@ -17,7 +18,7 @@ import (
 //	testhelpers.MustGit(t, repoDir, "commit", "-m", "message")
 func MustGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := gitenv.Command(args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Force `LC_ALL=C` on every git subprocess to prevent locale-dependent error messages from breaking output parsing
- Extract `internal/gitenv` package with `Env()` and `Command()` helpers, usable by any package without circular dependency concerns
- Migrate all production and test-helper callsites to use `gitenv.Command()`

Supersedes #12, which fixed only `internal/git/`. This PR extends the fix to all remaining callsites:
- `internal/commands/init.go` (3 callsites)
- `internal/paths/paths.go` (2 callsites)
- `internal/statevalidate/validate.go` (1 callsite)
- `internal/testhelpers/git.go` (1 callsite)

## Root cause

`BranchExists` and `RebaseOnto` parse git error messages for control flow. When the system locale is non-English (e.g. `LANG=fr_FR.UTF-8`), git translates its output, causing string matches to fail. See #12 for full reproduction and analysis (credit: @hnomichith).

## Test plan

- [x] `TestGitEnv_ForcesLCAllC` — verifies `Env()` replaces existing `LC_ALL`
- [x] `TestBranchExists_NonEnglishLocale` — regression test with French locale
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)