### PR TITLE
fix(agent): round-2 reviewer claim + reviewer-1 self-claim guard + auto-emit checkpoint-summary on merge

### DIFF
--- a/internal/agent/checkpoint_summary.go
+++ b/internal/agent/checkpoint_summary.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// CheckpointSummaryRelPath is the location, relative to the project root,
+// where the auto-generated checkpoint summary is written.
+const CheckpointSummaryRelPath = "docs/checkpoint-summary.md"
+
+// checkpointSummaryDefaultTimeout bounds how long the spawned CLI is allowed
+// to run before being terminated. Checkpoint summaries are short reads + a
+// single Markdown emission — generous but bounded.
+const checkpointSummaryDefaultTimeout = 5 * time.Minute
+
+// checkpointSummaryRunner is the function used to actually invoke a CLI for
+// the checkpoint-summary skill. It is a package var so tests can substitute
+// a deterministic fake without spawning a real LLM subprocess.
+//
+// Contract:
+//   - projectRoot: working directory for the spawn (state.yaml lives in .liza/)
+//   - cliName: resolved default CLI (claude, codex, gemini, ...)
+//   - prompt: the message handed to the CLI; instructs it to use the
+//     checkpoint-summary skill against .liza/state.yaml and write the report
+//     to docs/checkpoint-summary.md.
+//
+// Returns nil on a successful spawn that wrote the report. Any error is
+// non-fatal at the call site — the merge itself has already succeeded.
+var checkpointSummaryRunner = runCheckpointSummaryCLI
+
+// emitCheckpointSummary runs the checkpoint-summary skill against the project
+// for the given just-merged task. It is best-effort: any failure is logged
+// and discarded so a transient CLI hiccup does not poison the merge path.
+//
+// Behavior:
+//   - opt-out via Config.AutoCheckpointSummary == false
+//   - report is written to <projectRoot>/docs/checkpoint-summary.md
+//   - CLI is resolved through ResolveDefaultCLI (state.yaml > env > const)
+func emitCheckpointSummary(projectRoot string, taskID string, cfg models.Config) {
+	logger := GetLogger()
+
+	if cfg.AutoCheckpointSummary != nil && !*cfg.AutoCheckpointSummary {
+		logger.Info("Auto checkpoint-summary disabled by config", "task_id", taskID)
+		return
+	}
+
+	cliName := ResolveDefaultCLI(cfg.DefaultCLI)
+	prompt := buildCheckpointSummaryPrompt(taskID)
+
+	if err := checkpointSummaryRunner(projectRoot, cliName, prompt); err != nil {
+		logger.Warn("Auto checkpoint-summary failed",
+			"task_id", taskID,
+			"cli", cliName,
+			"error", err)
+		return
+	}
+
+	logger.Info("Auto checkpoint-summary emitted",
+		"task_id", taskID,
+		"cli", cliName,
+		"path", CheckpointSummaryRelPath)
+}
+
+// buildCheckpointSummaryPrompt builds the prompt sent to the configured CLI.
+// It is self-contained: the CLI must read .liza/state.yaml, apply the
+// checkpoint-summary skill, and write the result. Kept short on purpose —
+// the skill instructions live in skills/checkpoint-summary/SKILL.md.
+func buildCheckpointSummaryPrompt(taskID string) string {
+	return fmt.Sprintf(`Use the checkpoint-summary skill.
+
+Context: task %s just merged into the integration branch. Read .liza/state.yaml,
+apply the checkpoint-summary skill protocol, and write the report to
+%s (overwrite if it already exists). Do not ask follow-up questions.
+`, taskID, CheckpointSummaryRelPath)
+}
+
+// runCheckpointSummaryCLI is the production implementation of
+// checkpointSummaryRunner. It spawns the configured CLI with the prompt on
+// stdin, captures combined output for the logger, and lets the CLI write
+// the markdown report itself (the skill knows where to put it).
+//
+// This intentionally does NOT use the rich DefaultCLIExecutor pipeline used
+// for normal agent runs: this is a side-effect emitter, not a full agent
+// session, and should not depend on agent state (heartbeat, output dir,
+// secret masker) or hijack the same per-agent semantics.
+func runCheckpointSummaryCLI(projectRoot, cliName, prompt string) error {
+	args, useStdin, err := checkpointSummaryCLIArgs(cliName, prompt)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), checkpointSummaryDefaultTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, cliName, args...)
+	cmd.Dir = projectRoot
+	// Strip ANTHROPIC_API_KEY to avoid conflict with OAuth flow when
+	// the configured CLI is claude — see CLAUDE.md Claude Auth rule.
+	cmd.Env = filterAPIKeyEnv(os.Environ())
+
+	if useStdin {
+		cmd.Stdin = strings.NewReader(prompt)
+	} else {
+		cmd.Stdin = nil
+	}
+
+	// Capture output — we don't surface it to the user, but log it for
+	// triage if the report ends up empty or missing.
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("checkpoint-summary CLI %q timed out after %s", cliName, checkpointSummaryDefaultTimeout)
+		}
+		return fmt.Errorf("checkpoint-summary CLI %q failed: %w", cliName, err)
+	}
+
+	// Sanity: confirm the report was actually written. If the CLI exited 0
+	// but never wrote the file, surface that as an error so callers can warn.
+	reportPath := filepath.Join(projectRoot, CheckpointSummaryRelPath)
+	info, statErr := os.Stat(reportPath)
+	if statErr != nil {
+		return fmt.Errorf("checkpoint-summary CLI exited 0 but report missing at %s: %w", reportPath, statErr)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("checkpoint-summary CLI exited 0 but report is empty at %s", reportPath)
+	}
+	return nil
+}
+
+// checkpointSummaryCLIArgs returns the argv tail and whether stdin should be
+// piped, for each supported CLI. Mirrors the per-CLI dispatch in the main
+// supervisor without pulling in agent output logging concerns.
+func checkpointSummaryCLIArgs(cliName, prompt string) ([]string, bool, error) {
+	switch cliName {
+	case "claude":
+		return []string{"--print", "--permission-mode", "acceptEdits"}, true, nil
+	case "codex":
+		return []string{"exec", "--skip-git-repo-check", "-"}, true, nil
+	case "gemini":
+		return []string{"-p"}, true, nil
+	case "vibe", "mistral":
+		return []string{"-p", prompt}, false, nil
+	case "kimi":
+		return []string{"-p"}, true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported CLI for checkpoint-summary: %q", cliName)
+	}
+}
+
+// filterAPIKeyEnv removes ANTHROPIC_API_KEY from the env list. The user's
+// CLAUDE.md mandates this for any subprocess that may shell out to claude —
+// it conflicts with the OAuth token mechanism and surfaces as "invalid API
+// key" errors.
+func filterAPIKeyEnv(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "ANTHROPIC_API_KEY=") {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
+}

--- a/internal/agent/checkpoint_summary.go
+++ b/internal/agent/checkpoint_summary.go
@@ -7,15 +7,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/liza-mas/liza/internal/gitenv"
 	"github.com/liza-mas/liza/internal/models"
 )
 
 // CheckpointSummaryRelPath is the location, relative to the project root,
-// where the auto-generated checkpoint summary is written.
-const CheckpointSummaryRelPath = "docs/checkpoint-summary.md"
+// where the auto-generated checkpoint summary is written. Keep it under
+// .liza/ so Liza does not overwrite user-owned project documentation.
+const CheckpointSummaryRelPath = ".liza/checkpoint-summary.md"
 
 // checkpointSummaryDefaultTimeout bounds how long the spawned CLI is allowed
 // to run before being terminated. Checkpoint summaries are short reads + a
@@ -31,7 +34,8 @@ const checkpointSummaryDefaultTimeout = 5 * time.Minute
 //   - cliName: resolved default CLI (claude, codex, gemini, ...)
 //   - prompt: the message handed to the CLI; instructs it to use the
 //     checkpoint-summary skill against .liza/state.yaml and write the report
-//     to docs/checkpoint-summary.md.
+//     to .liza/checkpoint-summary.md.
+//   - cfg: runtime config used to preserve per-CLI launch settings.
 //
 // Returns nil on a successful spawn that wrote the report. Any error is
 // non-fatal at the call site — the merge itself has already succeeded.
@@ -43,7 +47,7 @@ var checkpointSummaryRunner = runCheckpointSummaryCLI
 //
 // Behavior:
 //   - opt-out via Config.AutoCheckpointSummary == false
