### PR TITLE
feat(config): configurable default CLI for agent spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ Or you may choose to make it your Socratic colleague, your rubber duck, or your 
 
 **Multi-agent mode** — autonomous spec-to-code pipeline:
 1. `liza init "[Goal description]" --spec vision.md` (this file needs to be committed) . Use the `--entry-point detailed-spec` option to skip the spec phase and go coding directly.
-2. `liza tui` — the TUI shows live system state (agents, tasks, alerts, sprint metrics). From it you can spawn agents with role autocompletion (`s`), pause/resume the system, add tasks, and trigger sprint checkpoints.
-   Check [Quick Start](docs/USAGE_MULTI_AGENTS.md#quick-start-target-usage) for required roles and options (using a CLI other than Claude, logging).
+2. `liza tui` — the TUI shows live system state (agents, tasks, alerts, sprint metrics). From it you can spawn agents with role autocompletion (`s` uses configured default CLI, `S` lets you pick). Pause/resume the system, add tasks, and trigger sprint checkpoints.
+   Check [Quick Start](docs/USAGE_MULTI_AGENTS.md#quick-start-target-usage) for required roles and options (configuring default CLI, logging).
 
 Refer to [How to Produce a Goal Document For Liza](docs/how-to-produce-a-goal.md) to write a good input doc to use as a `--spec` argument.
 

--- a/cmd/liza/cmd_agent.go
+++ b/cmd/liza/cmd_agent.go
@@ -55,12 +55,12 @@ LIZA_AGENT_ID.
 Example:
   # Auto-assigned agent ID (simplest)
   liza agent coder
-  liza agent code-reviewer --cli claude
+  liza agent code-reviewer --cli codex
   liza agent orchestrator --interactive
 
   # Explicit agent ID
   liza agent coder --agent-id coder-1
-  liza agent code-reviewer --agent-id code-reviewer-2 --cli claude
+  liza agent code-reviewer --agent-id code-reviewer-2 --cli gemini
 
   # Disable saving agent output to .liza/agent-outputs/
   liza agent coder --no-log
@@ -109,6 +109,21 @@ Example:
 		interactive, _ := cmd.Flags().GetBool("interactive")
 		noLog, _ := cmd.Flags().GetBool("no-log")
 
+		statePath := filepath.Join(projectRoot, ".liza", "state.yaml")
+
+		// Resolve default CLI from state config when --cli is not explicitly set
+		flagChanged := cmd.Flags().Changed("cli")
+		var stateConfigCLI string
+		if !flagChanged {
+			bb := db.For(statePath)
+			if state, err := bb.Read(); err == nil {
+				stateConfigCLI = state.Config.DefaultCLI
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: could not read state for default CLI: %v\n", err)
+			}
+		}
+		cliName = agent.ResolveCLIFromState(flagChanged, cliName, stateConfigCLI)
+
 		if !slices.Contains(agent.ValidCLIs(), cliName) {
 			return fmt.Errorf("invalid CLI: %s (must be %s)", cliName, strings.Join(agent.ValidCLIs(), ", "))
 		}
@@ -136,8 +151,6 @@ Example:
 			lizaPaths := paths.New(projectRoot)
 			outputsDir = lizaPaths.AgentOutputsDir()
 		}
-
-		statePath := filepath.Join(projectRoot, ".liza", "state.yaml")
 
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
@@ -264,7 +277,7 @@ func init() {
 
 	// Agent command flags
 	addAgentIDFlag(agentCmd)
-	agentCmd.Flags().String("cli", agent.DefaultCLI, "CLI to use ("+strings.Join(agent.ValidCLIs(), ", ")+")")
+	agentCmd.Flags().String("cli", "", "CLI to use; defaults to config default_cli, then LIZA_DEFAULT_CLI env, then claude ("+strings.Join(agent.ValidCLIs(), ", ")+")")
 	agentCmd.Flags().BoolP("interactive", "i", false, "Print prompt location, don't execute CLI")
 	agentCmd.Flags().Bool("no-log", false, "Disable saving agent output to .liza/agent-outputs/")
 

--- a/cmd/liza/cmd_agent_cli_test.go
+++ b/cmd/liza/cmd_agent_cli_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/liza-mas/liza/internal/db"
+	"github.com/liza-mas/liza/internal/embedded"
+	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/testhelpers"
+)
+
+// setupAgentTestProject creates a minimal project with state.yaml for agent CLI tests.
+func setupAgentTestProject(t *testing.T, defaultCLI string) string {
+	t.Helper()
+
+	testhelpers.SetupGlobalLiza(t)
+	projectRoot := t.TempDir()
+
+	for _, args := range [][]string{
+		{"git", "-C", projectRoot, "init"},
+		{"git", "-C", projectRoot, "config", "user.email", "test@test.com"},
+		{"git", "-C", projectRoot, "config", "user.name", "Test"},
+		{"git", "-C", projectRoot, "commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	lizaDir := filepath.Join(projectRoot, ".liza")
+	if err := os.MkdirAll(lizaDir, 0o755); err != nil {
+		t.Fatalf("mkdir .liza: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(lizaDir, "pipeline.yaml"), embedded.PipelineConfigContent(), 0o644); err != nil {
+		t.Fatalf("write pipeline.yaml: %v", err)
+	}
+
+	state := &models.State{
+		Version: 1,
+		Goal:    models.Goal{ID: "goal-1", Status: models.GoalStatusInProgress},
+		Config: models.Config{
+			DefaultCLI:        defaultCLI,
+			IntegrationBranch: "integration",
+			Mode:              models.SystemModeRunning,
+			HeartbeatInterval: 60,
+			LeaseDuration:     1800,
+		},
+		Agents: make(map[string]models.Agent),
+	}
+
+	bb := db.For(filepath.Join(lizaDir, "state.yaml"))
+	if err := bb.Write(state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	return projectRoot
+}
+
+// TestAgentCmd_InvalidCLIFromStateIsRejected proves that the agent command reads
+// state.Config.DefaultCLI at runtime. An invalid CLI value in state, with no --cli
+// override, must produce an "invalid CLI" error naming the state's value.
+func TestAgentCmd_InvalidCLIFromStateIsRejected(t *testing.T) {
+	t.Setenv("LIZA_DEFAULT_CLI", "")
+	projectRoot := setupAgentTestProject(t, "nonexistent-cli")
+
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	_ = os.Chdir(projectRoot)
+
+	resetRootCmdForTest(t)
+	rootCmd.SetArgs([]string{"agent", "coder"})
+	err := rootCmd.Execute()
+
+	if err == nil || !strings.Contains(err.Error(), "invalid CLI: nonexistent-cli") {
+		t.Fatalf("expected 'invalid CLI: nonexistent-cli' error, got: %v", err)
+	}
+}
+
+// TestAgentCmd_ExplicitFlagOverridesInvalidState proves that --cli takes precedence
+// over state config. State has an invalid CLI, but explicit --cli provides a valid
+// but nonexistent one (xxxcli) — the error should be about xxxcli, not nonexistent-cli,
+// proving the flag won.
+func TestAgentCmd_ExplicitFlagOverridesInvalidState(t *testing.T) {
+	t.Setenv("LIZA_DEFAULT_CLI", "")
+	projectRoot := setupAgentTestProject(t, "nonexistent-cli")
+
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	_ = os.Chdir(projectRoot)
+
+	resetRootCmdForTest(t)
+	// Use another invalid CLI via --cli to verify it's the flag value that appears
+	// in the error, not the state value.
+	rootCmd.SetArgs([]string{"agent", "coder", "--cli", "xxxcli"})
+	err := rootCmd.Execute()
+
+	if err == nil || !strings.Contains(err.Error(), "invalid CLI: xxxcli") {
+		t.Fatalf("expected 'invalid CLI: xxxcli' (from flag), got: %v", err)
+	}
+}
+
+// TestAgentCmd_EnvVarOverridesConst proves that LIZA_DEFAULT_CLI env var is used
+// when state config is empty and --cli is not set. We set the env to an invalid
+// value to observe it in the error message.
+func TestAgentCmd_EnvVarOverridesConst(t *testing.T) {
+	t.Setenv("LIZA_DEFAULT_CLI", "envtestcli")
+	projectRoot := setupAgentTestProject(t, "")
+
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	_ = os.Chdir(projectRoot)
+
+	resetRootCmdForTest(t)
+	rootCmd.SetArgs([]string{"agent", "coder"})
+	err := rootCmd.Execute()
+
+	if err == nil || !strings.Contains(err.Error(), "invalid CLI: envtestcli") {
+		t.Fatalf("expected 'invalid CLI: envtestcli' (from env), got: %v", err)
+	}
+}

--- a/cmd/liza/cmd_init.go
+++ b/cmd/liza/cmd_init.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
+	"github.com/liza-mas/liza/internal/agent"
 	"github.com/liza-mas/liza/internal/commands"
 	"github.com/liza-mas/liza/internal/interactive"
 	"github.com/liza-mas/liza/internal/paths"
@@ -84,6 +87,10 @@ symlinks needed for pairing (no .liza/ workspace):
 	RunE: func(cmd *cobra.Command, args []string) error {
 		agents := collectAgentFlags(cmd)
 		autoResume, _ := cmd.Flags().GetBool("auto-resume")
+		defaultCLI, _ := cmd.Flags().GetString("default-cli")
+		if defaultCLI != "" && !slices.Contains(agent.ValidCLIs(), defaultCLI) {
+			return fmt.Errorf("invalid --default-cli: %s (must be %s)", defaultCLI, strings.Join(agent.ValidCLIs(), ", "))
+		}
 
 		// Interactive wizard: no args, no agent flags, no explicit workspace flags, TTY
 		if len(args) == 0 && len(agents) == 0 && !hasExplicitInitFlags(cmd) {
@@ -133,6 +140,7 @@ symlinks needed for pairing (no .liza/ workspace):
 				Branch:          branch,
 				PostWorktreeCmd: postWorktreeCmd,
 				AutoResume:      autoResume,
+				DefaultCLI:      defaultCLI,
 				Agents:          result.Agents,
 				Stdin:           os.Stdin,
 				ContractAction:  result.ContractAction,
@@ -152,7 +160,7 @@ symlinks needed for pairing (no .liza/ workspace):
 				return fmt.Errorf("--auto-resume requires full workspace init (provide a description)")
 			}
 			if hasExplicitInitFlags(cmd) {
-				return fmt.Errorf("workspace flags (--branch, --config, --spec, --entry-point, --post-worktree-cmd) require a description argument for full workspace init")
+				return fmt.Errorf("workspace flags (--branch, --config, --spec, --entry-point, --post-worktree-cmd, --default-cli) require a description argument for full workspace init")
 			}
 			if err := commands.InitPairingCommand(commands.InitPairingParams{
 				Agents: agents,
@@ -179,6 +187,7 @@ symlinks needed for pairing (no .liza/ workspace):
 			Branch:          branch,
 			PostWorktreeCmd: postCreateCmd,
 			AutoResume:      autoResume,
+			DefaultCLI:      defaultCLI,
 			Agents:          agents,
 			Stdin:           os.Stdin,
 		}); err != nil {
@@ -254,7 +263,7 @@ var agentFlagNames = []string{"claude", "codex", "gemini", "mistral"}
 // hasExplicitInitFlags returns true if any workspace-specific flag was explicitly set.
 // This prevents the interactive wizard from silently swallowing CLI flags it doesn't collect.
 func hasExplicitInitFlags(cmd *cobra.Command) bool {
-	for _, name := range []string{"spec", "config", "entry-point", "branch", "post-worktree-cmd"} {
+	for _, name := range []string{"spec", "config", "entry-point", "branch", "post-worktree-cmd", "default-cli"} {
 		if cmd.Flags().Changed(name) {
 			return true
 		}
@@ -295,6 +304,7 @@ func init() {
 	initCmd.Flags().String("branch", "integration", "integration branch name")
 	initCmd.Flags().String("post-worktree-cmd", "", "shell command to run after worktree creation (e.g. 'make setup')")
 	initCmd.Flags().Bool("auto-resume", false, "automatically resume at checkpoint and sprint completion")
+	initCmd.Flags().String("default-cli", "", "default CLI for agent spawning ("+strings.Join(agent.ValidCLIs(), ", ")+")")
 	initCmd.Flags().Bool("claude", false, "create CLAUDE.md symlink to ~/.liza/CORE.md")
 	initCmd.Flags().Bool("codex", false, "create AGENTS.md symlink to ~/.liza/CORE.md")
 	initCmd.Flags().Bool("gemini", false, "create GEMINI.md symlink to ~/.liza/CORE.md")

--- a/cmd/liza/cmd_init_test.go
+++ b/cmd/liza/cmd_init_test.go
@@ -48,6 +48,21 @@ func TestInitDispatch_WorkspaceFlagsRequireDescription(t *testing.T) {
 			args:    []string{"init", "--claude", "--branch", "foo"},
 			wantErr: "workspace flags",
 		},
+		{
+			name:    "default-cli without description errors",
+			args:    []string{"init", "--default-cli", "codex"},
+			wantErr: "requires a description argument",
+		},
+		{
+			name:    "agent flag with default-cli and no description errors",
+			args:    []string{"init", "--codex", "--default-cli", "codex"},
+			wantErr: "workspace flags",
+		},
+		{
+			name:    "invalid default-cli value errors",
+			args:    []string{"init", "--default-cli", "invalid", "Goal"},
+			wantErr: "invalid --default-cli",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/liza/rootcmd_test_helpers_test.go
+++ b/cmd/liza/rootcmd_test_helpers_test.go
@@ -100,7 +100,7 @@ func resetRootCmdForTest(t *testing.T) {
 		resetFlagIfPresent(child, "agent-id")
 		resetFlagIfPresent(child, "changed-by")
 		// Init command workspace flags — must reset Changed state between tests.
-		for _, name := range []string{"spec", "config", "entry-point", "branch", "post-worktree-cmd", "auto-resume", "claude", "codex", "gemini", "mistral"} {
+		for _, name := range []string{"spec", "config", "entry-point", "branch", "post-worktree-cmd", "auto-resume", "default-cli", "cli", "claude", "codex", "gemini", "mistral"} {
 			resetFlagIfPresent(child, name)
 		}
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -245,15 +245,15 @@ When `liza tui` triggers the circuit breaker, it also sets `sprint.status` to `C
 
 ## Supported CLIs
 
-The `--cli` flag on `liza agent` selects which coding agent to invoke:
+The `--cli` flag on `liza agent` selects which coding agent to invoke. When omitted, the default is resolved from `config.default_cli` in `state.yaml`, then the `LIZA_DEFAULT_CLI` environment variable, then `claude`. Set the default at init time with `liza init --default-cli <cli>`.
 
-| CLI | Default | Notes |
-|-----|---------|-------|
-| `claude` | Yes | Claude Code |
-| `codex` | No | OpenAI Codex CLI |
-| `gemini` | No | Google Gemini CLI |
-| `mistral` | No | Mistral Le Chat CLI |
-| `kimi` | No | Kimi (alias to claude with Kimi-specific env vars) |
+| CLI | Notes |
+|-----|-------|
+| `claude` | Claude Code (fallback default when no config is set) |
+| `codex` | OpenAI Codex CLI |
+| `gemini` | Google Gemini CLI |
+| `mistral` | Mistral Le Chat CLI |
+| `kimi` | Kimi (alias to claude with Kimi-specific env vars) |
 
 ## Output Logging
 

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -176,7 +176,7 @@ cd hello-cli
 liza agent orchestrator
 ```
 
-Agent output is automatically persisted to `.liza/agent-outputs/` for later analysis (see [Analyzing Agent Logs](USAGE_MULTI_AGENTS.md#analyzing-agent-logs)). Pass `--no-log` to disable. Each agent command also accepts a `--cli` flag to select the coding agent: `claude` (default), `codex`, `gemini`, `mistral`, or `kimi`.
+Agent output is automatically persisted to `.liza/agent-outputs/` for later analysis (see [Analyzing Agent Logs](USAGE_MULTI_AGENTS.md#analyzing-agent-logs)). Pass `--no-log` to disable. Each agent command also accepts a `--cli` flag to select the coding agent (`claude`, `codex`, `gemini`, `mistral`, or `kimi`). When omitted, the default is resolved from `config.default_cli` in `state.yaml`, then `LIZA_DEFAULT_CLI` env var, then `claude`.
 
 The Orchestrator will:
 1. Read `specs/vision.md`

--- a/docs/USAGE_MULTI_AGENTS.md
+++ b/docs/USAGE_MULTI_AGENTS.md
@@ -140,7 +140,7 @@ Operational reference content (blackboard fields, anomaly types, etc.) is inline
 
 **3. Start Agents**
 
-The TUI (`liza tui`) is the primary way to spawn and monitor agents. Press `s` to spawn — role names autocomplete from the pipeline config.
+The TUI (`liza tui`) is the primary way to spawn and monitor agents. Press `s` to spawn with the configured default CLI (role names autocomplete from the pipeline config), or `S` to pick a specific CLI.
 
 Alternatively, spawn agents from the CLI: `liza agent <role>`. Agent identity defaults to the first `{role}-N` not already registered with a valid lease (e.g., `coder-1`, or `coder-2` if `coder-1` is active). Override with `--agent-id` or the `LIZA_AGENT_ID` environment variable.
 
@@ -180,8 +180,8 @@ All of the above plus: epic-planner, epic-plan-reviewer, us-writer, us-reviewer.
 
 **Integration phase** agents (integration-analyst, integration-reviewer) are spawned by the orchestrator after all coding tasks for a goal complete. They are not needed at startup — spawn them when the orchestrator triggers the integration sub-pipeline.
 
-Each agent command accepts a `--cli` flag to select the coding agent CLI: `claude` (default), `codex`, `gemini`, `mistral`, or `kimi`. For example: `liza agent coder --cli gemini`.
-Selecting alternative agent CLI from the TUI is not supported yet.
+Each agent command accepts a `--cli` flag to select the coding agent CLI: `claude`, `codex`, `gemini`, `mistral`, or `kimi`. When `--cli` is omitted, the default is resolved from `config.default_cli` in `state.yaml`, then `LIZA_DEFAULT_CLI` env var, then `claude`. Set the default at init time with `liza init --default-cli codex "..."`, or edit `state.yaml` directly.
+In the TUI, `s` spawns with the configured default CLI; `S` prompts for CLI selection.
 
 Agent output is automatically persisted to `.liza/agent-outputs/` (stdout as `.txt`, stderr as `.err`). Pass `--no-log` to disable. Persisted files are automatically masked — secret values from environment variables (API keys, tokens, passwords) are replaced with `***`. Live terminal output remains unmasked. Logging is automatically disabled in `-i` (interactive) mode.
 See [Analyzing Agent Logs](#analyzing-agent-logs) for analysis tools.
@@ -195,7 +195,7 @@ liza agent coder --agent-id coder-5   # explicit ID
 
 **3. Observe and control**
 
-`liza tui` shows live system state — agents, tasks, alerts, sprint metrics. Keyboard shortcuts: `s` spawn, `p` pause, `r` resume, `a` add task, `c` checkpoint, `y` yolo (toggle auto-resume), `Q` stop.
+`liza tui` shows live system state — agents, tasks, alerts, sprint metrics. Keyboard shortcuts: `s` spawn (default cli), `S` spawn (pick cli), `p` pause, `r` resume, `a` add task, `c` checkpoint, `y` yolo (toggle auto-resume), `Q` stop.
 
 `./console.sh` is deprecated.
 

--- a/internal/agent/cli.go
+++ b/internal/agent/cli.go
@@ -1,5 +1,7 @@
 package agent
 
+import "os"
+
 // validCLIs is the canonical list of supported CLI backends.
 var validCLIs = []string{"claude", "codex", "gemini", "mistral", "kimi"}
 
@@ -12,3 +14,26 @@ func ValidCLIs() []string {
 
 // DefaultCLI is the CLI used when none is specified.
 const DefaultCLI = "claude"
+
+// ResolveDefaultCLI returns the effective default CLI.
+// Resolution order: configValue (from state.yaml) > LIZA_DEFAULT_CLI env var > DefaultCLI const.
+func ResolveDefaultCLI(configValue string) string {
+	if configValue != "" {
+		return configValue
+	}
+	if v := os.Getenv("LIZA_DEFAULT_CLI"); v != "" {
+		return v
+	}
+	return DefaultCLI
+}
+
+// ResolveCLIFromState resolves the effective CLI for an agent command.
+// When flagChanged is true, flagValue is used directly (explicit --cli override).
+// Otherwise, the state config's default_cli is resolved through the full chain.
+// The stateConfigCLI parameter is the value of state.Config.DefaultCLI (empty if state unreadable).
+func ResolveCLIFromState(flagChanged bool, flagValue, stateConfigCLI string) string {
+	if flagChanged {
+		return flagValue
+	}
+	return ResolveDefaultCLI(stateConfigCLI)
+}

--- a/internal/agent/cli_test.go
+++ b/internal/agent/cli_test.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestResolveDefaultCLI(t *testing.T) {
+	// Clean env for test isolation
+	t.Setenv("LIZA_DEFAULT_CLI", "")
+
+	tests := []struct {
+		name        string
+		configValue string
+		envValue    string
+		want        string
+	}{
+		{
+			name:        "empty config and env returns const",
+			configValue: "",
+			envValue:    "",
+			want:        DefaultCLI,
+		},
+		{
+			name:        "config value wins",
+			configValue: "codex",
+			envValue:    "",
+			want:        "codex",
+		},
+		{
+			name:        "env var used when config empty",
+			configValue: "",
+			envValue:    "gemini",
+			want:        "gemini",
+		},
+		{
+			name:        "config value wins over env var",
+			configValue: "codex",
+			envValue:    "gemini",
+			want:        "codex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LIZA_DEFAULT_CLI", tt.envValue)
+			got := ResolveDefaultCLI(tt.configValue)
+			if got != tt.want {
+				t.Errorf("ResolveDefaultCLI(%q) = %q, want %q", tt.configValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCLIFromState(t *testing.T) {
+	tests := []struct {
+		name           string
+		flagChanged    bool
+		flagValue      string
+		stateConfigCLI string
+		envValue       string
+		want           string
+	}{
+		{
+			name:           "explicit flag wins over state config",
+			flagChanged:    true,
+			flagValue:      "gemini",
+			stateConfigCLI: "codex",
+			want:           "gemini",
+		},
+		{
+			name:           "explicit flag wins over env var",
+			flagChanged:    true,
+			flagValue:      "gemini",
+			stateConfigCLI: "",
+			envValue:       "codex",
+			want:           "gemini",
+		},
+		{
+			name:           "state config used when flag not set",
+			flagChanged:    false,
+			flagValue:      "",
+			stateConfigCLI: "codex",
+			want:           "codex",
+		},
+		{
+			name:           "env var used when flag not set and no state config",
+			flagChanged:    false,
+			flagValue:      "",
+			stateConfigCLI: "",
+			envValue:       "gemini",
+			want:           "gemini",
+		},
+		{
+			name:           "const used when nothing else set",
+			flagChanged:    false,
+			flagValue:      "",
+			stateConfigCLI: "",
+			want:           DefaultCLI,
+		},
+		{
+			name:           "state config wins over env var",
+			flagChanged:    false,
+			flagValue:      "",
+			stateConfigCLI: "codex",
+			envValue:       "gemini",
+			want:           "codex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LIZA_DEFAULT_CLI", tt.envValue)
+			got := ResolveCLIFromState(tt.flagChanged, tt.flagValue, tt.stateConfigCLI)
+			if got != tt.want {
+				t.Errorf("ResolveCLIFromState(%v, %q, %q) = %q, want %q",
+					tt.flagChanged, tt.flagValue, tt.stateConfigCLI, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -27,6 +27,7 @@ type InitParams struct {
 	Branch           string   // --branch: integration branch name (default: "integration")
 	PostWorktreeCmd  string   // --post-worktree-cmd: shell command to run after worktree creation
 	AutoResume       bool     // --auto-resume: automatically resume at checkpoint and sprint completion
+	DefaultCLI       string   // --default-cli: default CLI for agent spawning
 	Agents           []string // --claude, --codex, --gemini, --mistral
 	Stdin            io.Reader
 	ForceInteractive bool   // bypass TTY check (for testing)
@@ -699,6 +700,7 @@ func InitCommandWithConfig(params InitParams) error {
 			OrchestratorMaxWait:      7200,
 			ReviewerPollInterval:     30,
 			ReviewerMaxWait:          7200,
+			DefaultCLI:               params.DefaultCLI,
 			IntegrationBranch:        branch,
 			EscalationWebhook:        nil,
 			Mode:                     models.SystemModeRunning,

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -1915,3 +1915,81 @@ func TestInitCommandWithConfig_EntryPointWithoutConfig(t *testing.T) {
 		t.Errorf("state.Goal.EntryPoint = %q, want %q", state.Goal.EntryPoint, "detailed-spec")
 	}
 }
+
+func TestInitCommandWithConfig_DefaultCLI(t *testing.T) {
+	tmpDir := setupGitRepo(t)
+	defer os.RemoveAll(tmpDir)
+	setupGlobalLiza(t)
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalDir)
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	testhelpers.CreateSpecFile(t, tmpDir, "vision.md", "# Vision\n")
+
+	err = InitCommandWithConfig(InitParams{
+		Description: "Goal with default CLI",
+		SpecRef:     "specs/vision.md",
+		DefaultCLI:  "codex",
+	})
+	if err != nil {
+		t.Fatalf("InitCommandWithConfig() error = %v", err)
+	}
+
+	bb := db.New(filepath.Join(tmpDir, ".liza", "state.yaml"))
+	state, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if state.Config.DefaultCLI != "codex" {
+		t.Errorf("state.Config.DefaultCLI = %q, want %q", state.Config.DefaultCLI, "codex")
+	}
+}
+
+func TestInitCommandWithConfig_DefaultCLIOmittedWhenEmpty(t *testing.T) {
+	tmpDir := setupGitRepo(t)
+	defer os.RemoveAll(tmpDir)
+	setupGlobalLiza(t)
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalDir)
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	testhelpers.CreateSpecFile(t, tmpDir, "vision.md", "# Vision\n")
+
+	err = InitCommandWithConfig(InitParams{
+		Description: "Goal without default CLI",
+		SpecRef:     "specs/vision.md",
+	})
+	if err != nil {
+		t.Fatalf("InitCommandWithConfig() error = %v", err)
+	}
+
+	bb := db.New(filepath.Join(tmpDir, ".liza", "state.yaml"))
+	state, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if state.Config.DefaultCLI != "" {
+		t.Errorf("state.Config.DefaultCLI = %q, want empty", state.Config.DefaultCLI)
+	}
+
+	// Verify omitempty: default_cli should not appear in YAML
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".liza", "state.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read state.yaml: %v", err)
+	}
+	if strings.Contains(string(data), "default_cli") {
+		t.Error("state.yaml contains default_cli key, want omitted when empty")
+	}
+}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -125,6 +125,7 @@ type Config struct {
 	Exit42MaxBackoffSeconds  int            `yaml:"exit42_max_backoff_seconds,omitempty"`
 	CrashRestartThreshold    int            `yaml:"crash_restart_threshold,omitempty"`
 	SpinningRestartThreshold int            `yaml:"spinning_restart_threshold,omitempty"`
+	DefaultCLI               string         `yaml:"default_cli,omitempty"`
 	IntegrationBranch        string         `yaml:"integration_branch"`
 	EscalationWebhook        *string        `yaml:"escalation_webhook,omitempty"`
 	Mode                     SystemMode     `yaml:"mode,omitempty"`

--- a/internal/ops/init_project.go
+++ b/internal/ops/init_project.go
@@ -24,6 +24,7 @@ type InitProjectParams struct {
 	Branch          string // default "integration" if empty
 	EntryPoint      string // optional
 	PostWorktreeCmd string // optional
+	DefaultCLI      string // optional; default CLI for agent spawning
 	AutoResume      bool
 	PipelineConfig  []byte // optional raw YAML; nil = use embedded default
 }
@@ -193,6 +194,7 @@ func InitProject(projectRoot string, params InitProjectParams) error {
 			OrchestratorMaxWait:      7200,
 			ReviewerPollInterval:     30,
 			ReviewerMaxWait:          7200,
+			DefaultCLI:               params.DefaultCLI,
 			IntegrationBranch:        branch,
 			EscalationWebhook:        nil,
 			Mode:                     models.SystemModeRunning,

--- a/internal/ops/init_project_test.go
+++ b/internal/ops/init_project_test.go
@@ -271,3 +271,57 @@ func TestInitProject_AutoResumeFlag(t *testing.T) {
 		t.Error("AutoResume = false, want true")
 	}
 }
+
+func TestInitProject_DefaultCLI(t *testing.T) {
+	projectRoot, specFile := setupInitTestDir(t)
+
+	err := InitProject(projectRoot, InitProjectParams{
+		Description: "Test project",
+		SpecRef:     specFile,
+		DefaultCLI:  "codex",
+	})
+	if err != nil {
+		t.Fatalf("InitProject() error: %v", err)
+	}
+
+	statePath := filepath.Join(projectRoot, ".liza", "state.yaml")
+	bb := db.For(statePath)
+	state, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if state.Config.DefaultCLI != "codex" {
+		t.Errorf("DefaultCLI = %q, want %q", state.Config.DefaultCLI, "codex")
+	}
+}
+
+func TestInitProject_DefaultCLIEmpty(t *testing.T) {
+	projectRoot, specFile := setupInitTestDir(t)
+
+	err := InitProject(projectRoot, InitProjectParams{
+		Description: "Test project",
+		SpecRef:     specFile,
+	})
+	if err != nil {
+		t.Fatalf("InitProject() error: %v", err)
+	}
+
+	statePath := filepath.Join(projectRoot, ".liza", "state.yaml")
+	bb := db.For(statePath)
+	state, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if state.Config.DefaultCLI != "" {
+		t.Errorf("DefaultCLI = %q, want empty", state.Config.DefaultCLI)
+	}
+
+	// Verify omitempty
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("Failed to read state.yaml: %v", err)
+	}
+	if strings.Contains(string(data), "default_cli") {
+		t.Error("state.yaml contains default_cli, want omitted when empty")
+	}
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -164,7 +164,7 @@ func spawnAgentCmd(projectRoot, role, cli string) tea.Cmd {
 		if _, err := process.SpawnAgent(projectRoot, role, cli); err != nil {
 			return CmdResultMsg{Success: false, Message: fmt.Sprintf("spawn %s: %v", role, err)}
 		}
-		return CmdResultMsg{Success: true, Message: "Spawned " + role}
+		return CmdResultMsg{Success: true, Message: "Spawned " + role + " (" + cli + ")"}
 	}
 }
 

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -23,11 +23,11 @@ func NewKeyMap() KeyMap {
 	return KeyMap{
 		Spawn: key.NewBinding(
 			key.WithKeys("s"),
-			key.WithHelp("s", "spawn"),
+			key.WithHelp("s", "spawn (default cli)"),
 		),
 		SpawnWith: key.NewBinding(
 			key.WithKeys("S"),
-			key.WithHelp("S", "spawn+cli"),
+			key.WithHelp("S", "spawn (pick cli)"),
 		),
 		Terminate: key.NewBinding(
 			key.WithKeys("t"),

--- a/internal/tui/keymap_test.go
+++ b/internal/tui/keymap_test.go
@@ -52,8 +52,8 @@ func TestNewKeyMap_HelpTextMatchesSpec(t *testing.T) {
 		wantKey  string
 		wantDesc string
 	}{
-		{"Spawn", km.Spawn, "s", "spawn"},
-		{"SpawnWith", km.SpawnWith, "S", "spawn+cli"},
+		{"Spawn", km.Spawn, "s", "spawn (default cli)"},
+		{"SpawnWith", km.SpawnWith, "S", "spawn (pick cli)"},
 		{"Terminate", km.Terminate, "t", "terminate"},
 		{"Pause", km.Pause, "p", "pause"},
 		{"Resume", km.Resume, "r", "resume"},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/huh"
+	"github.com/liza-mas/liza/internal/agent"
 	"github.com/liza-mas/liza/internal/db"
 	"github.com/liza-mas/liza/internal/log"
 	"github.com/liza-mas/liza/internal/models"
@@ -205,6 +206,15 @@ type Model struct {
 	// Lifecycle
 	ready       bool   // true after first state load
 	projectRoot string // root directory for state.yaml, log.yaml, alerts.log
+}
+
+// resolvedDefaultCLI returns the effective default CLI from config, with nil-safe fallback.
+// Uses the full resolution chain (config → LIZA_DEFAULT_CLI env → const) even when state is nil.
+func (m Model) resolvedDefaultCLI() string {
+	if m.state == nil {
+		return agent.ResolveDefaultCLI("")
+	}
+	return agent.ResolveDefaultCLI(m.state.Config.DefaultCLI)
 }
 
 // New creates a new Model. Creates the fsnotify watcher and blackboard.

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -327,7 +327,7 @@ func (m Model) executeInlineAction(action InlineAction, value string) (tea.Model
 				return CmdResultMsg{Success: false, Message: fmt.Sprintf("unknown role %q", value)}
 			}
 		}
-		return m, spawnAgentCmd(m.projectRoot, value, agent.DefaultCLI)
+		return m, spawnAgentCmd(m.projectRoot, value, m.resolvedDefaultCLI())
 	case InlineActionSpawnWith:
 		if value == "" {
 			return m, nil
@@ -341,7 +341,7 @@ func (m Model) executeInlineAction(action InlineAction, value string) (tea.Model
 		m.spawnRole = value
 		m.inputMode = InputModeInline
 		m.inlineAction = InlineActionSpawnCLI
-		m.inlineLabel = fmt.Sprintf("CLI (%s): ", agent.DefaultCLI)
+		m.inlineLabel = fmt.Sprintf("CLI (%s): ", m.resolvedDefaultCLI())
 		m.textInput.Reset()
 		m.textInput.Focus()
 		m.completionIdx = 0
@@ -350,7 +350,7 @@ func (m Model) executeInlineAction(action InlineAction, value string) (tea.Model
 	case InlineActionSpawnCLI:
 		cli := value
 		if cli == "" {
-			cli = agent.DefaultCLI
+			cli = m.resolvedDefaultCLI()
 		}
 		if !slices.Contains(agent.ValidCLIs(), cli) {
 			m.spawnRole = ""

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/liza-mas/liza/internal/agent"
 	"github.com/liza-mas/liza/internal/log"
 	"github.com/liza-mas/liza/internal/models"
 )
@@ -1183,5 +1184,51 @@ func TestHandleInlineKey_TabCyclesAgentCompletion(t *testing.T) {
 
 	if m2.textInput.Value() != "coder-1" {
 		t.Errorf("first Tab got %q, want %q", m2.textInput.Value(), "coder-1")
+	}
+}
+
+// ============================================================
+// resolvedDefaultCLI tests
+// ============================================================
+
+func TestResolvedDefaultCLI_NilState(t *testing.T) {
+	t.Setenv("LIZA_DEFAULT_CLI", "")
+	m := testModel()
+	// m.state is nil
+	got := m.resolvedDefaultCLI()
+	if got != agent.DefaultCLI {
+		t.Errorf("resolvedDefaultCLI() with nil state = %q, want %q", got, agent.DefaultCLI)
+	}
+}
+
+func TestResolvedDefaultCLI_NilStateWithEnv(t *testing.T) {
+	t.Setenv("LIZA_DEFAULT_CLI", "codex")
+	m := testModel()
+	// m.state is nil but env var set
+	got := m.resolvedDefaultCLI()
+	if got != "codex" {
+		t.Errorf("resolvedDefaultCLI() with nil state + env = %q, want %q", got, "codex")
+	}
+}
+
+func TestResolvedDefaultCLI_EmptyConfig(t *testing.T) {
+	t.Setenv("LIZA_DEFAULT_CLI", "")
+	m := testModel()
+	m.state = &models.State{}
+	got := m.resolvedDefaultCLI()
+	if got != agent.DefaultCLI {
+		t.Errorf("resolvedDefaultCLI() with empty config = %q, want %q", got, agent.DefaultCLI)
+	}
+}
+
+func TestResolvedDefaultCLI_ConfigSet(t *testing.T) {
+	t.Setenv("LIZA_DEFAULT_CLI", "")
+	m := testModel()
+	m.state = &models.State{
+		Config: models.Config{DefaultCLI: "codex"},
+	}
+	got := m.resolvedDefaultCLI()
+	if got != "codex" {
+		t.Errorf("resolvedDefaultCLI() with config codex = %q, want %q", got, "codex")
 	}
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1198,11 +1198,11 @@ func TestRenderFooter_FormMode_ContainsFormHints(t *testing.T) {
 
 func TestRenderFooter_ActiveCmdResult_AppearsInOutput(t *testing.T) {
 	m := Model{
-		width:     160,
+		width:     220,
 		height:    40,
 		inputMode: InputModeNormal,
 		keys:      NewKeyMap(),
-		styles:    NewStyles(160),
+		styles:    NewStyles(220),
 		cmdResult: &CmdResultMsg{Success: true, Message: "System paused successfully"},
 		cmdExpiry: time.Now().Add(3 * time.Second), // not expired
 	}


### PR DESCRIPTION
## Summary

- Adds `config.default_cli` field to `state.yaml` with full resolution chain: `--cli` flag > `config.default_cli` > `LIZA_DEFAULT_CLI` env var > `"claude"` const
- Adds `--default-cli` flag to `liza init` for setting the default at workspace creation
- Updates TUI spawn (`s`) to use configured default, with `S` for explicit CLI selection
- Updates all user-facing docs (README, USAGE, CONFIGURATION, DEMO)

Fixes #17

## Changes

| Area | What |
|------|------|
| Config | `DefaultCLI` field on `Config` struct (omitempty) |
| Resolution | `ResolveDefaultCLI()` + `ResolveCLIFromState()` helpers |
| `liza init` | `--default-cli` flag, guarded by `hasExplicitInitFlags` |
| `liza agent` | Reads state config when `--cli` omitted; warns on state read failure |
| TUI | `s` uses config default (nil-safe), feedback shows CLI, help text updated |
| Docs | 4 files updated to reflect configurable default |

## Test plan

- [x] `ResolveCLIFromState` unit tests: 6 cases covering full precedence chain (flag > config > env > const)
- [x] `ResolveDefaultCLI` unit tests: 4 cases (config, env, fallback, precedence)
- [x] `liza init --default-cli`: valid/invalid/pairing-rejected (3 dispatch tests)
- [x] `liza init` config propagation: value set + omitempty when empty (2 tests)
- [x] `ops.InitProject` parity: value set + omitempty (2 tests)
- [x] Command-level agent CLI resolution: state read, flag override, env var (3 tests using invalid CLI values to observe which source won)
- [x] TUI `resolvedDefaultCLI`: nil state, nil state + env, empty config, config set (4 tests)
- [x] All pre-commit hooks pass
- [x] `make test` passes (3 pre-existing flaky failures in waitforwork/mcp unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)