### PR TITLE
feat(cli): add pi (pi-coding-agent) as a supported CLI backend

### DIFF
--- a/cmd/liza/cmd_init.go
+++ b/cmd/liza/cmd_init.go
@@ -341,7 +341,7 @@ Reports whether any changes were made.`,
 }
 
 // agentFlagNames is the canonical list of supported agent flag names.
-var agentFlagNames = []string{"claude", "codex", "gemini", "mistral"}
+var agentFlagNames = []string{"claude", "codex", "gemini", "mistral", "pi"}
 
 // hasExplicitInitFlags returns true if any workspace-specific flag was explicitly set.
 // This prevents the interactive wizard from silently swallowing CLI flags it doesn't collect.
@@ -404,6 +404,7 @@ func init() {
 	initCmd.Flags().Bool("codex", false, "create AGENTS.md symlink to ~/.liza/CORE.md and configure repo hooks")
 	initCmd.Flags().Bool("gemini", false, "create GEMINI.md symlink to ~/.liza/CORE.md")
 	initCmd.Flags().Bool("mistral", false, "set up ~/.vibe/ for Liza contract")
+	initCmd.Flags().Bool("pi", false, "create AGENTS.md symlink to ~/.liza/CORE.md for pi CLI")
 
 	// Validate command flags
 	validateCmd.Flags().Bool("skip-spec-check", false, "skip spec file existence check")

--- a/internal/agent/cli.go
+++ b/internal/agent/cli.go
@@ -3,7 +3,7 @@ package agent
 import "os"
 
 // validCLIs is the canonical list of supported CLI backends.
-var validCLIs = []string{"claude", "codex", "gemini", "mistral", "kimi"}
+var validCLIs = []string{"claude", "codex", "gemini", "mistral", "kimi", "pi"}
 
 // ValidCLIs returns the supported CLI backends. Returns a fresh copy to prevent mutation.
 func ValidCLIs() []string {

--- a/internal/agent/supervisor.go
+++ b/internal/agent/supervisor.go
@@ -608,6 +608,15 @@ func (d *DefaultCLIExecutor) Execute(ctx context.Context, cliName string, agentI
 			args = append(args, "--verbose", "--output-format", "stream-json")
 		}
 		cmd = exec.CommandContext(ctx, "kimi", args...)
+	case "pi":
+		args := []string{"-p"}
+		if !useStdin {
+			args = append(args, prompt)
+		}
+		if d.outputsDir != "" {
+			args = append(args, "--mode", "json")
+		}
+		cmd = exec.CommandContext(ctx, "pi", args...)
 	default:
 		return CLIExecutionResult{}, fmt.Errorf("unknown CLI: %s", cliName)
 	}

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -44,6 +44,7 @@ var InitAgentRepoSymlinks = map[string]string{
 	"claude": "CLAUDE.md",
 	"codex":  "AGENTS.md",
 	"gemini": "GEMINI.md",
+	"pi":     "AGENTS.md",
 }
 
 // globalFallbacks maps repo-root filenames to their CLI global fallback paths
@@ -100,6 +101,8 @@ func InitPairingCommand(params InitPairingParams) error {
 			hasMistral = true
 		case "gemini":
 			// handled by repoRootNames above
+		case "pi":
+			// handled by repoRootNames above; pi auto-discovers AGENTS.md
 		default:
 			return fmt.Errorf("unknown agent: %s", agent)
 		}


### PR DESCRIPTION
## Summary

Adds [Pi](https://github.com/badlogic/pi-mono) (a.k.a. `pi-coding-agent`) to Liza's `validCLIs` list, joining `claude`, `codex`, `gemini`, `mistral`, `kimi`. Spawned via `pi -p [--mode json]`, single-shot, prompt piped on stdin — the same shape as the existing adapters.

**Why Pi.** Pi is provider-agnostic by design — one CLI fronts Anthropic, OpenAI, Google, DeepSeek, Bedrock, Groq, OpenRouter, GLM, Kimi, Mistral, and ~15 others. Wiring it in lets Liza users pick any of those providers per role without a per-CLI Liza integration each time.

## Changes

| File | Change |
|------|--------|
| `internal/agent/cli.go` | `validCLIs` += `"pi"` |
| `internal/agent/supervisor.go` | `case "pi":` in `Execute` switch — `pi -p` (stdin-piped prompt), `--mode json` when output capture is enabled |
| `internal/commands/init.go` | `"pi" -> "AGENTS.md"` symlink (pi auto-discovers `AGENTS.md`); no-op case in classifier — no PreToolUse hook setup |
| `cmd/liza/cmd_init.go` | `--pi` flag registered; `"pi"` added to `agentFlagNames` |

No new packages, no new dependencies. `ExecuteInteractive`'s `default:` branch (`exec.Command(actualCLI)`) already handles `pi` interactive mode.

## Verified end-to-end on macOS

```bash
liza init --pi --default-cli pi "Build tiny todo CLI" --spec specs/vision.md
# AGENTS.md → ~/.liza/CORE.md, state.yaml.config.default_cli: pi

liza agent orchestrator --cli pi
# orchestrator-1 spawned, read contract via pi `read` tool calls,
# wrote epic-1 via `liza add-task` (model: opencode-go/glm-5)

liza tui
# epic-1 DRAFT_EPIC_PLAN visible; orchestrator-1 IDLE; hotkeys reachable
```

## Test plan

- [x] `make build` clean
- [x] `make test` passes on touched packages (`internal/agent`, `internal/commands`, `cmd/liza`)
- [x] `liza init --pi` creates `AGENTS.md` symlink to `~/.liza/CORE.md`
- [x] `liza init --default-cli pi` is accepted and persisted to `state.yaml`
- [x] `liza agent <role> --cli pi` spawns `pi -p`, contract is loaded from `AGENTS.md`, tool calls execute, state transitions are written via `liza` subcommands

## Out of scope (potential follow-ups)

- **Tool-call gating.** Pi has an `--mode rpc` + extension hook (`pi.on("tool_call", ...)` with `block: true/false`) that could give Liza native PreToolUse-equivalent enforcement on non-Claude harnesses. Out of scope here; would be a larger architectural change (persistent agent process instead of single-shot). Design notes available on request.
- **Per-role model pinning.** Pi accepts `--provider` / `--model`, but none of the existing adapters (`claude`, `codex`, `gemini`) pin a model — they all defer to each CLI's own settings. Adding it for `pi` only would be asymmetric. Per-role model selection is a cross-cutting addition that should land in `Config` and thread through every adapter.
- **`claude-hooks-compat`.** Pi has [a shim](https://github.com/badlogic/pi-mono/pull/4672) for running Claude Code PreToolUse hook scripts unchanged. Could let Liza's existing `enforce-init.sh` / `git-guard.sh` / `rtk-guard.sh` work under Pi without rewriting. Out of scope here.

## Notes for review

- Pi is an external dependency (npm package `@earendil-works/pi-coding-agent` or `pi.dev/install.sh`); `liza setup` doesn't install it. Users who pick `pi` are expected to have it on `$PATH`, same model as `claude` / `codex` today.
- I haven't touched the docs (`docs/CONFIGURATION.md`, `docs/USAGE_MULTI_AGENTS.md`, `README.md`) to keep this PR scoped to the adapter wiring. Happy to add a docs commit if you want.