-//   - report is written to <projectRoot>/docs/checkpoint-summary.md
+//   - report is written to <projectRoot>/.liza/checkpoint-summary.md
 //   - CLI is resolved through ResolveDefaultCLI (state.yaml > env > const)
 func emitCheckpointSummary(projectRoot string, taskID string, cfg models.Config) {
 	logger := GetLogger()
@@ -56,7 +60,7 @@ func emitCheckpointSummary(projectRoot string, taskID string, cfg models.Config)
 	cliName := ResolveDefaultCLI(cfg.DefaultCLI)
 	prompt := buildCheckpointSummaryPrompt(taskID)
 
-	if err := checkpointSummaryRunner(projectRoot, cliName, prompt); err != nil {
+	if err := checkpointSummaryRunner(projectRoot, cliName, prompt, cfg); err != nil {
 		logger.Warn("Auto checkpoint-summary failed",
 			"task_id", taskID,
 			"cli", cliName,
@@ -79,7 +83,8 @@ func buildCheckpointSummaryPrompt(taskID string) string {
 
 Context: task %s just merged into the integration branch. Read .liza/state.yaml,
 apply the checkpoint-summary skill protocol, and write the report to
-%s (overwrite if it already exists). Do not ask follow-up questions.
+%s (overwrite if it already exists). Do not create, edit, or delete any other
+file. Do not ask follow-up questions.
 `, taskID, CheckpointSummaryRelPath)
 }
 
@@ -88,24 +93,31 @@ apply the checkpoint-summary skill protocol, and write the report to
 // stdin, captures combined output for the logger, and lets the CLI write
 // the markdown report itself (the skill knows where to put it).
 //
-// This intentionally does NOT use the rich DefaultCLIExecutor pipeline used
-// for normal agent runs: this is a side-effect emitter, not a full agent
-// session, and should not depend on agent state (heartbeat, output dir,
-// secret masker) or hijack the same per-agent semantics.
-func runCheckpointSummaryCLI(projectRoot, cliName, prompt string) error {
-	args, useStdin, err := checkpointSummaryCLIArgs(cliName, prompt)
+// The runner reuses the same per-CLI argv builders as normal agent runs where
+// practical, but keeps output discarded because this is a best-effort side
+// effect rather than a supervised agent session.
+func runCheckpointSummaryCLI(projectRoot, cliName, prompt string, cfg models.Config) error {
+	beforeStatus, err := gitStatusSnapshot(projectRoot)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to snapshot git status before checkpoint-summary: %w", err)
 	}
+
+	reportPath := filepath.Join(projectRoot, CheckpointSummaryRelPath)
+	if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
+		return fmt.Errorf("failed to prepare checkpoint-summary directory: %w", err)
+	}
+
+	env := filterAPIKeyEnv(os.Environ())
 
 	ctx, cancel := context.WithTimeout(context.Background(), checkpointSummaryDefaultTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, cliName, args...)
+	cmd, useStdin, err := checkpointSummaryCLICommand(ctx, projectRoot, cliName, prompt, cfg, env)
+	if err != nil {
+		return err
+	}
 	cmd.Dir = projectRoot
-	// Strip ANTHROPIC_API_KEY to avoid conflict with OAuth flow when
-	// the configured CLI is claude — see CLAUDE.md Claude Auth rule.
-	cmd.Env = filterAPIKeyEnv(os.Environ())
+	cmd.Env = env
 
 	if useStdin {
 		cmd.Stdin = strings.NewReader(prompt)
@@ -118,16 +130,23 @@ func runCheckpointSummaryCLI(projectRoot, cliName, prompt string) error {
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+	statusErr := validateCheckpointSummaryStatus(projectRoot, beforeStatus)
+	if runErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("checkpoint-summary CLI %q timed out after %s", cliName, checkpointSummaryDefaultTimeout)
 		}
-		return fmt.Errorf("checkpoint-summary CLI %q failed: %w", cliName, err)
+		if statusErr != nil {
+			return fmt.Errorf("checkpoint-summary CLI %q failed: %w; %v", cliName, runErr, statusErr)
+		}
+		return fmt.Errorf("checkpoint-summary CLI %q failed: %w", cliName, runErr)
+	}
+	if statusErr != nil {
+		return statusErr
 	}
 
 	// Sanity: confirm the report was actually written. If the CLI exited 0
 	// but never wrote the file, surface that as an error so callers can warn.
-	reportPath := filepath.Join(projectRoot, CheckpointSummaryRelPath)
 	info, statErr := os.Stat(reportPath)
 	if statErr != nil {
 		return fmt.Errorf("checkpoint-summary CLI exited 0 but report missing at %s: %w", reportPath, statErr)
@@ -138,15 +157,46 @@ func runCheckpointSummaryCLI(projectRoot, cliName, prompt string) error {
 	return nil
 }
 
+func checkpointSummaryCLICommand(
+	ctx context.Context,
+	projectRoot, cliName, prompt string,
+	cfg models.Config,
+	env []string,
+) (*exec.Cmd, bool, error) {
+	actualCLI := cliName
+	if cliName == "mistral" {
+		actualCLI = "vibe"
+	}
+
+	args, useStdin, err := checkpointSummaryCLIArgs(actualCLI, projectRoot, prompt, cfg, env)
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch actualCLI {
+	case "codex":
+		codexConfig := resolveCodexLaunchConfig(cfg, env)
+		cmd, err := codexCommandContext(ctx, codexConfig.PackageVersion, args)
+		if err != nil {
+			return nil, false, err
+		}
+		return cmd, useStdin, nil
+	default:
+		return exec.CommandContext(ctx, actualCLI, args...), useStdin, nil
+	}
+}
+
 // checkpointSummaryCLIArgs returns the argv tail and whether stdin should be
-// piped, for each supported CLI. Mirrors the per-CLI dispatch in the main
-// supervisor without pulling in agent output logging concerns.
-func checkpointSummaryCLIArgs(cliName, prompt string) ([]string, bool, error) {
+// piped for each supported CLI. It mirrors the normal supervisor's per-CLI
+// argv builders so checkpoint summaries honor the same launch semantics.
+func checkpointSummaryCLIArgs(cliName, projectRoot, prompt string, cfg models.Config, env []string) ([]string, bool, error) {
 	switch cliName {
 	case "claude":
-		return []string{"--print", "--permission-mode", "acceptEdits"}, true, nil
+		disableSubagents := envValue(env, "LIZA_DISABLE_CLAUDE_SUBAGENTS") == "1"
+		return buildClaudeArgs(prompt, true, "", disableSubagents), true, nil
 	case "codex":
-		return []string{"exec", "--skip-git-repo-check", "-"}, true, nil
+		codexConfig := resolveCodexLaunchConfig(cfg, env)
+		return buildCodexArgs(projectRoot, prompt, true, "", nil, codexConfig.LegacyLandlock), true, nil
 	case "gemini":
 		return []string{"-p"}, true, nil
 	case "vibe", "mistral":
@@ -156,6 +206,111 @@ func checkpointSummaryCLIArgs(cliName, prompt string) ([]string, bool, error) {
 	default:
 		return nil, false, fmt.Errorf("unsupported CLI for checkpoint-summary: %q", cliName)
 	}
+}
+
+type checkpointStatusEntry struct {
+	status      string
+	fingerprint string
+}
+
+func gitStatusSnapshot(projectRoot string) (map[string]checkpointStatusEntry, error) {
+	output, err := gitenv.Output(projectRoot, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		return nil, err
+	}
+
+	entries := parseGitStatusPorcelainZ(output)
+	snapshot := make(map[string]checkpointStatusEntry, len(entries))
+	for _, entry := range entries {
+		snapshot[entry.path] = checkpointStatusEntry{
+			status:      entry.status,
+			fingerprint: checkpointPathFingerprint(projectRoot, entry.path),
+		}
+	}
+	return snapshot, nil
+}
+
+type gitStatusEntry struct {
+	status string
+	path   string
+}
+
+func parseGitStatusPorcelainZ(output []byte) []gitStatusEntry {
+	records := strings.Split(string(output), "\x00")
+	var entries []gitStatusEntry
+	for i := 0; i < len(records); i++ {
+		record := records[i]
+		if record == "" {
+			continue
+		}
+		if len(record) < 4 {
+			continue
+		}
+		status := record[:2]
+		entries = append(entries, gitStatusEntry{
+			status: status,
+			path:   filepath.ToSlash(record[3:]),
+		})
+		if strings.ContainsAny(status, "RC") && i+1 < len(records) {
+			i++ // porcelain -z includes the source path as a separate record.
+		}
+	}
+	return entries
+}
+
+func checkpointPathFingerprint(projectRoot, relPath string) string {
+	info, err := os.Lstat(filepath.Join(projectRoot, filepath.FromSlash(relPath)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "missing"
+		}
+		return "stat-error:" + err.Error()
+	}
+	return fmt.Sprintf("mode=%s size=%d mod=%d", info.Mode().String(), info.Size(), info.ModTime().UnixNano())
+}
+
+func validateCheckpointSummaryStatus(projectRoot string, before map[string]checkpointStatusEntry) error {
+	after, err := gitStatusSnapshot(projectRoot)
+	if err != nil {
+		return fmt.Errorf("failed to snapshot git status after checkpoint-summary: %w", err)
+	}
+	unexpected := unexpectedCheckpointSummaryStatusChanges(before, after)
+	if len(unexpected) > 0 {
+		return fmt.Errorf("checkpoint-summary CLI modified unexpected paths: %s", strings.Join(unexpected, ", "))
+	}
+	return nil
+}
+
+func unexpectedCheckpointSummaryStatusChanges(before, after map[string]checkpointStatusEntry) []string {
+	var unexpected []string
+	for path, afterEntry := range after {
+		if path == filepath.ToSlash(CheckpointSummaryRelPath) {
+			continue
+		}
+		beforeEntry, existed := before[path]
+		if existed && beforeEntry == afterEntry {
+			continue
+		}
+		unexpected = append(unexpected, formatCheckpointStatusEntry(afterEntry, path))
+	}
+
+	for path, beforeEntry := range before {
+		if path == filepath.ToSlash(CheckpointSummaryRelPath) {
+			continue
+		}
+		if _, stillPresent := after[path]; !stillPresent {
+			unexpected = append(unexpected, formatCheckpointStatusEntry(beforeEntry, path)+" (removed)")
+		}
+	}
+	sort.Strings(unexpected)
+	return unexpected
+}
+
+func formatCheckpointStatusEntry(entry checkpointStatusEntry, path string) string {
+	if entry.status == "" {
+		return path
+	}
+	return entry.status + " " + path
 }
 
 // filterAPIKeyEnv removes ANTHROPIC_API_KEY from the env list. The user's

--- a/internal/agent/checkpoint_summary.go
+++ b/internal/agent/checkpoint_summary.go
@@ -125,8 +125,8 @@ func runCheckpointSummaryCLI(projectRoot, cliName, prompt string, cfg models.Con
 		cmd.Stdin = nil
 	}
 
-	// Capture output — we don't surface it to the user, but log it for
-	// triage if the report ends up empty or missing.
+	// Discard subprocess output. Auto-summary is best-effort, and persisted
+	// agent output handling belongs to the normal supervised agent pipeline.
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 

--- a/internal/agent/checkpoint_summary_test.go
+++ b/internal/agent/checkpoint_summary_test.go
@@ -1,0 +1,189 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// withFakeCheckpointSummaryRunner swaps in a deterministic runner for the
+// duration of a sub-test and restores the previous one on cleanup.
+func withFakeCheckpointSummaryRunner(t *testing.T, fn func(projectRoot, cliName, prompt string) error) {
+	t.Helper()
+	prev := checkpointSummaryRunner
+	checkpointSummaryRunner = fn
+	t.Cleanup(func() { checkpointSummaryRunner = prev })
+}
+
+func TestEmitCheckpointSummary_DefaultOn(t *testing.T) {
+	tmp := t.TempDir()
+	var called bool
+	var gotCLI, gotPrompt string
+
+	withFakeCheckpointSummaryRunner(t, func(projectRoot, cliName, prompt string) error {
+		called = true
+		gotCLI = cliName
+		gotPrompt = prompt
+		if projectRoot != tmp {
+			t.Errorf("projectRoot = %q, want %q", projectRoot, tmp)
+		}
+		return nil
+	})
+
+	// Empty config — default is ON.
+	emitCheckpointSummary(tmp, "task-1", models.Config{})
+
+	if !called {
+		t.Fatal("expected checkpoint summary runner to be called for default config")
+	}
+	// Default CLI is "claude" per cli.go.
+	if gotCLI != DefaultCLI {
+		t.Errorf("cli = %q, want %q", gotCLI, DefaultCLI)
+	}
+	if !strings.Contains(gotPrompt, "checkpoint-summary skill") {
+		t.Errorf("prompt = %q, want to mention checkpoint-summary skill", gotPrompt)
+	}
+	if !strings.Contains(gotPrompt, "task-1") {
+		t.Errorf("prompt = %q, want to mention task ID", gotPrompt)
+	}
+	if !strings.Contains(gotPrompt, CheckpointSummaryRelPath) {
+		t.Errorf("prompt = %q, want to mention report path %q", gotPrompt, CheckpointSummaryRelPath)
+	}
+}
+
+func TestEmitCheckpointSummary_OptOut(t *testing.T) {
+	tmp := t.TempDir()
+	called := false
+	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+		called = true
+		return nil
+	})
+
+	off := false
+	emitCheckpointSummary(tmp, "task-2", models.Config{AutoCheckpointSummary: &off})
+
+	if called {
+		t.Fatal("expected runner to be skipped when AutoCheckpointSummary is false")
+	}
+}
+
+func TestEmitCheckpointSummary_ExplicitOn(t *testing.T) {
+	tmp := t.TempDir()
+	called := false
+	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+		called = true
+		return nil
+	})
+
+	on := true
+	emitCheckpointSummary(tmp, "task-3", models.Config{AutoCheckpointSummary: &on})
+	if !called {
+		t.Fatal("expected runner to fire when AutoCheckpointSummary is explicitly true")
+	}
+}
+
+func TestEmitCheckpointSummary_RunnerErrorIsSwallowed(t *testing.T) {
+	tmp := t.TempDir()
+	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+		return os.ErrNotExist
+	})
+
+	// Must not panic / must not propagate — runner errors are best-effort.
+	emitCheckpointSummary(tmp, "task-4", models.Config{})
+}
+
+func TestEmitCheckpointSummary_HonoursConfiguredCLI(t *testing.T) {
+	tmp := t.TempDir()
+	var gotCLI string
+	withFakeCheckpointSummaryRunner(t, func(_, cliName, _ string) error {
+		gotCLI = cliName
+		return nil
+	})
+
+	emitCheckpointSummary(tmp, "task-cli", models.Config{DefaultCLI: "codex"})
+	if gotCLI != "codex" {
+		t.Errorf("cli = %q, want %q (config override)", gotCLI, "codex")
+	}
+}
+
+func TestCheckpointSummaryCLIArgs_Supported(t *testing.T) {
+	cases := []struct {
+		cli      string
+		stdin    bool
+		argHints []string
+	}{
+		{cli: "claude", stdin: true, argHints: []string{"--print"}},
+		{cli: "codex", stdin: true, argHints: []string{"exec"}},
+		{cli: "gemini", stdin: true, argHints: []string{"-p"}},
+		{cli: "vibe", stdin: false, argHints: []string{"-p"}},
+		{cli: "kimi", stdin: true, argHints: []string{"-p"}},
+	}
+
+	for _, c := range cases {
+		args, useStdin, err := checkpointSummaryCLIArgs(c.cli, "prompt")
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", c.cli, err)
+			continue
+		}
+		if useStdin != c.stdin {
+			t.Errorf("%s: useStdin = %v, want %v", c.cli, useStdin, c.stdin)
+		}
+		for _, hint := range c.argHints {
+			found := false
+			for _, a := range args {
+				if a == hint {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%s: args %v missing hint %q", c.cli, args, hint)
+			}
+		}
+	}
+}
+
+func TestCheckpointSummaryCLIArgs_Unsupported(t *testing.T) {
+	if _, _, err := checkpointSummaryCLIArgs("not-a-cli", "x"); err == nil {
+		t.Fatal("expected error for unsupported CLI")
+	}
+}
+
+func TestFilterAPIKeyEnv_StripsAnthropicKey(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"ANTHROPIC_API_KEY=sk-secret",
+		"FOO=bar",
+	}
+	out := filterAPIKeyEnv(in)
+	for _, v := range out {
+		if strings.HasPrefix(v, "ANTHROPIC_API_KEY=") {
+			t.Fatalf("ANTHROPIC_API_KEY was not stripped: %v", out)
+		}
+	}
+	if len(out) != 2 {
+		t.Errorf("len(out) = %d, want 2", len(out))
+	}
+}
+
+// TestRunCheckpointSummaryCLI_ReportMissing exercises the post-run sanity
+// check: a CLI that exits 0 but never writes the report must be surfaced
+// as an error rather than silently swallowed.
+func TestRunCheckpointSummaryCLI_ReportMissing(t *testing.T) {
+	tmp := t.TempDir()
+	// `true` exits 0, writes nothing, takes no input — perfect stand-in
+	// for a CLI that fails to honour its instructions.
+	err := runCheckpointSummaryCLI(tmp, "claude", "prompt")
+	// The real "claude" binary may or may not exist on the test runner;
+	// we accept either the "report missing" sanity error or a spawn
+	// failure. Both are valid outcomes — we just don't want a panic.
+	if err == nil {
+		// If by miracle a report was written, ensure the file is there.
+		if _, statErr := os.Stat(filepath.Join(tmp, CheckpointSummaryRelPath)); statErr != nil {
+			t.Errorf("returned nil but report missing: %v", statErr)
+		}
+	}
+}

--- a/internal/agent/checkpoint_summary_test.go
+++ b/internal/agent/checkpoint_summary_test.go
@@ -3,15 +3,17 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/testhelpers"
 )
 
 // withFakeCheckpointSummaryRunner swaps in a deterministic runner for the
 // duration of a sub-test and restores the previous one on cleanup.
-func withFakeCheckpointSummaryRunner(t *testing.T, fn func(projectRoot, cliName, prompt string) error) {
+func withFakeCheckpointSummaryRunner(t *testing.T, fn func(projectRoot, cliName, prompt string, cfg models.Config) error) {
 	t.Helper()
 	prev := checkpointSummaryRunner
 	checkpointSummaryRunner = fn
@@ -23,7 +25,7 @@ func TestEmitCheckpointSummary_DefaultOn(t *testing.T) {
 	var called bool
 	var gotCLI, gotPrompt string
 
-	withFakeCheckpointSummaryRunner(t, func(projectRoot, cliName, prompt string) error {
+	withFakeCheckpointSummaryRunner(t, func(projectRoot, cliName, prompt string, _ models.Config) error {
 		called = true
 		gotCLI = cliName
 		gotPrompt = prompt
@@ -57,7 +59,7 @@ func TestEmitCheckpointSummary_DefaultOn(t *testing.T) {
 func TestEmitCheckpointSummary_OptOut(t *testing.T) {
 	tmp := t.TempDir()
 	called := false
-	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+	withFakeCheckpointSummaryRunner(t, func(string, string, string, models.Config) error {
 		called = true
 		return nil
 	})
@@ -73,7 +75,7 @@ func TestEmitCheckpointSummary_OptOut(t *testing.T) {
 func TestEmitCheckpointSummary_ExplicitOn(t *testing.T) {
 	tmp := t.TempDir()
 	called := false
-	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+	withFakeCheckpointSummaryRunner(t, func(string, string, string, models.Config) error {
 		called = true
 		return nil
 	})
@@ -87,7 +89,7 @@ func TestEmitCheckpointSummary_ExplicitOn(t *testing.T) {
 
 func TestEmitCheckpointSummary_RunnerErrorIsSwallowed(t *testing.T) {
 	tmp := t.TempDir()
-	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+	withFakeCheckpointSummaryRunner(t, func(string, string, string, models.Config) error {
 		return os.ErrNotExist
 	})
 
@@ -98,7 +100,7 @@ func TestEmitCheckpointSummary_RunnerErrorIsSwallowed(t *testing.T) {
 func TestEmitCheckpointSummary_HonoursConfiguredCLI(t *testing.T) {
 	tmp := t.TempDir()
 	var gotCLI string
-	withFakeCheckpointSummaryRunner(t, func(_, cliName, _ string) error {
+	withFakeCheckpointSummaryRunner(t, func(_, cliName, _ string, _ models.Config) error {
 		gotCLI = cliName
 		return nil
 	})
@@ -115,7 +117,7 @@ func TestCheckpointSummaryCLIArgs_Supported(t *testing.T) {
 		stdin    bool
 		argHints []string
 	}{
-		{cli: "claude", stdin: true, argHints: []string{"--print"}},
+		{cli: "claude", stdin: true, argHints: []string{"-p"}},
 		{cli: "codex", stdin: true, argHints: []string{"exec"}},
 		{cli: "gemini", stdin: true, argHints: []string{"-p"}},
 		{cli: "vibe", stdin: false, argHints: []string{"-p"}},
@@ -123,7 +125,7 @@ func TestCheckpointSummaryCLIArgs_Supported(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		args, useStdin, err := checkpointSummaryCLIArgs(c.cli, "prompt")
+		args, useStdin, err := checkpointSummaryCLIArgs(c.cli, "/tmp/project", "prompt", models.Config{}, nil)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", c.cli, err)
 			continue
@@ -147,7 +149,7 @@ func TestCheckpointSummaryCLIArgs_Supported(t *testing.T) {
 }
 
 func TestCheckpointSummaryCLIArgs_Unsupported(t *testing.T) {
-	if _, _, err := checkpointSummaryCLIArgs("not-a-cli", "x"); err == nil {
+	if _, _, err := checkpointSummaryCLIArgs("not-a-cli", "/tmp/project", "x", models.Config{}, nil); err == nil {
 		t.Fatal("expected error for unsupported CLI")
 	}
 }
@@ -169,21 +171,115 @@ func TestFilterAPIKeyEnv_StripsAnthropicKey(t *testing.T) {
 	}
 }
 
-// TestRunCheckpointSummaryCLI_ReportMissing exercises the post-run sanity
-// check: a CLI that exits 0 but never writes the report must be surfaced
-// as an error rather than silently swallowed.
+func TestRunCheckpointSummaryCLI_WritesLizaOwnedReport(t *testing.T) {
+	tmp := t.TempDir()
+	testhelpers.SetupTestGitRepo(t, tmp)
+	installFakeCLI(t, "claude", []string{
+		"mkdir -p .liza",
+		"printf '# checkpoint summary\\n' > .liza/checkpoint-summary.md",
+	})
+
+	err := runCheckpointSummaryCLI(tmp, "claude", "prompt", models.Config{})
+	if err != nil {
+		t.Fatalf("runCheckpointSummaryCLI() error = %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmp, CheckpointSummaryRelPath)); statErr != nil {
+		t.Errorf("expected report at %s: %v", CheckpointSummaryRelPath, statErr)
+	}
+}
+
 func TestRunCheckpointSummaryCLI_ReportMissing(t *testing.T) {
 	tmp := t.TempDir()
-	// `true` exits 0, writes nothing, takes no input — perfect stand-in
-	// for a CLI that fails to honour its instructions.
-	err := runCheckpointSummaryCLI(tmp, "claude", "prompt")
-	// The real "claude" binary may or may not exist on the test runner;
-	// we accept either the "report missing" sanity error or a spawn
-	// failure. Both are valid outcomes — we just don't want a panic.
+	testhelpers.SetupTestGitRepo(t, tmp)
+	installFakeCLI(t, "claude", nil)
+
+	err := runCheckpointSummaryCLI(tmp, "claude", "prompt", models.Config{})
 	if err == nil {
-		// If by miracle a report was written, ensure the file is there.
-		if _, statErr := os.Stat(filepath.Join(tmp, CheckpointSummaryRelPath)); statErr != nil {
-			t.Errorf("returned nil but report missing: %v", statErr)
-		}
+		t.Fatal("expected report missing error, got nil")
 	}
+	if !strings.Contains(err.Error(), "report missing") {
+		t.Fatalf("error = %q, want report missing", err.Error())
+	}
+}
+
+func TestRunCheckpointSummaryCLI_RejectsUnexpectedProjectMutation(t *testing.T) {
+	tmp := t.TempDir()
+	testhelpers.SetupTestGitRepo(t, tmp)
+	installFakeCLI(t, "claude", []string{
+		"mkdir -p .liza",
+		"printf '# checkpoint summary\\n' > .liza/checkpoint-summary.md",
+		"printf 'unexpected\\n' > unexpected.txt",
+	})
+
+	err := runCheckpointSummaryCLI(tmp, "claude", "prompt", models.Config{})
+	if err == nil {
+		t.Fatal("expected unexpected mutation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "modified unexpected paths") {
+		t.Fatalf("error = %q, want unexpected paths", err.Error())
+	}
+	if !strings.Contains(err.Error(), "unexpected.txt") {
+		t.Fatalf("error = %q, want unexpected.txt", err.Error())
+	}
+}
+
+func TestRunCheckpointSummaryCLI_RejectsUnexpectedLizaMutation(t *testing.T) {
+	tmp := t.TempDir()
+	testhelpers.SetupTestGitRepo(t, tmp)
+	installFakeCLI(t, "claude", []string{
+		"mkdir -p .liza",
+		"printf '# checkpoint summary\\n' > .liza/checkpoint-summary.md",
+		"printf 'unexpected\\n' > .liza/other.md",
+	})
+
+	err := runCheckpointSummaryCLI(tmp, "claude", "prompt", models.Config{})
+	if err == nil {
+		t.Fatal("expected unexpected .liza mutation error, got nil")
+	}
+	if !strings.Contains(err.Error(), ".liza/other.md") {
+		t.Fatalf("error = %q, want .liza/other.md", err.Error())
+	}
+}
+
+func TestRunCheckpointSummaryCLI_RejectsAlreadyDirtyMutation(t *testing.T) {
+	tmp := t.TempDir()
+	testhelpers.SetupTestGitRepo(t, tmp)
+	if err := os.WriteFile(filepath.Join(tmp, "notes.md"), []byte("clean\n"), 0o644); err != nil {
+		t.Fatalf("write notes.md: %v", err)
+	}
+	testhelpers.MustGit(t, tmp, "add", "notes.md")
+	testhelpers.MustGit(t, tmp, "commit", "-m", "Add notes")
+	if err := os.WriteFile(filepath.Join(tmp, "notes.md"), []byte("human draft\n"), 0o644); err != nil {
+		t.Fatalf("dirty notes.md: %v", err)
+	}
+
+	installFakeCLI(t, "claude", []string{
+		"mkdir -p .liza",
+		"printf '# checkpoint summary\\n' > .liza/checkpoint-summary.md",
+		"printf 'cli overwrite with different size\\n' > notes.md",
+	})
+
+	err := runCheckpointSummaryCLI(tmp, "claude", "prompt", models.Config{})
+	if err == nil {
+		t.Fatal("expected already-dirty mutation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "notes.md") {
+		t.Fatalf("error = %q, want notes.md", err.Error())
+	}
+}
+
+func installFakeCLI(t *testing.T, name string, body []string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell CLI helper is Unix-only")
+	}
+
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, name)
+	lines := []string{"#!/bin/sh", "set -eu"}
+	lines = append(lines, body...)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/agent/claiming.go
+++ b/internal/agent/claiming.go
@@ -327,9 +327,10 @@ func handleApprovedMerges(projectRoot, agentID string, bb *db.Blackboard, pr mod
 
 			// Auto-emit checkpoint-summary so humans get a fresh report under
 			// .liza/ without manually invoking the skill.
-			// Best-effort: failures are logged inside the helper and never
-			// block the merge cycle. Re-read state here so the config flag
-			// reflects the post-merge view, not a stale snapshot.
+			// Best-effort: failures are logged inside the helper and do not
+			// fail or roll back the completed merge. Re-read state here so
+			// the config flag reflects the post-merge view, not a stale
+			// snapshot.
 			if freshState, readErr := bb.Read(); readErr == nil {
 				emitCheckpointSummary(projectRoot, task.ID, freshState.Config)
 			} else {

--- a/internal/agent/claiming.go
+++ b/internal/agent/claiming.go
@@ -325,8 +325,8 @@ func handleApprovedMerges(projectRoot, agentID string, bb *db.Blackboard, pr mod
 
 			logger.Info("Successfully merged task", "task_id", task.ID)
 
-			// Auto-emit checkpoint-summary so humans get a fresh report at
-			// docs/checkpoint-summary.md without manually invoking the skill.
+			// Auto-emit checkpoint-summary so humans get a fresh report under
+			// .liza/ without manually invoking the skill.
 			// Best-effort: failures are logged inside the helper and never
 			// block the merge cycle. Re-read state here so the config flag
 			// reflects the post-merge view, not a stale snapshot.

--- a/internal/agent/claiming.go
+++ b/internal/agent/claiming.go
@@ -324,6 +324,18 @@ func handleApprovedMerges(projectRoot, agentID string, bb *db.Blackboard, pr mod
 			}
 
 			logger.Info("Successfully merged task", "task_id", task.ID)
+
+			// Auto-emit checkpoint-summary so humans get a fresh report at
+			// docs/checkpoint-summary.md without manually invoking the skill.
+			// Best-effort: failures are logged inside the helper and never
+			// block the merge cycle. Re-read state here so the config flag
+			// reflects the post-merge view, not a stale snapshot.
+			if freshState, readErr := bb.Read(); readErr == nil {
+				emitCheckpointSummary(projectRoot, task.ID, freshState.Config)
+			} else {
+				logger.Warn("Skipped auto checkpoint-summary — state re-read failed",
+					"task_id", task.ID, "error", readErr)
+			}
 		}
 	}
 

--- a/internal/agent/claiming_checkpoint_test.go
+++ b/internal/agent/claiming_checkpoint_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"github.com/liza-mas/liza/internal/models"
 	"github.com/liza-mas/liza/internal/ops"
 	"github.com/liza-mas/liza/internal/testhelpers"
-	"os"
 )
 
 // TestHandleApprovedMerges_AutoEmitsCheckpointSummary is the end-to-end wiring
@@ -25,7 +25,7 @@ func TestHandleApprovedMerges_AutoEmitsCheckpointSummary(t *testing.T) {
 
 	var runnerCalled bool
 	var gotProjectRoot, gotPrompt string
-	withFakeCheckpointSummaryRunner(t, func(projectRoot, cliName, prompt string) error {
+	withFakeCheckpointSummaryRunner(t, func(projectRoot, cliName, prompt string, _ models.Config) error {
 		runnerCalled = true
 		gotProjectRoot = projectRoot
 		gotPrompt = prompt
@@ -96,7 +96,7 @@ func TestHandleApprovedMerges_RespectsAutoCheckpointOptOut(t *testing.T) {
 	}
 
 	called := false
-	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+	withFakeCheckpointSummaryRunner(t, func(string, string, string, models.Config) error {
 		called = true
 		return nil
 	})

--- a/internal/agent/claiming_checkpoint_test.go
+++ b/internal/agent/claiming_checkpoint_test.go
@@ -1,0 +1,213 @@
+package agent
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/liza-mas/liza/internal/db"
+	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/ops"
+	"github.com/liza-mas/liza/internal/testhelpers"
+	"os"
+)
+
+// TestHandleApprovedMerges_AutoEmitsCheckpointSummary is the end-to-end wiring
+// test for bug fix #3 (auto-emit checkpoint-summary on merge). It builds a
+// minimal git repo + state with an APPROVED task ready to merge, swaps in a
+// deterministic checkpoint-summary runner that writes a sentinel file, runs
+// handleApprovedMerges, and asserts the runner was invoked with the merged
+// task ID. The default (config flag unset) must trigger emission.
+func TestHandleApprovedMerges_AutoEmitsCheckpointSummary(t *testing.T) {
+	tmpDir, stateFile, taskID := setupAgentMergeRepo(t)
+
+	var runnerCalled bool
+	var gotProjectRoot, gotPrompt string
+	withFakeCheckpointSummaryRunner(t, func(projectRoot, cliName, prompt string) error {
+		runnerCalled = true
+		gotProjectRoot = projectRoot
+		gotPrompt = prompt
+		// Simulate the CLI's job: write the report file so any downstream
+		// post-run sanity check would be satisfied.
+		reportPath := filepath.Join(projectRoot, CheckpointSummaryRelPath)
+		if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(reportPath, []byte("# checkpoint summary\nfake report\n"), 0o644)
+	})
+
+	bb := db.New(stateFile)
+	pr, err := ops.LoadResolverForModels(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadResolverForModels: %v", err)
+	}
+
+	if err := handleApprovedMerges(tmpDir, "code-reviewer-2", bb, pr); err != nil {
+		t.Fatalf("handleApprovedMerges: %v", err)
+	}
+
+	if !runnerCalled {
+		t.Fatal("expected checkpoint-summary runner to fire after merge")
+	}
+	if gotProjectRoot != tmpDir {
+		t.Errorf("projectRoot = %q, want %q", gotProjectRoot, tmpDir)
+	}
+	if !strings.Contains(gotPrompt, taskID) {
+		t.Errorf("prompt did not mention task ID %q: %q", taskID, gotPrompt)
+	}
+
+	// Verify the report file actually landed where the prompt asked for it.
+	reportPath := filepath.Join(tmpDir, CheckpointSummaryRelPath)
+	if _, err := os.Stat(reportPath); err != nil {
+		t.Errorf("expected report at %s, got: %v", reportPath, err)
+	}
+
+	// And the task is genuinely MERGED in state (sanity: we didn't just
+	// short-circuit before the merge).
+	state, err := bb.Read()
+	if err != nil {
+		t.Fatalf("bb.Read: %v", err)
+	}
+	mergedTask := state.FindTask(taskID)
+	if mergedTask == nil {
+		t.Fatal("merged task vanished from state")
+	}
+	if mergedTask.Status != models.TaskStatusMerged {
+		t.Errorf("status = %v, want MERGED", mergedTask.Status)
+	}
+}
+
+// TestHandleApprovedMerges_RespectsAutoCheckpointOptOut confirms the opt-out
+// path: a project that explicitly sets auto_checkpoint_summary: false must
+// not invoke the runner even when a merge succeeds.
+func TestHandleApprovedMerges_RespectsAutoCheckpointOptOut(t *testing.T) {
+	tmpDir, stateFile, _ := setupAgentMergeRepo(t)
+
+	// Patch the config in-place to disable auto checkpoint.
+	bb := db.New(stateFile)
+	if err := bb.Modify(func(s *models.State) error {
+		off := false
+		s.Config.AutoCheckpointSummary = &off
+		return nil
+	}); err != nil {
+		t.Fatalf("bb.Modify: %v", err)
+	}
+
+	called := false
+	withFakeCheckpointSummaryRunner(t, func(string, string, string) error {
+		called = true
+		return nil
+	})
+
+	pr, err := ops.LoadResolverForModels(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadResolverForModels: %v", err)
+	}
+	if err := handleApprovedMerges(tmpDir, "code-reviewer-2", bb, pr); err != nil {
+		t.Fatalf("handleApprovedMerges: %v", err)
+	}
+
+	if called {
+		t.Fatal("runner fired despite AutoCheckpointSummary=false")
+	}
+}
+
+// setupAgentMergeRepo builds a minimal git repo + Liza state ready for the
+// merge path: integration branch, a worktree with one commit, a task in
+// APPROVED status with two approvals (quorum 2 already met by reviewer-1
+// and reviewer-2). The caller passes in the agentID used for the merge.
+func setupAgentMergeRepo(t *testing.T) (projectRoot, stateFile, taskID string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	taskID = "merge-checkpoint"
+
+	testhelpers.SetupTestGitRepo(t, tmpDir)
+	stateFile, _ = testhelpers.SetupLizaDir(t, tmpDir)
+
+	mustGit := func(args ...string) string {
+		full := append([]string{"-C", tmpDir}, args...)
+		out, err := exec.Command("git", full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	// integration branch already created by SetupTestGitRepo; just check it out.
+	mustGit("checkout", "integration")
+
+	// Create worktree on a new branch.
+	wtDir := filepath.Join(tmpDir, ".worktrees", taskID)
+	if err := os.MkdirAll(filepath.Dir(wtDir), 0o755); err != nil {
+		t.Fatalf("mkdir worktrees: %v", err)
+	}
+	if out, err := exec.Command(
+		"git", "-C", tmpDir, "worktree", "add", wtDir, "integration", "-b", "task/"+taskID,
+	).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, string(out))
+	}
+
+	// Make a commit in the worktree.
+	wtFile := filepath.Join(wtDir, "feature.txt")
+	if err := os.WriteFile(wtFile, []byte("feature implementation\n"), 0o644); err != nil {
+		t.Fatalf("write feature.txt: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", wtDir, "add", "feature.txt").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, string(out))
+	}
+	if out, err := exec.Command("git", "-C", wtDir, "commit", "-m", "feat: add feature").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, string(out))
+	}
+	commitSHA := strings.TrimSpace(mustGitInDir(t, wtDir, "rev-parse", "HEAD"))
+
+	// Build the state with the task pre-approved by 2 reviewers.
+	now := time.Now().UTC()
+	state := testhelpers.CreateValidState()
+	state.Config.IntegrationBranch = "integration"
+	state.Goal.SpecRef = "README.md"
+
+	worktreeRel := filepath.Join(".worktrees", taskID)
+	baseCommit := "base"
+	approvedBy := "code-reviewer-1"
+	state.Tasks = []models.Task{
+		{
+			ID:           taskID,
+			Description:  "feature work",
+			Status:       models.TaskStatusApproved,
+			Priority:     1,
+			Created:      now,
+			SpecRef:      "README.md",
+			DoneWhen:     "ok",
+			Scope:        "test",
+			RolePair:     "coding-pair",
+			Worktree:     &worktreeRel,
+			BaseCommit:   &baseCommit,
+			ReviewCommit: &commitSHA,
+			ApprovedBy:   &approvedBy,
+			Approvals: []models.Approval{
+				{Agent: "code-reviewer-1", Provider: "anthropic", Timestamp: now},
+				{Agent: "code-reviewer-2", Provider: "openai", Timestamp: now},
+			},
+			History: []models.TaskHistoryEntry{},
+		},
+	}
+
+	// Register the merging reviewer so quorum checks don't trip.
+	state.Agents["code-reviewer-1"] = testhelpers.RegisteredTestAgent("code-reviewer")
+	state.Agents["code-reviewer-2"] = testhelpers.RegisteredTestAgent("code-reviewer")
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	return tmpDir, stateFile, taskID
+}
+
+func mustGitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{"-C", dir}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/agent/strategy_reviewer.go
+++ b/internal/agent/strategy_reviewer.go
@@ -105,7 +105,10 @@ func (s *reviewerStrategy) WaitForWork(ctx context.Context, bb *db.Blackboard, c
 	pr := loadResolver(config.ProjectRoot)
 	return waitForWorkEventDriven(ctx, bb, config.ProjectRoot, pollInterval, maxWait,
 		func(state *models.State) (bool, string) {
-			count := models.CountReviewableTasks(state, s.role, pr)
+			// Use agent-aware count so a reviewer that just approved a task
+			// doesn't keep seeing it as "reviewable" — round-2 must go to a
+			// different reviewer (see filterAlreadyApprovedByAgent in ops).
+			count := models.CountReviewableTasksForAgent(state, s.role, config.AgentID, pr)
 			if count > 0 {
 				return true, fmt.Sprintf("Found %d %s-reviewable task(s)", count, s.role)
 			}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -122,32 +122,32 @@ type Config struct {
 	// OrchestratorMaxWait is the maximum time an orchestrator agent will wait for work
 	// before exiting. When 0, defaults to DefaultOrchestratorMaxWait (5 hours).
 	// The orchestrator will exit earlier if STOPPED mode is detected or context is cancelled.
-	OrchestratorMaxWait      int            `yaml:"orchestrator_max_wait"`
-	ReviewerPollInterval     int            `yaml:"reviewer_poll_interval"`
-	ReviewerMaxWait          int            `yaml:"reviewer_max_wait"`
-	Exit42RestartThreshold   int            `yaml:"exit42_restart_threshold,omitempty"`
-	Exit42MaxBackoffSeconds  int            `yaml:"exit42_max_backoff_seconds,omitempty"`
-	CrashRestartThreshold    int            `yaml:"crash_restart_threshold,omitempty"`
-	SpinningRestartThreshold int            `yaml:"spinning_restart_threshold,omitempty"`
-	AgentProgressTimeout     int            `yaml:"agent_progress_timeout,omitempty"`
-	DefaultCLI               string         `yaml:"default_cli,omitempty"`
-	DefaultDoerCLI           string         `yaml:"default_doer_cli,omitempty"`
-	DefaultReviewerCLI       string         `yaml:"default_reviewer_cli,omitempty"`
-	ScipSearch               []string       `yaml:"scip_search,omitempty"`
-	CodexPackageVersion      string         `yaml:"codex_package_version,omitempty"`
-	CodexLegacyLandlock      bool           `yaml:"codex_legacy_landlock,omitempty"`
-	IntegrationBranch        string         `yaml:"integration_branch"`
-	EscalationWebhook        *string        `yaml:"escalation_webhook,omitempty"`
-	Mode                     SystemMode     `yaml:"mode,omitempty"`
-	ModeChangedAt            *time.Time     `yaml:"mode_changed_at,omitempty"`
-	ModeChangedBy            *string        `yaml:"mode_changed_by,omitempty"`
-	DiagnosticLogging        bool           `yaml:"diagnostic_logging,omitempty"`
-	AutoResume               bool           `yaml:"auto_resume,omitempty"`
-	NoFollowUp               bool           `yaml:"no_follow_up,omitempty"`
-	PostWorktreeCmd          *string        `yaml:"post_worktree_cmd,omitempty"`
+	OrchestratorMaxWait      int        `yaml:"orchestrator_max_wait"`
+	ReviewerPollInterval     int        `yaml:"reviewer_poll_interval"`
+	ReviewerMaxWait          int        `yaml:"reviewer_max_wait"`
+	Exit42RestartThreshold   int        `yaml:"exit42_restart_threshold,omitempty"`
+	Exit42MaxBackoffSeconds  int        `yaml:"exit42_max_backoff_seconds,omitempty"`
+	CrashRestartThreshold    int        `yaml:"crash_restart_threshold,omitempty"`
+	SpinningRestartThreshold int        `yaml:"spinning_restart_threshold,omitempty"`
+	AgentProgressTimeout     int        `yaml:"agent_progress_timeout,omitempty"`
+	DefaultCLI               string     `yaml:"default_cli,omitempty"`
+	DefaultDoerCLI           string     `yaml:"default_doer_cli,omitempty"`
+	DefaultReviewerCLI       string     `yaml:"default_reviewer_cli,omitempty"`
+	ScipSearch               []string   `yaml:"scip_search,omitempty"`
+	CodexPackageVersion      string     `yaml:"codex_package_version,omitempty"`
+	CodexLegacyLandlock      bool       `yaml:"codex_legacy_landlock,omitempty"`
+	IntegrationBranch        string     `yaml:"integration_branch"`
+	EscalationWebhook        *string    `yaml:"escalation_webhook,omitempty"`
+	Mode                     SystemMode `yaml:"mode,omitempty"`
+	ModeChangedAt            *time.Time `yaml:"mode_changed_at,omitempty"`
+	ModeChangedBy            *string    `yaml:"mode_changed_by,omitempty"`
+	DiagnosticLogging        bool       `yaml:"diagnostic_logging,omitempty"`
+	AutoResume               bool       `yaml:"auto_resume,omitempty"`
+	NoFollowUp               bool       `yaml:"no_follow_up,omitempty"`
+	PostWorktreeCmd          *string    `yaml:"post_worktree_cmd,omitempty"`
 	// AutoCheckpointSummary controls whether Liza auto-invokes the
 	// checkpoint-summary skill against a task that just reached MERGED and
-	// writes the result to docs/checkpoint-summary.md. Default (nil) is ON.
+	// writes the result to .liza/checkpoint-summary.md. Default (nil) is ON.
 	// Set explicitly to false to opt out.
 	AutoCheckpointSummary *bool          `yaml:"auto_checkpoint_summary,omitempty"`
 	Extra                 map[string]any `yaml:",inline"`

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -145,5 +145,10 @@ type Config struct {
 	AutoResume               bool           `yaml:"auto_resume,omitempty"`
 	NoFollowUp               bool           `yaml:"no_follow_up,omitempty"`
 	PostWorktreeCmd          *string        `yaml:"post_worktree_cmd,omitempty"`
-	Extra                    map[string]any `yaml:",inline"`
+	// AutoCheckpointSummary controls whether Liza auto-invokes the
+	// checkpoint-summary skill against a task that just reached MERGED and
+	// writes the result to docs/checkpoint-summary.md. Default (nil) is ON.
+	// Set explicitly to false to opt out.
+	AutoCheckpointSummary *bool          `yaml:"auto_checkpoint_summary,omitempty"`
+	Extra                 map[string]any `yaml:",inline"`
 }

--- a/internal/models/diagnostics.go
+++ b/internal/models/diagnostics.go
@@ -30,6 +30,25 @@ func CountReviewableTasks(state *State, role string, pr PipelineResolver) int {
 	return count
 }
 
+// CountReviewableTasksForAgent is the agent-aware variant of CountReviewableTasks:
+// it excludes tasks that the given agent has already approved. The reviewer
+// supervisor's wait loop uses this so an agent that just approved doesn't
+// spin "found 1 reviewable task" → claim → reject (self-approval) → repeat.
+func CountReviewableTasksForAgent(state *State, role, agentID string, pr PipelineResolver) int {
+	count := 0
+	for i := range state.Tasks {
+		t := &state.Tasks[i]
+		if !t.IsClaimable(role, state.Tasks, pr) {
+			continue
+		}
+		if t.HasApprovalFromAgent(agentID) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
 // GetCoderWorkDiagnostics returns detailed diagnostic information about task availability for coders.
 func GetCoderWorkDiagnostics(state *State, pr PipelineResolver) string {
 	claimable := CountClaimableTasks(state, RoleCoder, pr)

--- a/internal/models/diagnostics_test.go
+++ b/internal/models/diagnostics_test.go
@@ -439,6 +439,36 @@ func TestDiagnosticsQuorumStates(t *testing.T) {
 		}
 	})
 
+	t.Run("CountReviewableTasksForAgent excludes prior approver", func(t *testing.T) {
+		// reviewer-1 already approved this task — for them it must not be
+		// reviewable any more, but reviewer-2 should still see it.
+		approver := "code-reviewer-1"
+		state := &State{
+			Tasks: []Task{
+				{
+					ID:           "t1",
+					Status:       "CODE_PARTIALLY_APPROVED",
+					Type:         TaskTypeCoding,
+					RolePair:     "coding-pair",
+					ReviewCommit: strPtr("rc"),
+					Approvals: []Approval{
+						{Agent: approver, Provider: "anthropic", Timestamp: now},
+					},
+				},
+			},
+		}
+		if got := CountReviewableTasksForAgent(state, "code-reviewer", approver, pr); got != 0 {
+			t.Errorf("CountReviewableTasksForAgent(prior approver) = %d, want 0", got)
+		}
+		if got := CountReviewableTasksForAgent(state, "code-reviewer", "code-reviewer-2", pr); got != 1 {
+			t.Errorf("CountReviewableTasksForAgent(other reviewer) = %d, want 1", got)
+		}
+		// Sanity: role-level count is still 1 (it's claimable for the role).
+		if got := CountReviewableTasks(state, "code-reviewer", pr); got != 1 {
+			t.Errorf("CountReviewableTasks(role) = %d, want 1", got)
+		}
+	})
+
 	t.Run("diagnostics reports partially_approved as awaiting second review", func(t *testing.T) {
 		state := &State{
 			Tasks: []Task{

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -480,6 +480,22 @@ func (t *Task) LastApprover() string {
 	return t.Approvals[len(t.Approvals)-1].Agent
 }
 
+// HasApprovalFromAgent reports whether the given agent has already recorded
+// an approval on this task. Used to prevent a reviewer from re-claiming
+// (and double-approving) a task they previously voted on — the second
+// review must come from a different agent to satisfy independent review.
+func (t *Task) HasApprovalFromAgent(agentID string) bool {
+	if agentID == "" {
+		return false
+	}
+	for _, a := range t.Approvals {
+		if a.Agent == agentID {
+			return true
+		}
+	}
+	return false
+}
+
 // TransitionWith validates and applies a status transition using a transition map
 // built from pipeline config. The target status must exist as a key in the
 // transition map (i.e., be a declared state).

--- a/internal/ops/claim_reviewer_task.go
+++ b/internal/ops/claim_reviewer_task.go
@@ -95,6 +95,14 @@ func ClaimReviewerTask(input ClaimReviewerTaskInput) (*ClaimReviewerTaskResult, 
 			return &PreconditionError{Reason: "no reviewable tasks found"}
 		}
 
+		// Independent-review filter: skip tasks the claiming agent already
+		// approved. Without this, a reviewer-1 polling loop would re-claim
+		// its own partially_approved task and self-rubber-stamp the quorum.
+		candidates = filterAlreadyApprovedByAgent(candidates, input.AgentID)
+		if len(candidates) == 0 {
+			return &PreconditionError{Reason: "no reviewable tasks found (all candidates already approved by claimer)"}
+		}
+
 		// Filter out candidates in claim cooldown to prevent claim-release spin.
 		candidates = filterReviewClaimCooldown(candidates, input.AgentID, defaultReviewClaimCooldown, now)
 		if len(candidates) == 0 {
@@ -338,6 +346,26 @@ func isDiversitySatisfiable(
 		}
 	}
 	return false
+}
+
+// filterAlreadyApprovedByAgent removes candidates where the given agent has
+// already recorded an approval. A reviewer must not be allowed to re-claim a
+// task they already approved — the round-2 verdict has to come from an
+// independent reviewer (quorum > 1 contract). Without this filter, the
+// agent loop happily picks up its own partially_approved task during round
+// 2 polling and double-counts the same approval.
+func filterAlreadyApprovedByAgent(candidates []*models.Task, agentID string) []*models.Task {
+	if agentID == "" {
+		return candidates
+	}
+	var filtered []*models.Task
+	for _, t := range candidates {
+		if t.HasApprovalFromAgent(agentID) {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	return filtered
 }
 
 // filterReviewClaimCooldown removes candidates where the claiming agent has a

--- a/internal/ops/claim_reviewer_task_test.go
+++ b/internal/ops/claim_reviewer_task_test.go
@@ -829,6 +829,123 @@ func TestClaimReviewerTask_PartiallyApproved(t *testing.T) {
 	}
 }
 
+func TestClaimReviewerTask_SkipsTaskAlreadyApprovedByClaimer(t *testing.T) {
+	// Verifies the independent-review filter: a reviewer that already approved
+	// a task in round 1 must not be allowed to claim the same partially_approved
+	// task for round 2. Without this filter, the agent loop polling for
+	// partially_approved tasks would happily self-rubber-stamp the quorum.
+	tmpDir := t.TempDir()
+	testhelpers.SetupTestGitRepo(t, tmpDir)
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+
+	now := time.Now().UTC()
+	state := testhelpers.CreateValidState()
+	registerClaimReviewerTaskTestAgents(state)
+	reviewCommit := "abc123"
+	state.Tasks = []models.Task{
+		{
+			ID:           "task-pa",
+			Status:       models.TaskStatusPartiallyApproved,
+			RolePair:     "coding-pair",
+			Priority:     1,
+			ReviewCommit: &reviewCommit,
+			History:      []models.TaskHistoryEntry{},
+			Created:      now,
+			// Reviewer-1 already approved — must NOT be eligible for round 2.
+			Approvals: []models.Approval{
+				{Agent: "code-reviewer-1", Provider: "anthropic", Timestamp: now},
+			},
+		},
+	}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	_, err := ClaimReviewerTask(ClaimReviewerTaskInput{
+		ProjectRoot:   tmpDir,
+		AgentID:       "code-reviewer-1",
+		LeaseDuration: 1800,
+	})
+	if err == nil {
+		t.Fatal("expected error when prior approver tries to re-claim, got nil")
+	}
+	if !strings.Contains(err.Error(), "already approved by claimer") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "already approved by claimer")
+	}
+
+	// Verify task state is unchanged — still partially_approved, no new
+	// ReviewingBy assignment.
+	bb := db.New(stateFile)
+	readState, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	task := readState.FindTask("task-pa")
+	if task == nil {
+		t.Fatal("Task not found")
+	}
+	if task.Status != models.TaskStatusPartiallyApproved {
+		t.Errorf("status = %v, want unchanged PARTIALLY_APPROVED", task.Status)
+	}
+	if task.ReviewingBy != nil {
+		t.Errorf("ReviewingBy = %v, want nil (no claim should have occurred)", *task.ReviewingBy)
+	}
+}
+
+func TestClaimReviewerTask_Round2GoesToDifferentReviewer(t *testing.T) {
+	// End-to-end claim-filter check: when reviewer-1 has approved and
+	// reviewer-2 polls, reviewer-2 picks up the partially_approved task
+	// for round 2 even though reviewer-1's loop would have rejected it.
+	tmpDir := t.TempDir()
+	testhelpers.SetupTestGitRepo(t, tmpDir)
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+
+	now := time.Now().UTC()
+	state := testhelpers.CreateValidState()
+	registerClaimReviewerTaskTestAgents(state)
+	reviewCommit := "abc123"
+	state.Tasks = []models.Task{
+		{
+			ID:           "task-pa",
+			Status:       models.TaskStatusPartiallyApproved,
+			RolePair:     "coding-pair",
+			Priority:     1,
+			ReviewCommit: &reviewCommit,
+			History:      []models.TaskHistoryEntry{},
+			Created:      now,
+			Approvals: []models.Approval{
+				{Agent: "code-reviewer-1", Provider: "anthropic", Timestamp: now},
+			},
+		},
+	}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	// reviewer-2 (a different reviewer) must succeed in claiming.
+	result, err := ClaimReviewerTask(ClaimReviewerTaskInput{
+		ProjectRoot:   tmpDir,
+		AgentID:       "code-reviewer-2",
+		LeaseDuration: 1800,
+	})
+	if err != nil {
+		t.Fatalf("ClaimReviewerTask() error: %v", err)
+	}
+	if result.TaskID != "task-pa" {
+		t.Errorf("TaskID = %q, want %q", result.TaskID, "task-pa")
+	}
+
+	// Status should now be REVIEWING_CODE_2 with reviewer-2 holding the lease.
+	bb := db.New(stateFile)
+	readState, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Failed to read state: %v", err)
+	}
+	task := readState.FindTask("task-pa")
+	if task.Status != models.TaskStatusReviewingCode2 {
+		t.Errorf("status = %v, want REVIEWING_CODE_2", task.Status)
+	}
+	if task.ReviewingBy == nil || *task.ReviewingBy != "code-reviewer-2" {
+		t.Errorf("ReviewingBy = %v, want code-reviewer-2", task.ReviewingBy)
+	}
+}
+
 func TestClaimReviewerTask_ClaimPriority_PartiallyApprovedOverSubmitted(t *testing.T) {
 	// Verifies that partially_approved tasks are selected before submitted tasks
 	// at the same priority level.

--- a/support-docs/CONFIGURATION.md
+++ b/support-docs/CONFIGURATION.md
@@ -119,6 +119,7 @@ All configuration lives in `.liza/state.yaml` under the `config` section.
 | `codex_package_version` | (none) | — | — | npm package version | Pins headless Codex agents to `@openai/codex@<version>` |
 | `codex_legacy_landlock` | false | — | — | boolean | Adds Codex `use_legacy_landlock` and `workspace-write` flags for headless MAS agents |
 | `post_worktree_cmd` | (none) | — | — | shell cmd | Command run after worktree creation (e.g. `npm install`) |
+| `auto_checkpoint_summary` | true | — | — | boolean | Auto-runs checkpoint-summary after successful merges and writes `.liza/checkpoint-summary.md` |
 | `scip_search` | (none) | — | — | language list | Durable allowlist of SCIP languages Liza may index when `LIZA_ENABLE_SCIP_SEARCH` is truthy |
 
 ### SCIP Search (`config.scip_search`)
@@ -299,6 +300,18 @@ CIRCUIT_BREAKER_TRIPPED -> RUNNING (liza resume, after fixing root cause)
 When `liza tui` triggers the circuit breaker, it also sets `sprint.status` to `CHECKPOINT`.
 
 `liza tui` also auto-checkpoints when all non-terminal planned tasks are BLOCKED (sprint stalled), since no agent can make further progress without human intervention.
+
+## Checkpoint Summary
+
+After a successful merge, Liza auto-invokes the configured default CLI with the
+`checkpoint-summary` skill and writes the latest report to
+`.liza/checkpoint-summary.md`. The operation is best-effort: merge success does
+not depend on the report being created. Set `auto_checkpoint_summary: false` in
+`.liza/state.yaml` to disable it.
+
+The summary emitter snapshots git status paths and filesystem metadata before
+and after the CLI run. Changes outside `.liza/checkpoint-summary.md` are logged
+as an auto-summary failure and do not block the completed merge.
 
 ## Task Lifecycle States
 


### PR DESCRIPTION
## Summary

Three bug fixes surfaced during real Liza-on-codex runs while preparing Omni's M1 demo. Each one is a small, independent change.

### 1. Round-2 reviewer can't auto-claim

`internal/ops/claim_reviewer_task.go` lacked `REVIEWING_*_2` in its claimable states slice. After reviewer-1 issued APPROVED, the task advanced to `REVIEWING_*_2` but no reviewer agent's polling loop would pick it up — quorum-2 reviews stalled indefinitely.

**Fix:** add `REVIEWING_*_2` to the claimable-state filter.

### 2. Reviewer-1 self-claim regression

`internal/agent/claiming.go`: after issuing APPROVED, reviewer-1's agent loop tried to re-claim the same task it had just voted on (the lease was released; nothing prevented re-pickup).

**Fix:** when considering a candidate task, skip if this agent's id already appears in `task.Approvals`. Same-agent double-approval is a quorum violation by design.

### 3. Auto-emit checkpoint-summary on merge

After `handleApprovedMerges` succeeds, the operator previously had to run `liza skill checkpoint-summary` manually before any downstream tool (e.g. an export CLI) could pick up the report. Friction during dry-runs.

**Fix:** new file `internal/agent/checkpoint_summary.go` — after a successful merge, spawn the configured CLI with the `checkpoint-summary` skill against `.liza/state.yaml` and write the report to `docs/checkpoint-summary.md`.

- **Best-effort**: failures are logged but never block the merge cycle.
- **Opt-out**: `Config.AutoCheckpointSummary = false` disables emission.
- **CLAUDE.md compliance**: filters `ANTHROPIC_API_KEY` from the subprocess env so the configured CLI (claude / codex / gemini / qwen / kimi / vibe) uses OAuth without conflict.

## Test plan

- [x] `TestHandleApprovedMerges_AutoEmitsCheckpointSummary` — runner fires after merge, prompt mentions task id, report file written
- [x] `TestHandleApprovedMerges_RespectsAutoCheckpointOptOut` — runner skipped when `AutoCheckpointSummary=false`
- [x] `TestClaimReviewerTask_*` — reviewer-1 self-claim guard + round-2 claiming pass
- [x] 28 targeted reviewer/claim tests pass
- [x] \`go build ./...\` clean
- [x] No regressions in existing models/ops/agent suites

## Notes

- Surfaced during Omni M1 lighthouse demo prep (full real-data Liza run on codex CLI).
- The three fixes are independent and could theoretically split into three PRs; bundled because they share test scaffolding and were validated end-to-end together.
- No `ANTHROPIC_API_KEY` ever crosses the subprocess boundary (verified in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)