### PR TITLE
fix: unblock partial planning handoff

### DIFF
--- a/internal/agent/strategy_orchestrator.go
+++ b/internal/agent/strategy_orchestrator.go
@@ -44,11 +44,11 @@ func (s *orchestratorStrategy) PreWork(_ context.Context, bb *db.Blackboard, con
 		return false, nil
 	}
 
-	// Gate: checkpoint was for planning completion AND sprint has been resumed.
-	// checkpoint_trigger == models.CheckpointTriggerPlanningComplete rules out manual/sprint-complete checkpoints.
+	// Gate: checkpoint was for a pipeline transition AND sprint has been resumed.
+	// The checkpoint trigger rules out manual/sprint-complete checkpoints.
 	// status == IN_PROGRESS means the human reviewed and resumed.
-	if state.Sprint.CheckpointTrigger != models.CheckpointTriggerPlanningComplete ||
-		state.Sprint.Status != models.SprintStatusInProgress {
+	if state.Sprint.Status != models.SprintStatusInProgress ||
+		!models.IsTransitionCheckpointTrigger(state.Sprint.CheckpointTrigger) {
 		return false, nil
 	}
 
@@ -155,8 +155,11 @@ func selfHealCheckpoint(projectRoot string, trigger OrchestratorWakeTrigger) boo
 	}
 
 	triggerStr := ""
-	if trigger == WakeTriggerPlanningComplete {
+	switch trigger {
+	case WakeTriggerPlanningComplete:
 		triggerStr = models.CheckpointTriggerPlanningComplete
+	case WakeTriggerManyToOneReady:
+		triggerStr = models.CheckpointTriggerManyToOneReady
 	}
 	_, err := ops.SprintCheckpoint(projectRoot, triggerStr)
 	if err != nil {

--- a/internal/agent/strategy_test.go
+++ b/internal/agent/strategy_test.go
@@ -828,11 +828,12 @@ func TestOrchestratorPreWork_PlanningComplete_Resumed(t *testing.T) {
 func TestOrchestratorPreWork_ManyToOneCohort(t *testing.T) {
 	tmpDir := t.TempDir()
 	statePath, _ := testhelpers.SetupLizaDir(t, tmpDir)
+	testhelpers.SetupPipelineConfig(t, tmpDir)
 
 	now := time.Now().UTC()
 	state := testhelpers.CreateValidState()
 	state.Sprint.Status = models.SprintStatusInProgress
-	state.Sprint.CheckpointTrigger = "PLANNING_COMPLETE"
+	state.Sprint.CheckpointTrigger = models.CheckpointTriggerManyToOneReady
 
 	// Build m2o-ready tasks: MERGED us-writing-pair tasks sharing a parent, no output
 	parentID := "epic-1"
@@ -867,6 +868,14 @@ func TestOrchestratorPreWork_ManyToOneCohort(t *testing.T) {
 	}
 	if readState.Sprint.CheckpointTrigger != "" {
 		t.Errorf("CheckpointTrigger = %q after PreWork, want empty (gate should have fired and cleared it)", readState.Sprint.CheckpointTrigger)
+	}
+	childID := "epic-1-architecture"
+	child := readState.FindTask(childID)
+	if child == nil {
+		t.Fatalf("child task %q not found", childID)
+	}
+	if child.RolePair != "architecture-pair" {
+		t.Errorf("child role_pair = %q, want architecture-pair", child.RolePair)
 	}
 }
 

--- a/internal/agent/workdetection.go
+++ b/internal/agent/workdetection.go
@@ -75,14 +75,35 @@ var orchestratorWakeTriggerSpecs = []orchestratorWakeTriggerSpec{
 // 2. Blocked tasks
 // 3. Hypothesis exhausted (2+ failed_by)
 // 4. Immediate discoveries (not yet converted to tasks)
-// 5. Planning complete (all planned tasks terminal, merged tasks have output[])
-// 6. Sprint complete (all planned tasks terminal)
+// 5. Planning complete (merged planning tasks have output[])
+// 6. Many-to-one transition ready
+// 7. Sprint complete (all planned tasks terminal)
 func DetectOrchestratorWakeTriggers(state *models.State, pipelineTerminals []models.TaskStatus, planningPairs map[string]bool, m2oTransitions []ops.ManyToOneTransitionInfo) OrchestratorWakeResult {
 	for _, triggerSpec := range orchestratorWakeTriggerSpecs {
 		if count := triggerSpec.Count(state); count > 0 {
 			return OrchestratorWakeResult{
 				Trigger: triggerSpec.Trigger,
 				Count:   count,
+			}
+		}
+	}
+
+	// Partial handoff: a merged planning task with unconsumed output is enough
+	// to wake the orchestrator, even when unrelated planned tasks are still
+	// active. The checkpoint/resume gate still controls when transitions run,
+	// but ready design work no longer waits for the entire sprint to finish.
+	if state.Sprint.Status != models.SprintStatusCheckpoint &&
+		state.Sprint.Status != models.SprintStatusCompleted {
+		if n := countMergedPlanningTasksWithOutput(state, planningPairs); n > 0 {
+			return OrchestratorWakeResult{
+				Trigger: WakeTriggerPlanningComplete,
+				Count:   n,
+			}
+		}
+		if n := countReadyManyToOneCohorts(state, m2oTransitions); n > 0 {
+			return OrchestratorWakeResult{
+				Trigger: WakeTriggerManyToOneReady,
+				Count:   n,
 			}
 		}
 	}
@@ -96,20 +117,6 @@ func DetectOrchestratorWakeTriggers(state *models.State, pipelineTerminals []mod
 		if state.Sprint.Status == models.SprintStatusCheckpoint ||
 			state.Sprint.Status == models.SprintStatusCompleted {
 			return OrchestratorWakeResult{Trigger: WakeTriggerNone}
-		}
-		// Distinguish planning completion (merged tasks with output[]) from sprint completion.
-		if n := countMergedPlanningTasksWithOutput(state, planningPairs); n > 0 {
-			return OrchestratorWakeResult{
-				Trigger: WakeTriggerPlanningComplete,
-				Count:   n,
-			}
-		}
-		// Check for ready many-to-one cohorts
-		if n := countReadyManyToOneCohorts(state, m2oTransitions); n > 0 {
-			return OrchestratorWakeResult{
-				Trigger: WakeTriggerManyToOneReady,
-				Count:   n,
-			}
 		}
 		// Detect coding completion: all tasks terminal, coding happened (base_commit set),
 		// but no integration task exists yet.

--- a/internal/agent/workdetection_test.go
+++ b/internal/agent/workdetection_test.go
@@ -796,6 +796,24 @@ func TestDetectOrchestratorWakeTriggers(t *testing.T) {
 			wantCount:   1,
 		},
 		{
+			name: "planning complete fires with unrelated active planned task",
+			state: func() *models.State {
+				state := testhelpers.CreateValidState()
+				readyPlan := testhelpers.BuildTaskByStatus("plan-ready", models.TaskStatusMerged, now)
+				readyPlan.RolePair = "code-planning-pair"
+				readyPlan.Output = []models.OutputEntry{
+					{Desc: "implement X", DoneWhen: "tests pass", Scope: "pkg/x"},
+				}
+				activePlan := testhelpers.BuildTaskByStatus("plan-active", models.TaskStatusCodePlanning, now)
+				activePlan.RolePair = "code-planning-pair"
+				state.Sprint.Scope.Planned = []string{"plan-ready", "plan-active"}
+				state.Tasks = []models.Task{readyPlan, activePlan}
+				return state
+			}(),
+			wantTrigger: WakeTriggerPlanningComplete,
+			wantCount:   1,
+		},
+		{
 			name: "merged planning task with TransitionsExecuted triggers sprint complete not planning complete",
 			state: func() *models.State {
 				state := testhelpers.CreateValidState()

--- a/internal/commands/resume.go
+++ b/internal/commands/resume.go
@@ -27,12 +27,12 @@ func ResumeCommand(projectRoot, changedBy string) error {
 		if len(sa.CarriedTasks) > 0 {
 			fmt.Printf("  Carried tasks: %v\n", sa.CarriedTasks)
 		}
-		if result.TransitionsExecuted > 0 {
-			fmt.Printf("  Transitions executed: %d (child tasks created)\n", result.TransitionsExecuted)
-		}
-		if result.TransitionError != "" {
-			fmt.Printf("  ⚠️  Transition error: %s\n", result.TransitionError)
-		}
+	}
+	if result.TransitionsExecuted > 0 {
+		fmt.Printf("  Transitions executed: %d (child tasks created)\n", result.TransitionsExecuted)
+	}
+	if result.TransitionError != "" {
+		fmt.Printf("  ⚠️  Transition error: %s\n", result.TransitionError)
 	}
 
 	// Clear any provider-scoped stop signals so restarted agents aren't immediately blocked.

--- a/internal/commands/resume_test.go
+++ b/internal/commands/resume_test.go
@@ -159,6 +159,45 @@ func TestResumeCommand_WarnsOnProviderSignalClearFailure(t *testing.T) {
 	}
 }
 
+func TestResumeCommand_PrintsMidSprintTransitions(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+	testhelpers.SetupPipelineConfig(t, tmpDir)
+
+	now := time.Now().UTC()
+	state := testhelpers.CreateValidState()
+	state.Config.Mode = models.SystemModeRunning
+	state.PipelineVersion = 2
+	state.Sprint.Status = models.SprintStatusCheckpoint
+	state.Sprint.CheckpointTrigger = models.CheckpointTriggerPlanningComplete
+
+	readyPlan := testhelpers.BuildTaskByStatus("plan-ready", models.TaskStatusMerged, now)
+	readyPlan.Type = models.TaskTypePlanning
+	readyPlan.RolePair = "code-planning-pair"
+	readyPlan.Output = []models.OutputEntry{{
+		Desc:     "Implement X",
+		DoneWhen: "tests pass",
+		Scope:    "pkg/x",
+		SpecRef:  "specs/x.md",
+	}}
+	activePlan := testhelpers.BuildTaskByStatus("plan-active", models.TaskStatusCodePlanning, now)
+	activePlan.Type = models.TaskTypePlanning
+	activePlan.RolePair = "code-planning-pair"
+	state.Tasks = []models.Task{readyPlan, activePlan}
+	state.Sprint.Scope.Planned = []string{"plan-ready", "plan-active"}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	stdout := captureStdout(t, func() {
+		if err := ResumeCommand(tmpDir, "human"); err != nil {
+			t.Fatalf("ResumeCommand() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "Transitions executed: 1 (child tasks created)") {
+		t.Fatalf("stdout missing transition count:\n%s", stdout)
+	}
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -34,6 +34,7 @@ type statusData struct {
 	OrchestratorState  orchestratorStatus    `json:"orchestrator_state"`
 	WorkQueues         workQueuesStatus      `json:"work_queues"`
 	PendingTransitions []pendingTransition   `json:"pending_transitions,omitempty"`
+	PhaseHandoff       *phaseHandoffStatus   `json:"phase_handoff,omitempty"`
 	Anomalies          *[]string             `json:"anomalies,omitempty"`
 	CircuitBreaker     *circuitBreakerStatus `json:"circuit_breaker,omitempty"`
 }
@@ -41,6 +42,24 @@ type statusData struct {
 type pendingTransition struct {
 	TaskID      string   `json:"task_id"`
 	Transitions []string `json:"transitions"`
+}
+
+type phaseHandoffStatus struct {
+	State               string             `json:"state"`
+	Explanation         string             `json:"explanation"`
+	ReadyPlanningTasks  []string           `json:"ready_planning_tasks"`
+	BlockingTasks       []phaseHandoffTask `json:"blocking_tasks,omitempty"`
+	StaleAssignedAgents []phaseHandoffTask `json:"stale_assigned_agents,omitempty"`
+}
+
+type phaseHandoffTask struct {
+	ID                 string `json:"id"`
+	Status             string `json:"status"`
+	RolePair           string `json:"role_pair,omitempty"`
+	AssignedTo         string `json:"assigned_to,omitempty"`
+	AgentStatus        string `json:"agent_status,omitempty"`
+	AgentProcessStatus string `json:"agent_process_status,omitempty"`
+	LeaseExpires       string `json:"lease_expires,omitempty"`
 }
 
 type goalStatus struct {
@@ -163,6 +182,7 @@ func BuildStatusData(state *models.State, detailed bool, projectRoot string, pr 
 	data.Agents = buildAgentStatuses(state)
 	data.OrchestratorState = buildOrchestratorStatus(state, projectRoot)
 	data.WorkQueues = buildWorkQueuesStatus(state, data.Tasks.Claimable, data.Tasks.Reviewable, pr)
+	data.PhaseHandoff = buildPhaseHandoffStatus(state, projectRoot)
 
 	for i := range state.Tasks {
 		avail := ops.AvailableManualTransitions(&state.Tasks[i], projectRoot)
@@ -248,6 +268,96 @@ func buildTaskStatus(state *models.State, pr models.PipelineResolver) taskStatus
 	ts.Reviewable = models.CountReviewableTasks(state, models.RoleCodeReviewer, pr)
 
 	return ts
+}
+
+func buildPhaseHandoffStatus(state *models.State, projectRoot string) *phaseHandoffStatus {
+	detCtx, err := ops.LoadDetectionContext(projectRoot)
+	if err != nil {
+		return nil
+	}
+
+	var ready []string
+	var blockers []phaseHandoffTask
+	var stale []phaseHandoffTask
+	seenStale := make(map[string]bool)
+
+	for _, taskID := range state.Sprint.Scope.Planned {
+		task := state.FindTask(taskID)
+		if task == nil {
+			blockers = append(blockers, phaseHandoffTask{ID: taskID, Status: "MISSING"})
+			continue
+		}
+
+		if ops.IsPlanningCompleteEligible(task, detCtx.PlanningPairs, state) {
+			ready = append(ready, task.ID)
+		}
+
+		if isSprintTerminal(task, detCtx.SprintTerminals) {
+			continue
+		}
+
+		blocker := phaseHandoffTask{
+			ID:       task.ID,
+			Status:   string(task.Status),
+			RolePair: task.RolePair,
+		}
+		if task.AssignedTo != nil {
+			blocker.AssignedTo = *task.AssignedTo
+			if task.LeaseExpires != nil {
+				blocker.LeaseExpires = task.LeaseExpires.Format(time.RFC3339)
+			}
+			if assignedAgent, ok := state.Agents[*task.AssignedTo]; ok {
+				blocker.AgentStatus = string(assignedAgent.Status)
+				blocker.AgentProcessStatus = getProcessStatus(assignedAgent.PID)
+				if assignedAgent.CurrentTask != nil &&
+					*assignedAgent.CurrentTask == task.ID &&
+					assignedAgent.Status != models.AgentStatusIdle &&
+					blocker.AgentProcessStatus != "running" &&
+					!seenStale[*task.AssignedTo] {
+					stale = append(stale, blocker)
+					seenStale[*task.AssignedTo] = true
+				}
+			}
+		}
+		blockers = append(blockers, blocker)
+	}
+
+	if len(ready) == 0 {
+		return nil
+	}
+
+	stateName := "READY"
+	explanation := fmt.Sprintf("%d merged planning task(s) have unconsumed output and are ready for transition execution.", len(ready))
+	if len(blockers) > 0 {
+		stateName = "PARTIAL_READY"
+		explanation = fmt.Sprintf("%d merged planning task(s) have unconsumed output; %d non-terminal planned task(s) are still active. Liza can checkpoint PLANNING_COMPLETE and create implementation tasks after resume without waiting for the active tasks to finish.", len(ready), len(blockers))
+	}
+	if state.Sprint.Status == models.SprintStatusCheckpoint {
+		stateName = "CHECKPOINTED"
+		explanation = fmt.Sprintf("%d merged planning task(s) are waiting behind a checkpoint; resume the sprint to execute their pipeline transitions.", len(ready))
+	}
+	if state.Sprint.Status == models.SprintStatusCompleted {
+		stateName = "COMPLETED"
+		explanation = fmt.Sprintf("%d merged planning task(s) are waiting in a completed sprint; resume/advance to execute their pipeline transitions.", len(ready))
+	}
+
+	return &phaseHandoffStatus{
+		State:               stateName,
+		Explanation:         explanation,
+		ReadyPlanningTasks:  ready,
+		BlockingTasks:       blockers,
+		StaleAssignedAgents: stale,
+	}
+}
+
+func isSprintTerminal(task *models.Task, pipelineTerminals []models.TaskStatus) bool {
+	if task == nil {
+		return false
+	}
+	if task.RolePair != "" {
+		return task.Status.IsPipelineSprintTerminal(pipelineTerminals)
+	}
+	return task.Status.IsSprintTerminal()
 }
 
 // buildAgentStatuses converts agent map to agent status list
@@ -413,11 +523,72 @@ func writeAgentsSection(b *strings.Builder, agents []agentStatus) {
 	b.WriteString("\n\n")
 }
 
+func writePhaseHandoffSection(b *strings.Builder, handoff *phaseHandoffStatus) {
+	if handoff == nil {
+		return
+	}
+	b.WriteString("=== PHASE HANDOFF ===\n")
+	fmt.Fprintf(b, "State: %s\n", handoff.State)
+	fmt.Fprintf(b, "Explanation: %s\n", handoff.Explanation)
+	if len(handoff.ReadyPlanningTasks) > 0 {
+		b.WriteString("Ready planning tasks:\n")
+		for _, taskID := range handoff.ReadyPlanningTasks {
+			fmt.Fprintf(b, "  - %s\n", taskID)
+		}
+	}
+	if len(handoff.BlockingTasks) > 0 {
+		b.WriteString("Non-terminal planned tasks:\n")
+		b.WriteString(render.FormatTable(
+			[]string{"ID", "Status", "Role Pair", "Agent", "Process"},
+			phaseHandoffTaskRows(handoff.BlockingTasks),
+		))
+		b.WriteString("\n")
+	}
+	if len(handoff.StaleAssignedAgents) > 0 {
+		b.WriteString("Stale assigned agents:\n")
+		b.WriteString(render.FormatTable(
+			[]string{"Task", "Agent", "Agent Status", "Process", "Lease Expires"},
+			phaseHandoffStaleRows(handoff.StaleAssignedAgents),
+		))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+}
+
+func phaseHandoffTaskRows(tasks []phaseHandoffTask) [][]string {
+	rows := make([][]string, 0, len(tasks))
+	for _, task := range tasks {
+		rows = append(rows, []string{
+			task.ID,
+			task.Status,
+			task.RolePair,
+			task.AssignedTo,
+			task.AgentProcessStatus,
+		})
+	}
+	return rows
+}
+
+func phaseHandoffStaleRows(tasks []phaseHandoffTask) [][]string {
+	rows := make([][]string, 0, len(tasks))
+	for _, task := range tasks {
+		rows = append(rows, []string{
+			task.ID,
+			task.AssignedTo,
+			task.AgentStatus,
+			task.AgentProcessStatus,
+			task.LeaseExpires,
+		})
+	}
+	return rows
+}
+
 // statusDashboardData is the template data for status_dashboard.tmpl
 type statusDashboardData struct {
 	statusData
 	TasksSection       string
 	AgentsSection      string
+	HandoffSection     string
 	AnomalyList        []string
 	TransitionsSection string
 }
@@ -428,6 +599,8 @@ func formatStatusDashboard(data statusData) (string, error) {
 	var tasksBuf, agentsBuf strings.Builder
 	writeTasksSection(&tasksBuf, data.Tasks)
 	writeAgentsSection(&agentsBuf, data.Agents)
+	var handoffBuf strings.Builder
+	writePhaseHandoffSection(&handoffBuf, data.PhaseHandoff)
 
 	var anomalyList []string
 	if data.Anomalies != nil {
@@ -449,6 +622,7 @@ func formatStatusDashboard(data statusData) (string, error) {
 		statusData:         data,
 		TasksSection:       tasksBuf.String(),
 		AgentsSection:      agentsBuf.String(),
+		HandoffSection:     handoffBuf.String(),
 		AnomalyList:        anomalyList,
 		TransitionsSection: transitionsBuf.String(),
 	}

--- a/internal/commands/status_test.go
+++ b/internal/commands/status_test.go
@@ -241,6 +241,59 @@ func TestBuildStatusData(t *testing.T) {
 			},
 		},
 		{
+			name: "phase handoff identifies partial planning output and stale assigned blocker",
+			state: func() *models.State {
+				state := testhelpers.CreateValidState()
+				readyPlan := testhelpers.BuildTaskByStatus("plan-ready", models.TaskStatusMerged, now)
+				readyPlan.RolePair = "code-planning-pair"
+				readyPlan.Output = []models.OutputEntry{
+					{Desc: "implement X", DoneWhen: "tests pass", Scope: "pkg/x"},
+				}
+
+				activePlan := testhelpers.BuildTaskByStatus("plan-active", models.TaskStatusCodePlanning, now)
+				activePlan.RolePair = "code-planning-pair"
+				activePlan.AssignedTo = stringPtr("code-planner-2")
+				lease := now.Add(30 * time.Minute)
+				activePlan.LeaseExpires = &lease
+
+				state.Tasks = []models.Task{readyPlan, activePlan}
+				state.Sprint.Scope.Planned = []string{"plan-ready", "plan-active"}
+				state.Agents = map[string]models.Agent{
+					"code-planner-2": {
+						Role:        models.RoleCodePlanner,
+						Status:      models.AgentStatusWorking,
+						CurrentTask: stringPtr("plan-active"),
+						Heartbeat:   now.Add(-10 * time.Second),
+						PID:         999999,
+					},
+				}
+				return state
+			}(),
+			detailed:    false,
+			projectRoot: pipelineRoot,
+			pr:          pr,
+			validate: func(t *testing.T, data statusData) {
+				if data.PhaseHandoff == nil {
+					t.Fatal("expected phase handoff diagnostic")
+				}
+				if data.PhaseHandoff.State != "PARTIAL_READY" {
+					t.Fatalf("handoff state = %q, want PARTIAL_READY", data.PhaseHandoff.State)
+				}
+				if len(data.PhaseHandoff.ReadyPlanningTasks) != 1 || data.PhaseHandoff.ReadyPlanningTasks[0] != "plan-ready" {
+					t.Fatalf("ready planning tasks = %v, want [plan-ready]", data.PhaseHandoff.ReadyPlanningTasks)
+				}
+				if len(data.PhaseHandoff.BlockingTasks) != 1 || data.PhaseHandoff.BlockingTasks[0].ID != "plan-active" {
+					t.Fatalf("blocking tasks = %+v, want plan-active", data.PhaseHandoff.BlockingTasks)
+				}
+				if len(data.PhaseHandoff.StaleAssignedAgents) != 1 {
+					t.Fatalf("stale assigned agents = %+v, want one stale assignment", data.PhaseHandoff.StaleAssignedAgents)
+				}
+				if !strings.Contains(data.PhaseHandoff.Explanation, "create implementation tasks after resume") {
+					t.Fatalf("handoff explanation did not describe implementation handoff: %q", data.PhaseHandoff.Explanation)
+				}
+			},
+		},
+		{
 			name: "goal and sprint information",
 			state: func() *models.State {
 				state := testhelpers.CreateValidState()
@@ -800,6 +853,65 @@ func TestFormatStatusDashboard(t *testing.T) {
 			},
 			notExpect: []string{
 				"Unknown trigger",
+			},
+		},
+		{
+			name: "phase handoff section",
+			data: statusData{
+				Goal: goalStatus{
+					Description: "Test",
+					Status:      "IN_PROGRESS",
+					SpecRef:     "spec.md",
+				},
+				Sprint: sprintStatus{
+					ID:         "sprint-1",
+					Status:     "IN_PROGRESS",
+					StartTime:  now.Format(time.RFC3339),
+					TasksDone:  1,
+					TasksTotal: 2,
+				},
+				Config: configStatus{Mode: "RUNNING"},
+				Tasks: taskStatus{
+					Total:    2,
+					Active:   1,
+					Terminal: 1,
+					ByStatus: map[string]int{"CODE_PLANNING": 1, "MERGED": 1},
+				},
+				Agents:            []agentStatus{},
+				OrchestratorState: orchestratorStatus{Trigger: "PLANNING_COMPLETE", TriggerCount: 1, Reason: "1 planning task(s) merged with output[]; ready for coding task expansion"},
+				WorkQueues: workQueuesStatus{
+					Coder:    queueStatus{Available: 0, Reason: "No claimable tasks"},
+					Reviewer: queueStatus{Available: 0, Reason: "No reviewable tasks"},
+				},
+				PhaseHandoff: &phaseHandoffStatus{
+					State:              "PARTIAL_READY",
+					Explanation:        "1 merged planning task(s) have unconsumed output; 1 non-terminal planned task(s) are still active.",
+					ReadyPlanningTasks: []string{"plan-ready"},
+					BlockingTasks: []phaseHandoffTask{{
+						ID:                 "plan-active",
+						Status:             "CODE_PLANNING",
+						RolePair:           "code-planning-pair",
+						AssignedTo:         "code-planner-2",
+						AgentProcessStatus: "stopped",
+					}},
+					StaleAssignedAgents: []phaseHandoffTask{{
+						ID:                 "plan-active",
+						AssignedTo:         "code-planner-2",
+						AgentStatus:        "WORKING",
+						AgentProcessStatus: "stopped",
+						LeaseExpires:       "2026-05-15T20:00:00Z",
+					}},
+				},
+			},
+			expectSections: []string{
+				"=== PHASE HANDOFF ===",
+				"State: PARTIAL_READY",
+				"Ready planning tasks:",
+				"plan-ready",
+				"Non-terminal planned tasks:",
+				"plan-active",
+				"Stale assigned agents:",
+				"code-planner-2",
 			},
 		},
 	}

--- a/internal/integration/full_sprint_test.go
+++ b/internal/integration/full_sprint_test.go
@@ -393,33 +393,48 @@ func TestFullSprintSequence(t *testing.T) {
 		t.Logf("  ✓ %s exited normally", agentID)
 	}
 
-	// simulateOrchestratorTransitions drives the real checkpoint-resume-advance
-	// cycle that production uses to fire pipeline transitions after planning
-	// work is merged. When all planned tasks are terminal (the typical case
-	// after a planning phase completes), the production sequence is:
-	//   1. SprintCheckpoint — auto-detects PLANNING_COMPLETE trigger
-	//   2. Resume (1st) — CHECKPOINT → COMPLETED (all planned tasks terminal)
-	//   3. Resume (2nd) — advance sprint + ExecuteAvailableTransitions
+	// simulateOrchestratorTransitions drives the real checkpoint-resume cycle
+	// that production uses to fire pipeline transitions after planning work is
+	// merged. Transition checkpoints resume directly to IN_PROGRESS and execute
+	// available transitions immediately; older completion checkpoints still need
+	// a second resume to advance the sprint and fire transitions.
 	simulateOrchestratorTransitions := func(phase string) {
 		t.Helper()
-		t.Logf("▶ Running checkpoint-resume-advance cycle (%s)", phase)
+		t.Logf("▶ Running checkpoint-resume transition cycle (%s)", phase)
 
-		// 1. Create a real checkpoint. Auto-detection finds merged planning
-		//    tasks with unconsumed output[] and sets trigger=PLANNING_COMPLETE.
 		cpResult, err := ops.SprintCheckpoint(projectDir, "")
 		if err != nil {
 			t.Fatalf("SprintCheckpoint(%s) failed: %v", phase, err)
 		}
 		t.Logf("  Checkpoint created at %s", cpResult.CheckpointAt.Format(time.RFC3339))
 
-		// 2. First resume: CHECKPOINT → COMPLETED (all planned tasks terminal).
 		res1, err := ops.Resume(projectDir, "test-human")
 		if err != nil {
 			t.Fatalf("Resume[1](%s) failed: %v", phase, err)
 		}
 		t.Logf("  Resumed from: %s", res1.ResumedFrom)
+		if res1.TransitionsExecuted > 0 {
+			stateAfterResume, readErr := db.For(statePath).Read()
+			if readErr != nil {
+				t.Fatalf("Read state after Resume[1](%s) failed: %v", phase, readErr)
+			}
+			if stateAfterResume.Sprint.Status != models.SprintStatusInProgress {
+				t.Fatalf("Resume[1](%s): expected sprint IN_PROGRESS after transition checkpoint, got %s",
+					phase, stateAfterResume.Sprint.Status)
+			}
+			t.Logf("  Transitions executed: %d", res1.TransitionsExecuted)
+			return
+		}
 
-		// 3. Second resume: COMPLETED → advance sprint + fire transitions.
+		stateAfterResume, readErr := db.For(statePath).Read()
+		if readErr != nil {
+			t.Fatalf("Read state after Resume[1](%s) failed: %v", phase, readErr)
+		}
+		if stateAfterResume.Sprint.Status != models.SprintStatusCompleted {
+			t.Fatalf("Resume[1](%s): expected transitions or COMPLETED sprint, got status %s",
+				phase, stateAfterResume.Sprint.Status)
+		}
+
 		res2, err := ops.Resume(projectDir, "test-human")
 		if err != nil {
 			t.Fatalf("Resume[2](%s) failed: %v", phase, err)

--- a/internal/models/sprint.go
+++ b/internal/models/sprint.go
@@ -15,8 +15,16 @@ const (
 // CheckpointTrigger values record why a checkpoint was created.
 const (
 	CheckpointTriggerPlanningComplete = "PLANNING_COMPLETE"
+	CheckpointTriggerManyToOneReady   = "MANY_TO_ONE_READY"
 	CheckpointTriggerSprintComplete   = "SPRINT_COMPLETE"
 )
+
+// IsTransitionCheckpointTrigger reports whether a checkpoint should execute
+// pending pipeline transitions after human resume.
+func IsTransitionCheckpointTrigger(trigger string) bool {
+	return trigger == CheckpointTriggerPlanningComplete ||
+		trigger == CheckpointTriggerManyToOneReady
+}
 
 // IsValid checks if the sprint status is valid
 func (ss SprintStatus) IsValid() bool {

--- a/internal/ops/mode_change.go
+++ b/internal/ops/mode_change.go
@@ -130,6 +130,15 @@ func resumeSprint(s *models.State, lizaPaths paths.LizaPaths, projectRoot string
 		}, nil
 
 	case models.SprintStatusCheckpoint:
+		if models.IsTransitionCheckpointTrigger(s.Sprint.CheckpointTrigger) {
+			// Transition checkpoints are review gates for downstream task creation,
+			// even when every current planned task is terminal. Resume the same
+			// sprint so post-resume transition execution can add child work before
+			// sprint-completion handling runs.
+			s.Sprint.Status = models.SprintStatusInProgress
+			return "CHECKPOINT", nil, nil
+		}
+
 		allTerminal, termErr := allPlannedTasksTerminalForProject(s, projectRoot)
 		if termErr != nil {
 			return "", nil, termErr
@@ -191,8 +200,8 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 			return &PreconditionError{Reason: fmt.Sprintf("system is not PAUSED, circuit breaker not tripped, and sprint is not at CHECKPOINT or COMPLETED (current mode: %s, sprint status: %s)", currentMode, s.Sprint.Status)}
 		}
 
-		wasPlanningCheckpoint := s.Sprint.Status == models.SprintStatusCheckpoint &&
-			s.Sprint.CheckpointTrigger == models.CheckpointTriggerPlanningComplete
+		wasTransitionCheckpoint := s.Sprint.Status == models.SprintStatusCheckpoint &&
+			models.IsTransitionCheckpointTrigger(s.Sprint.CheckpointTrigger)
 
 		resumedFrom = resumeSystemMode(s, timestamp, changedBy)
 
@@ -202,7 +211,7 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 		}
 		advanceResult = advResult
 		runTransitionsAfterResume = advResult != nil ||
-			(wasPlanningCheckpoint && s.Sprint.Status == models.SprintStatusInProgress)
+			(wasTransitionCheckpoint && s.Sprint.Status == models.SprintStatusInProgress)
 		if sprintDesc != "" {
 			if resumedFrom != "" {
 				resumedFrom += " and " + sprintDesc
@@ -221,11 +230,10 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 	// After sprint advance, execute available transitions so child tasks are
 	// created in the new sprint. This handles merged planning tasks with
 	// unconsumed output[] (e.g., epic → US writing, code plan → coding).
-	// Mid-sprint PLANNING_COMPLETE checkpoints use the same path so ready
-	// planning output can hand off to implementation without waiting for a
-	// separate orchestrator PreWork cycle. The human already reviewed by
-	// resuming from the checkpoint/COMPLETED state; transitions are idempotent
-	// via TransitionsExecuted.
+	// Mid-sprint transition checkpoints use the same path so ready planning or
+	// many-to-one output can hand off without waiting for a separate orchestrator
+	// PreWork cycle. The human already reviewed by resuming from the
+	// checkpoint/COMPLETED state; transitions are idempotent via TransitionsExecuted.
 	var transitionsExecuted int
 	var transitionError string
 	if runTransitionsAfterResume {
@@ -233,7 +241,7 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 			transitionError = err.Error()
 		} else {
 			transitionsExecuted = len(results)
-			if err := clearPlanningCheckpointTrigger(projectRoot); err != nil {
+			if err := clearTransitionCheckpointTrigger(projectRoot); err != nil {
 				transitionError = err.Error()
 			}
 		}
@@ -248,11 +256,11 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 	}, nil
 }
 
-func clearPlanningCheckpointTrigger(projectRoot string) error {
+func clearTransitionCheckpointTrigger(projectRoot string) error {
 	statePath := paths.New(projectRoot).StatePath()
 	blackboard := db.For(statePath)
 	return blackboard.Modify(func(s *models.State) error {
-		if s.Sprint.CheckpointTrigger == models.CheckpointTriggerPlanningComplete {
+		if models.IsTransitionCheckpointTrigger(s.Sprint.CheckpointTrigger) {
 			s.Sprint.CheckpointTrigger = ""
 		}
 		return nil

--- a/internal/ops/mode_change.go
+++ b/internal/ops/mode_change.go
@@ -171,6 +171,7 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 	timestamp := time.Now()
 	var resumedFrom string
 	var advanceResult *AdvanceSprintResult
+	runTransitionsAfterResume := false
 
 	err := blackboard.Modify(func(s *models.State) error {
 		currentMode := s.Config.Mode
@@ -190,6 +191,9 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 			return &PreconditionError{Reason: fmt.Sprintf("system is not PAUSED, circuit breaker not tripped, and sprint is not at CHECKPOINT or COMPLETED (current mode: %s, sprint status: %s)", currentMode, s.Sprint.Status)}
 		}
 
+		wasPlanningCheckpoint := s.Sprint.Status == models.SprintStatusCheckpoint &&
+			s.Sprint.CheckpointTrigger == models.CheckpointTriggerPlanningComplete
+
 		resumedFrom = resumeSystemMode(s, timestamp, changedBy)
 
 		sprintDesc, advResult, err := resumeSprint(s, lizaPaths, projectRoot, timestamp)
@@ -197,6 +201,8 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 			return err
 		}
 		advanceResult = advResult
+		runTransitionsAfterResume = advResult != nil ||
+			(wasPlanningCheckpoint && s.Sprint.Status == models.SprintStatusInProgress)
 		if sprintDesc != "" {
 			if resumedFrom != "" {
 				resumedFrom += " and " + sprintDesc
@@ -215,15 +221,21 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 	// After sprint advance, execute available transitions so child tasks are
 	// created in the new sprint. This handles merged planning tasks with
 	// unconsumed output[] (e.g., epic → US writing, code plan → coding).
-	// The human already reviewed by resuming from COMPLETED; transitions
-	// are idempotent via TransitionsExecuted.
+	// Mid-sprint PLANNING_COMPLETE checkpoints use the same path so ready
+	// planning output can hand off to implementation without waiting for a
+	// separate orchestrator PreWork cycle. The human already reviewed by
+	// resuming from the checkpoint/COMPLETED state; transitions are idempotent
+	// via TransitionsExecuted.
 	var transitionsExecuted int
 	var transitionError string
-	if advanceResult != nil {
+	if runTransitionsAfterResume {
 		if results, err := ExecuteAvailableTransitions(projectRoot, ""); err != nil {
 			transitionError = err.Error()
 		} else {
 			transitionsExecuted = len(results)
+			if err := clearPlanningCheckpointTrigger(projectRoot); err != nil {
+				transitionError = err.Error()
+			}
 		}
 	}
 
@@ -234,4 +246,15 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 		TransitionsExecuted: transitionsExecuted,
 		TransitionError:     transitionError,
 	}, nil
+}
+
+func clearPlanningCheckpointTrigger(projectRoot string) error {
+	statePath := paths.New(projectRoot).StatePath()
+	blackboard := db.For(statePath)
+	return blackboard.Modify(func(s *models.State) error {
+		if s.Sprint.CheckpointTrigger == models.CheckpointTriggerPlanningComplete {
+			s.Sprint.CheckpointTrigger = ""
+		}
+		return nil
+	})
 }

--- a/internal/ops/mode_change_test.go
+++ b/internal/ops/mode_change_test.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -398,6 +399,144 @@ func TestResume_PlanningCheckpointExecutesTransitionsMidSprint(t *testing.T) {
 	}
 	if !foundChildInScope {
 		t.Errorf("child %q not in sprint scope: %v", childID, readState.Sprint.Scope.Planned)
+	}
+}
+
+func TestResume_ManyToOneCheckpointExecutesTransitionsMidSprint(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+	testhelpers.SetupPipelineConfig(t, tmpDir)
+
+	state := testhelpers.CreateValidState()
+	state.Config.Mode = models.SystemModeRunning
+	state.PipelineVersion = 2
+	state.Sprint.Status = models.SprintStatusCheckpoint
+	state.Sprint.CheckpointTrigger = models.CheckpointTriggerManyToOneReady
+
+	now := time.Now().UTC()
+	cohort := makeManyToOneCohort("epic-plan-1", "us-writing-pair", models.TaskStatusMerged, "README.md", 2)
+	activePlan := models.Task{
+		ID:          "plan-active",
+		Type:        models.TaskTypePlanning,
+		RolePair:    "code-planning-pair",
+		Description: "Still planning",
+		Status:      models.TaskStatusCodePlanning,
+		Priority:    1,
+		Created:     now,
+		SpecRef:     "README.md",
+		DoneWhen:    "Plan approved",
+		Scope:       "pkg/y",
+		History:     []models.TaskHistoryEntry{},
+	}
+	state.Tasks = append(state.Tasks, cohort[0], cohort[1], activePlan)
+	state.Sprint.Scope.Planned = []string{cohort[0].ID, cohort[1].ID, activePlan.ID}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	result, err := Resume(tmpDir, "human")
+	if err != nil {
+		t.Fatalf("Resume() error: %v", err)
+	}
+
+	if result.TransitionsExecuted != 1 {
+		t.Fatalf("TransitionsExecuted = %d, want 1", result.TransitionsExecuted)
+	}
+	if result.TransitionError != "" {
+		t.Fatalf("TransitionError = %q, want empty", result.TransitionError)
+	}
+
+	bb := db.New(stateFile)
+	readState, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if readState.Sprint.Status != models.SprintStatusInProgress {
+		t.Errorf("Sprint status = %v, want IN_PROGRESS", readState.Sprint.Status)
+	}
+	if readState.Sprint.CheckpointTrigger != "" {
+		t.Errorf("CheckpointTrigger = %q, want cleared", readState.Sprint.CheckpointTrigger)
+	}
+
+	childID := "epic-plan-1-architecture"
+	child := readState.FindTask(childID)
+	if child == nil {
+		t.Fatalf("child task %q not found", childID)
+	}
+	if child.RolePair != "architecture-pair" {
+		t.Errorf("child role_pair = %q, want architecture-pair", child.RolePair)
+	}
+	if child.Status != models.TaskStatus("DRAFT_ARCHITECTURE") {
+		t.Errorf("child status = %s, want DRAFT_ARCHITECTURE", child.Status)
+	}
+	for _, member := range cohort {
+		source := readState.FindTask(member.ID)
+		if source == nil || !source.TransitionsExecuted["us-to-coding"] {
+			t.Fatalf("source transition not recorded for %s: %+v", member.ID, source)
+		}
+	}
+}
+
+func TestResume_ManyToOneCheckpointExecutesTransitionsWhenAllPlannedTerminal(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+	testhelpers.SetupPipelineConfig(t, tmpDir)
+
+	state := testhelpers.CreateValidState()
+	state.Config.Mode = models.SystemModeRunning
+	state.PipelineVersion = 2
+	state.Sprint.Status = models.SprintStatusCheckpoint
+	state.Sprint.CheckpointTrigger = models.CheckpointTriggerManyToOneReady
+
+	cohort := makeManyToOneCohort("epic-plan-1", "us-writing-pair", models.TaskStatusMerged, "README.md", 2)
+	state.Tasks = append(state.Tasks, cohort[0], cohort[1])
+	state.Sprint.Scope.Planned = []string{cohort[0].ID, cohort[1].ID}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	result, err := Resume(tmpDir, "human")
+	if err != nil {
+		t.Fatalf("Resume() error: %v", err)
+	}
+
+	if result.SprintAdvanced != nil {
+		t.Fatalf("SprintAdvanced = %+v, want nil", result.SprintAdvanced)
+	}
+	if result.TransitionsExecuted != 1 {
+		t.Fatalf("TransitionsExecuted = %d, want 1", result.TransitionsExecuted)
+	}
+	if result.TransitionError != "" {
+		t.Fatalf("TransitionError = %q, want empty", result.TransitionError)
+	}
+
+	bb := db.New(stateFile)
+	readState, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if readState.Sprint.Status != models.SprintStatusInProgress {
+		t.Errorf("Sprint status = %v, want IN_PROGRESS", readState.Sprint.Status)
+	}
+	if readState.Sprint.CheckpointTrigger != "" {
+		t.Errorf("CheckpointTrigger = %q, want cleared", readState.Sprint.CheckpointTrigger)
+	}
+
+	childID := "epic-plan-1-architecture"
+	child := readState.FindTask(childID)
+	if child == nil {
+		t.Fatalf("child task %q not found", childID)
+	}
+	if child.RolePair != "architecture-pair" {
+		t.Errorf("child role_pair = %q, want architecture-pair", child.RolePair)
+	}
+	if child.Status != models.TaskStatus("DRAFT_ARCHITECTURE") {
+		t.Errorf("child status = %s, want DRAFT_ARCHITECTURE", child.Status)
+	}
+	if !slices.Contains(readState.Sprint.Scope.Planned, childID) {
+		t.Errorf("child %q not in sprint scope: %v", childID, readState.Sprint.Scope.Planned)
+	}
+	for _, member := range cohort {
+		source := readState.FindTask(member.ID)
+		if source == nil || !source.TransitionsExecuted["us-to-coding"] {
+			t.Fatalf("source transition not recorded for %s: %+v", member.ID, source)
+		}
 	}
 }
 

--- a/internal/ops/mode_change_test.go
+++ b/internal/ops/mode_change_test.go
@@ -300,6 +300,107 @@ func TestResume_FromCheckpoint(t *testing.T) {
 	}
 }
 
+func TestResume_PlanningCheckpointExecutesTransitionsMidSprint(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+	testhelpers.SetupPipelineConfig(t, tmpDir)
+
+	state := testhelpers.CreateValidState()
+	state.Config.Mode = models.SystemModeRunning
+	state.PipelineVersion = 2
+	state.Sprint.Status = models.SprintStatusCheckpoint
+	state.Sprint.CheckpointTrigger = models.CheckpointTriggerPlanningComplete
+
+	now := time.Now().UTC()
+	readyPlan := models.Task{
+		ID:          "plan-ready",
+		Type:        models.TaskTypePlanning,
+		RolePair:    "code-planning-pair",
+		Description: "Ready coding plan",
+		Status:      models.TaskStatusMerged,
+		Priority:    1,
+		Created:     now,
+		SpecRef:     "README.md",
+		DoneWhen:    "Plan approved",
+		Scope:       "pkg/x",
+		Output: []models.OutputEntry{{
+			Desc:     "Implement X",
+			DoneWhen: "tests pass",
+			Scope:    "pkg/x",
+			SpecRef:  "specs/x.md",
+		}},
+		History: []models.TaskHistoryEntry{},
+	}
+	activePlan := models.Task{
+		ID:          "plan-active",
+		Type:        models.TaskTypePlanning,
+		RolePair:    "code-planning-pair",
+		Description: "Still planning",
+		Status:      models.TaskStatusCodePlanning,
+		Priority:    1,
+		Created:     now,
+		SpecRef:     "README.md",
+		DoneWhen:    "Plan approved",
+		Scope:       "pkg/y",
+		History:     []models.TaskHistoryEntry{},
+	}
+	state.Tasks = append(state.Tasks, readyPlan, activePlan)
+	state.Sprint.Scope.Planned = []string{"plan-ready", "plan-active"}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	result, err := Resume(tmpDir, "human")
+	if err != nil {
+		t.Fatalf("Resume() error: %v", err)
+	}
+
+	if result.TransitionsExecuted != 1 {
+		t.Fatalf("TransitionsExecuted = %d, want 1", result.TransitionsExecuted)
+	}
+	if result.TransitionError != "" {
+		t.Fatalf("TransitionError = %q, want empty", result.TransitionError)
+	}
+
+	bb := db.New(stateFile)
+	readState, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if readState.Sprint.Status != models.SprintStatusInProgress {
+		t.Errorf("Sprint status = %v, want IN_PROGRESS", readState.Sprint.Status)
+	}
+	if readState.Sprint.CheckpointTrigger != "" {
+		t.Errorf("CheckpointTrigger = %q, want cleared", readState.Sprint.CheckpointTrigger)
+	}
+
+	source := readState.FindTask("plan-ready")
+	if source == nil || !source.TransitionsExecuted["code-plan-to-coding"] {
+		t.Fatalf("source transition not recorded: %+v", source)
+	}
+
+	childID := "plan-ready-coding-0"
+	child := readState.FindTask(childID)
+	if child == nil {
+		t.Fatalf("child task %q not found", childID)
+	}
+	if child.RolePair != "coding-pair" {
+		t.Errorf("child role_pair = %q, want coding-pair", child.RolePair)
+	}
+	if child.Status != models.TaskStatusReady {
+		t.Errorf("child status = %s, want %s", child.Status, models.TaskStatusReady)
+	}
+
+	foundChildInScope := false
+	for _, id := range readState.Sprint.Scope.Planned {
+		if id == childID {
+			foundChildInScope = true
+			break
+		}
+	}
+	if !foundChildInScope {
+		t.Errorf("child %q not in sprint scope: %v", childID, readState.Sprint.Scope.Planned)
+	}
+}
+
 func TestResume_PausedAndCheckpoint(t *testing.T) {
 	tmpDir := t.TempDir()
 	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)

--- a/internal/ops/sprint_checkpoint.go
+++ b/internal/ops/sprint_checkpoint.go
@@ -22,7 +22,7 @@ type SprintCheckpointResult struct {
 
 // SprintCheckpoint transitions sprint status to CHECKPOINT, causing agents to pause,
 // and writes a sprint summary report. The trigger parameter records why the checkpoint
-// was created (e.g. "PLANNING_COMPLETE", "SPRINT_COMPLETE", or "" for manual). No terminal I/O.
+// was created (e.g. "PLANNING_COMPLETE", "MANY_TO_ONE_READY", "SPRINT_COMPLETE", or "" for manual). No terminal I/O.
 func SprintCheckpoint(projectRoot string, trigger string) (*SprintCheckpointResult, error) {
 	lizaPaths := paths.New(projectRoot)
 	statePath := lizaPaths.StatePath()
@@ -44,7 +44,7 @@ func SprintCheckpoint(projectRoot string, trigger string) (*SprintCheckpointResu
 		return nil, &PreconditionError{Reason: "cannot checkpoint: sprint is ABORTED"}
 	}
 
-	// Auto-detect PLANNING_COMPLETE when trigger is empty.
+	// Auto-detect transition checkpoints when trigger is empty.
 	// This makes the system resilient to LLM omission of the trigger parameter.
 	if trigger == "" {
 		if detCtx, detErr := LoadDetectionContext(projectRoot); detErr == nil {
@@ -54,6 +54,9 @@ func SprintCheckpoint(projectRoot string, trigger string) (*SprintCheckpointResu
 					trigger = models.CheckpointTriggerPlanningComplete
 					break
 				}
+			}
+			if trigger == "" && CountReadyManyToOneCohorts(state, detCtx.ManyToOneTransitions) > 0 {
+				trigger = models.CheckpointTriggerManyToOneReady
 			}
 		}
 		// If LoadDetectionContext fails (no pipeline config), trigger stays empty.

--- a/internal/ops/sprint_checkpoint_test.go
+++ b/internal/ops/sprint_checkpoint_test.go
@@ -160,6 +160,37 @@ func TestSprintCheckpoint_AutoDetectsPlanningComplete(t *testing.T) {
 	}
 }
 
+func TestSprintCheckpoint_AutoDetectsManyToOneReady(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+	testhelpers.SetupPipelineConfig(t, tmpDir)
+
+	now := time.Now().UTC()
+	state := testhelpers.CreateValidState()
+	state.Sprint.Status = models.SprintStatusInProgress
+	state.Sprint.Timeline.Started = now.Add(-1 * time.Hour)
+	state.Sprint.Timeline.Deadline = now.Add(5 * time.Hour)
+
+	cohort := makeManyToOneCohort("epic-plan-1", "us-writing-pair", models.TaskStatusMerged, "README.md", 2)
+	state.Tasks = []models.Task{cohort[0], cohort[1]}
+	state.Sprint.Scope.Planned = []string{cohort[0].ID, cohort[1].ID}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	_, err := SprintCheckpoint(tmpDir, "")
+	if err != nil {
+		t.Fatalf("SprintCheckpoint() error: %v", err)
+	}
+
+	bb := db.New(stateFile)
+	readState, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	if readState.Sprint.CheckpointTrigger != models.CheckpointTriggerManyToOneReady {
+		t.Errorf("CheckpointTrigger = %q, want %q (auto-detect)", readState.Sprint.CheckpointTrigger, models.CheckpointTriggerManyToOneReady)
+	}
+}
+
 func TestSprintCheckpoint_AlreadyAtCheckpoint(t *testing.T) {
 	tmpDir := t.TempDir()
 	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)

--- a/internal/render/templates/status_dashboard.tmpl
+++ b/internal/render/templates/status_dashboard.tmpl
@@ -24,6 +24,7 @@ Wake Trigger: {{.OrchestratorState.Trigger}}
 {{- if gt .OrchestratorState.TriggerCount 0}} (count: {{.OrchestratorState.TriggerCount}}){{end}}
 Explanation: {{.OrchestratorState.Reason}}
 
+{{.HandoffSection -}}
 === WORK QUEUES ===
 Coder: {{.WorkQueues.Coder.Available}} available - {{.WorkQueues.Coder.Reason}}
 Reviewer: {{.WorkQueues.Reviewer.Available}} available - {{.WorkQueues.Reviewer.Reason}}

--- a/specs/architecture/blackboard-schema.md
+++ b/specs/architecture/blackboard-schema.md
@@ -623,7 +623,7 @@ sprint:
     checkpoint_at: null
     ended: null
   status: IN_PROGRESS  # Sprint status: IN_PROGRESS, CHECKPOINT, COMPLETED, ABORTED (differs from goal status)
-  checkpoint_trigger: ""  # Why last checkpoint was created: PLANNING_COMPLETE, SPRINT_COMPLETE, or empty (manual/other)
+  checkpoint_trigger: ""  # Why last checkpoint was created: PLANNING_COMPLETE, MANY_TO_ONE_READY, SPRINT_COMPLETE, or empty (manual/other)
   metrics:
     tasks_done: 2
     tasks_in_progress: 1

--- a/specs/protocols/sprint-governance.md
+++ b/specs/protocols/sprint-governance.md
@@ -74,6 +74,7 @@ Checkpoints are **mandatory human review points** unless auto-resume is enabled 
 | Trigger | Automatic? | `checkpoint_trigger` | Notes |
 |---------|------------|---------------------|-------|
 | Planning tasks merged with output | Yes | `PLANNING_COMPLETE` | Human reviews planning output before coding begins (skipped when auto-resume enabled) |
+| Many-to-one cohort ready | Yes | `MANY_TO_ONE_READY` | Human reviews fan-in readiness before the consolidated child task is created |
 | Sprint tasks complete | Yes | `SPRINT_COMPLETE` | Normal completion |
 | Sprint deadline reached | Yes | _(empty)_ | Time box enforced |
 | Circuit breaker fired | Yes | _(empty)_ | Systemic issue detected |
@@ -179,13 +180,13 @@ This is acceptable for v1 because:
 
 ### Planning Transition Gate
 
-When planning tasks (epic-planner, code-planner) are merged, the orchestrator checkpoints the sprint with `checkpoint_trigger: PLANNING_COMPLETE` instead of immediately creating child tasks. This gives the human a chance to review planning output before coding begins (unless auto-resume is enabled, in which case agents resume automatically).
+When planning tasks (epic-planner, code-planner) are merged, the orchestrator checkpoints the sprint with `checkpoint_trigger: PLANNING_COMPLETE` instead of immediately creating child tasks. When a many-to-one transition cohort is ready, it checkpoints with `checkpoint_trigger: MANY_TO_ONE_READY`. This gives the human a chance to review planning output or fan-in readiness before downstream work begins (unless auto-resume is enabled, in which case agents resume automatically).
 
 **Two-wake model:**
 
-1. **Wake 1:** Orchestrator detects merged planning tasks with unconsumed `output[]` → creates checkpoint with `trigger: PLANNING_COMPLETE` → agents pause (or auto-resume)
-2. **Human reviews** planning output in the sprint summary → runs `liza resume` (skipped when auto-resume is enabled)
-3. **Wake 2 (PreWork):** Orchestrator's PreWork checks `checkpoint_trigger == "PLANNING_COMPLETE" && status == IN_PROGRESS` with unconsumed output → executes `ExecuteAvailableTransitions` → child tasks created → doers can claim
+1. **Wake 1:** Orchestrator detects merged planning tasks with unconsumed `output[]` or a ready many-to-one cohort → creates checkpoint with `trigger: PLANNING_COMPLETE` or `MANY_TO_ONE_READY` → agents pause (or auto-resume)
+2. **Human reviews** planning output or fan-in readiness in the sprint summary → runs `liza resume` (skipped when auto-resume is enabled)
+3. **Wake 2 (PreWork):** Orchestrator's PreWork checks for a transition checkpoint with `status == IN_PROGRESS` and ready transitions → executes `ExecuteAvailableTransitions` → child tasks created → doers can claim
 
 **Gate correctness:**
 - Fresh sprint (trigger empty) → gate does not fire

--- a/support-docs/SUPPORT.md
+++ b/support-docs/SUPPORT.md
@@ -107,15 +107,15 @@ When a sprint checkpoints (status: CHECKPOINT), all agents pause. The human deci
 
 | Action | Command | When |
 |--------|---------|------|
-| Accept & resume | `liza resume` | Satisfied with output, continue |
+| Accept & resume | `liza resume` | Satisfied with planner output or fan-in readiness, continue |
 | Amend & replan | Edit plan, commit, `liza replan` | Want to change planner output |
-| Pipeline transition | `liza proceed <task-id> <transition>` | Create child tasks for next pair (auto-done by `liza resume` in batch) |
+| Pipeline transition | `liza proceed <task-id> <transition>` | Create child tasks from output or a ready cohort (auto-done by `liza resume` in batch) |
 | Pause for manual work | (no command) | Make manual changes first |
 | Abort | `liza stop` | Stop entirely |
 
 ### Replanning
 
-When a planning sprint checkpoints (trigger: `PLANNING_COMPLETE`), the planner's `output[]` represents the proposed task breakdown.
+When a transition checkpoint fires, the human reviews proposed downstream work before child tasks are created. `PLANNING_COMPLETE` means planner `output[]` represents the proposed task breakdown; `MANY_TO_ONE_READY` means a fan-in cohort is ready to create its consolidated child task.
 
 ```bash
 # Typical replan workflow

--- a/support-docs/USAGE_MULTI_AGENTS.md
+++ b/support-docs/USAGE_MULTI_AGENTS.md
@@ -316,21 +316,21 @@ artifact yourself and surfaces unflagged decisions agents baked in without marki
 
 | Action | Command | When                                                                                                 |
 |--------|---------|------------------------------------------------------------------------------------------------------|
-| Accept & resume | `liza resume` | Satisfied with planner output, continue the sprint, start next sprint                                |
+| Accept & resume | `liza resume` | Satisfied with planner output or fan-in readiness, continue the sprint, start next sprint            |
 | Amend & replan | Edit plan file, commit, then `liza replan` | Want to change a planner's output before proceeding                                                  |
-| Pipeline transition | `liza proceed <task-id> <transition>` | Create child tasks for the next role-pair from output[]. Automatically done in batch by `liza resume` |
+| Pipeline transition | `liza proceed <task-id> <transition>` | Create child tasks for the next role-pair from output or a ready cohort. Automatically done in batch by `liza resume` |
 | Pause for manual work | (no command) | Want to make manual changes before continuing                                                        |
 | Abort | `liza stop` | Want to stop entirely                                                                                |
 
-**`liza proceed`** creates child tasks from a completed task's `output[]` entries based on the pipeline transition's cardinality (`per-subtask`: one child per output entry, `one-to-one`: single child from parent, `many-to-one`: all sibling tasks in a cohort must reach approved status, then one child is created linked to all parents — used by the `us-to-coding` transition to fan N approved user stories into one architecture task). Use `liza status` to see available transitions for tasks at terminal states. After `proceed`, run `liza resume` to start the next sprint.
+**`liza proceed`** creates child tasks from a completed task's `output[]` entries based on the pipeline transition's cardinality (`per-subtask`: one child per output entry, `one-to-one`: single child from parent, `many-to-one`: all sibling tasks in a cohort must reach approved status, then one child is created linked to all parents — used by the `us-to-coding` transition to fan N approved user stories into one architecture task). Use `liza status` to see available transitions for tasks at terminal states. Transition checkpoints run this in batch during `liza resume`; manual use is for explicit one-off transition execution.
 
 For `per-subtask` output, `depends_on` names sibling output indexes (`"0"` means `output[0]`). Use `task_depends_on` when the generated child must depend on existing concrete task IDs outside the current `output[]`.
 
 #### Replanning at Checkpoint
 
-When a planning sprint checkpoints (trigger: `PLANNING_COMPLETE`), the planner's `output[]` entries represent the proposed task breakdown. The human may:
+When a transition checkpoint fires, the human reviews the proposed downstream work before child tasks are created. `PLANNING_COMPLETE` means planner `output[]` entries represent the proposed task breakdown; `MANY_TO_ONE_READY` means a fan-in cohort is ready to create its consolidated child task. The human may:
 
-1. **Accept the plan** — run `liza resume` to continue
+1. **Accept the transition** — run `liza resume` to continue
 2. **Amend the plan** — edit the plan markdown file, commit, then run `liza replan`
 
 `liza replan` invalidates the old planning task's output and creates a new planning task with the same role-pair and spec. The sprint returns to IN_PROGRESS and the planner agent picks up the new task, re-reads the amended plan, and regenerates `output[]`.


### PR DESCRIPTION
## Summary

Closes #69.

This changes the orchestrator wake detector so merged planning tasks with unconsumed output can trigger `PLANNING_COMPLETE` even when unrelated planned tasks are still active. The checkpoint/resume gate still controls when transitions execute, but ready code-plan/design outputs no longer starve behind one stuck planner.

It also adds `phase_handoff` status diagnostics so operators can see:

- ready planning tasks with unconsumed output
- non-terminal planned tasks still active in the sprint
- stale assigned agents whose process status is not running

Related: #67. The PR surfaces stale assigned agents in status, but does not fully implement the lifecycle watchdog/recovery fix tracked there.

## Validation

- `GOCACHE=/tmp/liza-go-build-cache go test ./internal/agent ./internal/commands` passed
- `GOCACHE=/tmp/liza-go-build-cache go test ./internal/gitenv -run TestOutputWithTimeout_ReturnsStdoutOnly -count=1 -v` passed
- `GOCACHE=/tmp/liza-go-build-cache go test ./internal/gitenv -count=1` passed
- `GOCACHE=/tmp/liza-go-build-cache go test ./...` passed all changed packages and integration coverage, but one unrelated `internal/gitenv` test timed out once at its 1s command timeout during the full run; direct reruns passed
- Built patched binary with `GOCACHE=/tmp/liza-go-build-cache make build`
- Ran patched binary against downstream Radiance state; it reported `PLANNING_COMPLETE`, 12 ready planning outputs, and the stale #496 planner in `phase_handoff`