### PR TITLE
[tooling] add terminal multiplexer launch commands

### DIFF
--- a/cmd/liza/cmd_launch.go
+++ b/cmd/liza/cmd_launch.go
@@ -1,0 +1,1040 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/liza-mas/liza/internal/agent"
+	"github.com/spf13/cobra"
+)
+
+var launchCmd = &cobra.Command{
+	Use:   "launch",
+	Short: "Launch grouped Liza workflows",
+}
+
+var launchWeztermCmd = &cobra.Command{
+	Use:   "wezterm",
+	Short: "Launch Liza workflows in WezTerm panes",
+}
+
+var launchCmuxCmd = &cobra.Command{
+	Use:   "cmux",
+	Short: "Launch Liza workflows in CMUX panes",
+}
+
+var launchWeztermMASCmd = &cobra.Command{
+	Use:   "mas",
+	Short: "Launch a multi-agent role set in WezTerm panes",
+	Long: `Launch a Liza multi-agent role set in one WezTerm window.
+
+Preset role sets:
+  technical-spec     orchestrator, code-planner, code-plan-reviewer, coder, code-reviewer
+  functional-spec    technical-spec plus architect, architecture-reviewer
+  general-objective  functional-spec plus epic-planner, epic-plan-reviewer, us-writer, us-reviewer`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectRoot, err := launchWorkingDir(cmd, true)
+		if err != nil {
+			return err
+		}
+		preset, _ := cmd.Flags().GetString("preset")
+		roles, _ := cmd.Flags().GetStringArray("role")
+		if len(roles) == 0 {
+			var ok bool
+			roles, ok = masLaunchPresets()[preset]
+			if !ok {
+				return cliValidationError(fmt.Sprintf("unknown MAS launch preset %q", preset))
+			}
+		}
+
+		cliName, _ := cmd.Flags().GetString("cli")
+		noTUI, _ := cmd.Flags().GetBool("no-tui")
+		commands := make([][]string, 0, len(roles)+1)
+		if !noTUI {
+			commands = append(commands, []string{"liza", "tui"})
+		}
+		for _, role := range roles {
+			role = strings.TrimSpace(role)
+			if role == "" {
+				return cliValidationError("--role values must not be empty")
+			}
+			agentCmd := []string{"liza", "agent", role}
+			if cliName != "" {
+				if !containsString(agent.ValidCLIs(), cliName) {
+					return cliValidationError(fmt.Sprintf("invalid --cli %q", cliName))
+				}
+				agentCmd = append(agentCmd, "--cli", cliName)
+			}
+			commands = append(commands, agentCmd)
+		}
+		if len(commands) == 0 {
+			return cliValidationError("nothing to launch: provide --role or omit --no-tui")
+		}
+
+		opts, err := weztermOptionsFromFlags(cmd, projectRoot, "liza-mas-"+preset)
+		if err != nil {
+			return err
+		}
+		return runWeztermLaunch(cmd, opts, commands)
+	},
+}
+
+var launchWeztermAdversarialPairingCmd = &cobra.Command{
+	Use:   "adversarial-pairing <blackboard-path>",
+	Short: "Launch adversarial-pairing doer/reviewer sessions in WezTerm panes",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := launchWorkingDir(cmd, false)
+		if err != nil {
+			return err
+		}
+		boardPath, err := resolveLaunchPath(cwd, args[0])
+		if err != nil {
+			return cliValidationWrap("resolve blackboard path", err)
+		}
+		goal, _ := cmd.Flags().GetString("goal")
+		yolo, _ := cmd.Flags().GetBool("yolo")
+		if err := ensureAdversarialPairingBlackboard(boardPath, goal, yolo, cmd); err != nil {
+			return err
+		}
+		doerCLI, _ := cmd.Flags().GetString("doer-cli")
+		if !containsString(agent.ValidCLIs(), doerCLI) {
+			return cliValidationError(fmt.Sprintf("invalid --doer-cli %q", doerCLI))
+		}
+		reviewerSpecs, _ := cmd.Flags().GetStringArray("reviewer")
+		if len(reviewerSpecs) == 0 {
+			reviewerSpecs = []string{"codex", "codex-2=codex"}
+		}
+		doerPrompt := pairingSkillPrompt("doer", boardPath, yolo)
+		panes := []interactivePane{{Command: pairingInteractiveCLICommand(doerCLI), Prompt: doerPrompt}}
+		for _, spec := range reviewerSpecs {
+			id, cliName, err := parseReviewerLaunchSpec(spec)
+			if err != nil {
+				return err
+			}
+			if !containsString(agent.ValidCLIs(), cliName) {
+				return cliValidationError(fmt.Sprintf("invalid reviewer CLI %q", cliName))
+			}
+			prompt := pairingSkillPrompt("reviewer-"+id, boardPath, false)
+			panes = append(panes, interactivePane{Command: pairingInteractiveCLICommand(cliName), Prompt: prompt})
+		}
+
+		opts, err := weztermOptionsFromFlags(cmd, cwd, "liza-adversarial")
+		if err != nil {
+			return err
+		}
+		return runWeztermInteractiveLaunch(cmd, opts, panes)
+	},
+}
+
+var launchCmuxMASCmd = &cobra.Command{
+	Use:   "mas",
+	Short: "Launch a multi-agent role set in CMUX panes",
+	Long: `Launch a Liza multi-agent role set in one CMUX workspace.
+
+Preset role sets:
+  technical-spec     orchestrator, code-planner, code-plan-reviewer, coder, code-reviewer
+  functional-spec    technical-spec plus architect, architecture-reviewer
+  general-objective  functional-spec plus epic-planner, epic-plan-reviewer, us-writer, us-reviewer`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectRoot, err := launchWorkingDir(cmd, true)
+		if err != nil {
+			return err
+		}
+		preset, _ := cmd.Flags().GetString("preset")
+		roles, _ := cmd.Flags().GetStringArray("role")
+		if len(roles) == 0 {
+			var ok bool
+			roles, ok = masLaunchPresets()[preset]
+			if !ok {
+				return cliValidationError(fmt.Sprintf("unknown MAS launch preset %q", preset))
+			}
+		}
+
+		cliName, _ := cmd.Flags().GetString("cli")
+		noTUI, _ := cmd.Flags().GetBool("no-tui")
+		commands := make([][]string, 0, len(roles)+1)
+		if !noTUI {
+			commands = append(commands, []string{"liza", "tui"})
+		}
+		for _, role := range roles {
+			role = strings.TrimSpace(role)
+			if role == "" {
+				return cliValidationError("--role values must not be empty")
+			}
+			agentCmd := []string{"liza", "agent", role}
+			if cliName != "" {
+				if !containsString(agent.ValidCLIs(), cliName) {
+					return cliValidationError(fmt.Sprintf("invalid --cli %q", cliName))
+				}
+				agentCmd = append(agentCmd, "--cli", cliName)
+			}
+			commands = append(commands, agentCmd)
+		}
+		if len(commands) == 0 {
+			return cliValidationError("nothing to launch: provide --role or omit --no-tui")
+		}
+
+		opts, err := cmuxOptionsFromFlags(cmd, projectRoot, "liza-mas-"+preset)
+		if err != nil {
+			return err
+		}
+		return runCmuxLaunch(cmd, opts, commands)
+	},
+}
+
+var launchCmuxAdversarialPairingCmd = &cobra.Command{
+	Use:   "adversarial-pairing <blackboard-path>",
+	Short: "Launch adversarial-pairing doer/reviewer sessions in CMUX panes",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := launchWorkingDir(cmd, false)
+		if err != nil {
+			return err
+		}
+		boardPath, err := resolveLaunchPath(cwd, args[0])
+		if err != nil {
+			return cliValidationWrap("resolve blackboard path", err)
+		}
+		goal, _ := cmd.Flags().GetString("goal")
+		yolo, _ := cmd.Flags().GetBool("yolo")
+		if err := ensureAdversarialPairingBlackboard(boardPath, goal, yolo, cmd); err != nil {
+			return err
+		}
+		doerCLI, _ := cmd.Flags().GetString("doer-cli")
+		if !containsString(agent.ValidCLIs(), doerCLI) {
+			return cliValidationError(fmt.Sprintf("invalid --doer-cli %q", doerCLI))
+		}
+		reviewerSpecs, _ := cmd.Flags().GetStringArray("reviewer")
+		if len(reviewerSpecs) == 0 {
+			reviewerSpecs = []string{"codex", "codex-2=codex"}
+		}
+		doerPrompt := pairingSkillPrompt("doer", boardPath, yolo)
+		panes := []interactivePane{{Command: pairingInteractiveCLICommand(doerCLI), Prompt: doerPrompt}}
+		for _, spec := range reviewerSpecs {
+			id, cliName, err := parseReviewerLaunchSpec(spec)
+			if err != nil {
+				return err
+			}
+			if !containsString(agent.ValidCLIs(), cliName) {
+				return cliValidationError(fmt.Sprintf("invalid reviewer CLI %q", cliName))
+			}
+			prompt := pairingSkillPrompt("reviewer-"+id, boardPath, false)
+			panes = append(panes, interactivePane{Command: pairingInteractiveCLICommand(cliName), Prompt: prompt})
+		}
+
+		opts, err := cmuxOptionsFromFlags(cmd, cwd, "liza-adversarial")
+		if err != nil {
+			return err
+		}
+		return runCmuxInteractiveLaunch(cmd, opts, panes)
+	},
+}
+
+type weztermLaunchOptions struct {
+	Class     string
+	Workspace string
+	CWD       string
+	DryRun    bool
+}
+
+type cmuxLaunchOptions struct {
+	Workspace string
+	CWD       string
+	DryRun    bool
+}
+
+type interactivePane struct {
+	Command []string
+	Prompt  string
+}
+
+func masLaunchPresets() map[string][]string {
+	return map[string][]string{
+		"technical-spec": {
+			"orchestrator",
+			"code-planner",
+			"code-plan-reviewer",
+			"coder",
+			"code-reviewer",
+		},
+		"functional-spec": {
+			"orchestrator",
+			"architect",
+			"architecture-reviewer",
+			"code-planner",
+			"code-plan-reviewer",
+			"coder",
+			"code-reviewer",
+		},
+		"general-objective": {
+			"orchestrator",
+			"epic-planner",
+			"epic-plan-reviewer",
+			"us-writer",
+			"us-reviewer",
+			"architect",
+			"architecture-reviewer",
+			"code-planner",
+			"code-plan-reviewer",
+			"coder",
+			"code-reviewer",
+		},
+	}
+}
+
+func launchWorkingDir(cmd *cobra.Command, requireLizaProject bool) (string, error) {
+	cwd, _ := cmd.Flags().GetString("cwd")
+	if cwd != "" {
+		abs, err := filepath.Abs(cwd)
+		if err != nil {
+			return "", cliValidationWrap("resolve --cwd", err)
+		}
+		return abs, nil
+	}
+	if requireLizaProject {
+		return requireProjectRoot()
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", cliValidationWrap("get current directory", err)
+	}
+	return wd, nil
+}
+
+func resolveLaunchPath(cwd, path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	return filepath.Abs(filepath.Join(cwd, path))
+}
+
+func ensureAdversarialPairingBlackboard(path, goal string, yolo bool, cmd *cobra.Command) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return cliValidationWrap("inspect blackboard path", err)
+	}
+	if strings.TrimSpace(goal) == "" {
+		return cliValidationError("blackboard does not exist; create it first or pass --goal to initialize it before launching reviewers")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return cliValidationWrap("create blackboard directory", err)
+	}
+	content := initialAdversarialPairingBlackboard(goal, yolo, time.Now().UTC())
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return cliValidationWrap("create adversarial-pairing blackboard", err)
+	}
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		return cliValidationWrap("write adversarial-pairing blackboard", err)
+	}
+	if err := file.Close(); err != nil {
+		return cliValidationWrap("close adversarial-pairing blackboard", err)
+	}
+	cmd.Printf("Created adversarial-pairing blackboard: %s\n", path)
+	return nil
+}
+
+func initialAdversarialPairingBlackboard(goal string, yolo bool, now time.Time) string {
+	goal = strings.TrimSpace(goal)
+	yoloValue := "false"
+	if yolo {
+		yoloValue = "true"
+	}
+	return fmt.Sprintf(`---
+phase: DRAFT
+yolo: %s
+work_type: feature
+rca_required: false
+red_test_required: false
+required_reviewers: []
+plan_revision: 0
+analysis_revision: 0
+red_test_round: 0
+code_review_round: 0
+phase_updated_at: "%s"
+worktree: null
+agents:
+  doer:
+    role: doer
+    status: DRAFT
+    last_seen: null
+    reviewed_analysis_revision: null
+    analysis_verdict: null
+    reviewed_plan_revision: null
+    plan_verdict: null
+    reviewed_red_test_round: null
+    red_test_verdict: null
+    reviewed_code_round: null
+    code_verdict: null
+---
+
+# Adversarial Pairing Blackboard
+
+## Goal
+
+%s
+
+## Evidence
+
+## Plan Revisions
+
+## Plan Reviews
+
+## Implementation Notes
+
+## Code Review Rounds
+
+## Validation
+
+## Decisions
+`, yoloValue, now.Format(time.RFC3339), goal)
+}
+
+func weztermOptionsFromFlags(cmd *cobra.Command, cwd, defaultClass string) (weztermLaunchOptions, error) {
+	className, _ := cmd.Flags().GetString("class")
+	if className == "" {
+		className = defaultClass
+	}
+	workspace, _ := cmd.Flags().GetString("workspace")
+	if workspace == "" {
+		workspace = className
+	}
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	return weztermLaunchOptions{Class: className, Workspace: workspace, CWD: cwd, DryRun: dryRun}, nil
+}
+
+func cmuxOptionsFromFlags(cmd *cobra.Command, cwd, defaultWorkspace string) (cmuxLaunchOptions, error) {
+	workspace, _ := cmd.Flags().GetString("workspace")
+	if workspace == "" {
+		className, _ := cmd.Flags().GetString("class")
+		if className != "" {
+			workspace = className
+		} else {
+			workspace = defaultWorkspace
+		}
+	}
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	return cmuxLaunchOptions{Workspace: workspace, CWD: cwd, DryRun: dryRun}, nil
+}
+
+func runWeztermLaunch(cmd *cobra.Command, opts weztermLaunchOptions, commands [][]string) error {
+	if len(commands) == 0 {
+		return cliValidationError("no commands to launch")
+	}
+	script := buildWeztermPaneScript(opts, commands)
+	args := []string{
+		"start",
+		"--class", opts.Class,
+		"--workspace", opts.Workspace,
+		"--cwd", opts.CWD,
+		"--",
+		launchShell(),
+		"-lc",
+		script,
+	}
+	if opts.DryRun {
+		cmd.Println(shellJoin(append([]string{"wezterm"}, args...)))
+		return nil
+	}
+	if _, err := exec.LookPath("wezterm"); err != nil {
+		return cliValidationWrap("wezterm not found on PATH", err)
+	}
+	launch := exec.Command("wezterm", args...)
+	launch.Stdout = os.Stdout
+	launch.Stderr = os.Stderr
+	launch.Stdin = os.Stdin
+	if err := launch.Start(); err != nil {
+		return err
+	}
+	return launch.Process.Release()
+}
+
+func runWeztermInteractiveLaunch(cmd *cobra.Command, opts weztermLaunchOptions, panes []interactivePane) error {
+	if len(panes) == 0 {
+		return cliValidationError("no panes to launch")
+	}
+	script := buildWeztermInteractivePaneScript(opts, panes)
+	args := []string{
+		"start",
+		"--class", opts.Class,
+		"--workspace", opts.Workspace,
+		"--cwd", opts.CWD,
+		"--",
+		launchShell(),
+		"-lc",
+		script,
+	}
+	if opts.DryRun {
+		cmd.Println(shellJoin(append([]string{"wezterm"}, args...)))
+		return nil
+	}
+	if _, err := exec.LookPath("wezterm"); err != nil {
+		return cliValidationWrap("wezterm not found on PATH", err)
+	}
+	launch := exec.Command("wezterm", args...)
+	launch.Stdout = os.Stdout
+	launch.Stderr = os.Stderr
+	launch.Stdin = os.Stdin
+	if err := launch.Start(); err != nil {
+		return err
+	}
+	return launch.Process.Release()
+}
+
+func runCmuxLaunch(cmd *cobra.Command, opts cmuxLaunchOptions, commands [][]string) error {
+	if len(commands) == 0 {
+		return cliValidationError("no commands to launch")
+	}
+	if opts.DryRun {
+		cmuxCmds, err := buildCmuxLaunchCommands(opts, commands)
+		if err != nil {
+			return err
+		}
+		for _, c := range cmuxCmds {
+			cmd.Println(shellJoin(c))
+		}
+		return nil
+	}
+	if _, err := exec.LookPath("cmux"); err != nil {
+		return cliValidationWrap("cmux not found on PATH", err)
+	}
+
+	// Create workspace with first command
+	createArgs := []string{
+		"cmux", "new-workspace",
+		"--name", opts.Workspace,
+		"--cwd", opts.CWD,
+		"--command", shellJoin(commands[0]),
+	}
+	output, err := exec.Command(createArgs[0], createArgs[1:]...).CombinedOutput()
+	if err != nil {
+		return cliValidationWrap("create cmux workspace", err)
+	}
+	workspaceRef, err := parseCmuxRef(output, "workspace")
+	if err != nil {
+		return err
+	}
+
+	// Create panes for additional commands
+	for i, cmd := range commands[1:] {
+		direction := "right"
+		if i%2 == 1 {
+			direction = "down"
+		}
+		paneArgs := []string{
+			"cmux", "new-pane",
+			"--type", "terminal",
+			"--direction", direction,
+			"--workspace", workspaceRef,
+		}
+		paneOutput, err := exec.Command(paneArgs[0], paneArgs[1:]...).CombinedOutput()
+		if err != nil {
+			return err
+		}
+		surfaceRef, err := parseCmuxRef(paneOutput, "surface")
+		if err != nil {
+			return err
+		}
+		if err := cmuxSendText(workspaceRef, surfaceRef, shellJoin(cmd)); err != nil {
+			return cliValidationWrap("send command to cmux pane", err)
+		}
+		if err := cmuxSendKey(workspaceRef, surfaceRef, "enter"); err != nil {
+			return cliValidationWrap("send enter key to cmux pane", err)
+		}
+	}
+	return nil
+}
+
+func runCmuxInteractiveLaunch(cmd *cobra.Command, opts cmuxLaunchOptions, panes []interactivePane) error {
+	if len(panes) == 0 {
+		return cliValidationError("no panes to launch")
+	}
+	if opts.DryRun {
+		cmuxCmds, err := buildCmuxInteractiveLaunchCommands(opts, panes)
+		if err != nil {
+			return err
+		}
+		for _, c := range cmuxCmds {
+			cmd.Println(shellJoin(c))
+		}
+		return nil
+	}
+	if _, err := exec.LookPath("cmux"); err != nil {
+		return cliValidationWrap("cmux not found on PATH", err)
+	}
+
+	// Create workspace with first pane
+	createArgs := []string{
+		"cmux", "new-workspace",
+		"--name", opts.Workspace,
+		"--cwd", opts.CWD,
+		"--command", shellJoin(panes[0].Command),
+	}
+	output, err := exec.Command(createArgs[0], createArgs[1:]...).CombinedOutput()
+	if err != nil {
+		return cliValidationWrap("create cmux workspace", err)
+	}
+	workspaceRef, err := parseCmuxRef(output, "workspace")
+	if err != nil {
+		return err
+	}
+	primarySurfaceRef, err := cmuxWorkspaceSelectedSurfaceRef(workspaceRef)
+	if err != nil {
+		return err
+	}
+
+	// Create additional panes and collect surface references
+	surfaceRefs := []string{primarySurfaceRef}
+	for i, pane := range panes[1:] {
+		direction := "right"
+		if i%2 == 1 {
+			direction = "down"
+		}
+		paneArgs := []string{
+			"cmux", "new-pane",
+			"--type", "terminal",
+			"--direction", direction,
+			"--workspace", workspaceRef,
+		}
+		paneOutput, err := exec.Command(paneArgs[0], paneArgs[1:]...).CombinedOutput()
+		if err != nil {
+			return cliValidationWrap("create cmux pane", err)
+		}
+		surfaceRef, err := parseCmuxRef(paneOutput, "surface")
+		if err != nil {
+			return err
+		}
+		surfaceRefs = append(surfaceRefs, surfaceRef)
+		if err := cmuxSendText(workspaceRef, surfaceRef, shellJoin(pane.Command)); err != nil {
+			return cliValidationWrap("send command to cmux pane", err)
+		}
+		if err := cmuxSendKey(workspaceRef, surfaceRef, "enter"); err != nil {
+			return cliValidationWrap("send enter key to cmux pane", err)
+		}
+	}
+
+	if err := waitForCmuxInteractiveSurfaces(workspaceRef, surfaceRefs, 60*time.Second); err != nil {
+		return err
+	}
+	time.Sleep(2 * time.Second)
+
+	// Send prompts to all panes
+	for i, pane := range panes {
+		if err := cmuxSendPrompt(workspaceRef, surfaceRefs[i], pane.Prompt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cmuxSendText(workspaceRef, surfaceRef, text string) error {
+	return exec.Command("cmux", "send", "--workspace", workspaceRef, "--surface", surfaceRef, text).Run()
+}
+
+func cmuxSendKey(workspaceRef, surfaceRef, key string) error {
+	return exec.Command("cmux", "send-key", "--workspace", workspaceRef, "--surface", surfaceRef, key).Run()
+}
+
+func cmuxSendPrompt(workspaceRef, surfaceRef, prompt string) error {
+	if err := cmuxSendText(workspaceRef, surfaceRef, prompt); err != nil {
+		return cliValidationWrap("send prompt to cmux pane", err)
+	}
+	for attempt := 0; attempt < 5; attempt++ {
+		if err := cmuxSendKey(workspaceRef, surfaceRef, "enter"); err != nil {
+			return cliValidationWrap("send enter key to cmux pane", err)
+		}
+		time.Sleep(2 * time.Second)
+		screen, err := cmuxReadScreen(workspaceRef, surfaceRef)
+		if err != nil || !cmuxPromptStillPending(screen, prompt) {
+			return nil
+		}
+	}
+	return cliValidationError("cmux prompt remained pending after submit attempts")
+}
+
+func cmuxWorkspaceSelectedSurfaceRef(workspaceRef string) (string, error) {
+	output, err := exec.Command("cmux", "list-pane-surfaces", "--workspace", workspaceRef).CombinedOutput()
+	if err != nil {
+		return "", cliValidationWrap("list cmux workspace surfaces", err)
+	}
+	return parseCmuxRef(output, "surface")
+}
+
+func waitForCmuxInteractiveSurfaces(workspaceRef string, surfaceRefs []string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	hostSelectionSent := map[string]bool{}
+	for {
+		allReady := true
+		for _, surfaceRef := range surfaceRefs {
+			screen, err := cmuxReadScreen(workspaceRef, surfaceRef)
+			if err != nil {
+				allReady = false
+				break
+			}
+			if cmuxScreenNeedsHostSelection(screen) && !hostSelectionSent[surfaceRef] {
+				if err := cmuxSendKey(workspaceRef, surfaceRef, "enter"); err != nil {
+					return cliValidationWrap("select cmux codex host", err)
+				}
+				hostSelectionSent[surfaceRef] = true
+				allReady = false
+				break
+			}
+			if !cmuxScreenLooksInteractive(screen) {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return cliValidationError("timed out waiting for cmux panes to become interactive")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func cmuxSurfaceLooksInteractive(workspaceRef, surfaceRef string) bool {
+	screen, err := cmuxReadScreen(workspaceRef, surfaceRef)
+	if err != nil {
+		return false
+	}
+	return cmuxScreenLooksInteractive(screen)
+}
+
+func cmuxReadScreen(workspaceRef, surfaceRef string) (string, error) {
+	output, err := exec.Command("cmux", "read-screen", "--workspace", workspaceRef, "--surface", surfaceRef, "--lines", "80").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func cmuxScreenNeedsHostSelection(screen string) bool {
+	return strings.Contains(screen, "Pick host for agent") && strings.Contains(screen, "enter submit")
+}
+
+func cmuxPromptStillPending(screen, prompt string) bool {
+	return strings.Contains(screen, "› "+prompt) && !strings.Contains(screen, "Working")
+}
+
+func cmuxScreenLooksInteractive(screen string) bool {
+	if !strings.Contains(screen, "OpenAI Codex") {
+		return false
+	}
+	for _, marker := range []string{
+		"Starting MCP servers",
+		"esc to interrupt",
+		"Working",
+	} {
+		if strings.Contains(screen, marker) {
+			return false
+		}
+	}
+	return strings.Contains(screen, "›")
+}
+
+func parseCmuxRef(output []byte, refType string) (string, error) {
+	prefix := refType + ":"
+	for _, field := range strings.Fields(strings.TrimSpace(string(output))) {
+		if strings.HasPrefix(field, prefix) {
+			return field, nil
+		}
+	}
+	return "", cliValidationError(fmt.Sprintf("cmux output did not include %s ref: %s", refType, strings.TrimSpace(string(output))))
+}
+
+func buildWeztermPaneScript(opts weztermLaunchOptions, commands [][]string) string {
+	var b strings.Builder
+	for i, paneCommand := range commands[1:] {
+		direction := "--right"
+		if i%2 == 1 {
+			direction = "--bottom"
+		}
+		b.WriteString("wezterm cli split-pane ")
+		b.WriteString(direction)
+		b.WriteString(" --cwd ")
+		b.WriteString(shellQuote(opts.CWD))
+		b.WriteString(" -- ")
+		b.WriteString(shellJoin(paneCommand))
+		b.WriteString("\n")
+	}
+	b.WriteString("exec ")
+	b.WriteString(shellJoin(commands[0]))
+	b.WriteString("\n")
+	return b.String()
+}
+
+func buildWeztermInteractivePaneScript(opts weztermLaunchOptions, panes []interactivePane) string {
+	var b strings.Builder
+	b.WriteString("set -e\n")
+	b.WriteString("wezterm_liza_send_prompt() {\n")
+	b.WriteString("  pane_id=\"$1\"\n")
+	b.WriteString("  prompt=\"$2\"\n")
+	b.WriteString("  (\n")
+	b.WriteString("    sleep 2\n")
+	b.WriteString("    printf '%s' \"$prompt\" | wezterm cli --class ")
+	b.WriteString(shellQuote(opts.Class))
+	b.WriteString(" send-text --no-paste --pane-id \"$pane_id\"\n")
+	b.WriteString("    printf '\\r' | wezterm cli --class ")
+	b.WriteString(shellQuote(opts.Class))
+	b.WriteString(" send-text --no-paste --pane-id \"$pane_id\"\n")
+	b.WriteString("  ) &\n")
+	b.WriteString("}\n")
+	for i, pane := range panes[1:] {
+		direction := "--right"
+		if i%2 == 1 {
+			direction = "--bottom"
+		}
+		paneVar := fmt.Sprintf("pane_id_%d", i+1)
+		b.WriteString(paneVar)
+		b.WriteString("=$(wezterm cli --class ")
+		b.WriteString(shellQuote(opts.Class))
+		b.WriteString(" split-pane ")
+		b.WriteString(direction)
+		b.WriteString(" --cwd ")
+		b.WriteString(shellQuote(opts.CWD))
+		b.WriteString(" -- ")
+		b.WriteString(shellJoin(pane.Command))
+		b.WriteString(")\n")
+		b.WriteString("wezterm_liza_send_prompt \"$")
+		b.WriteString(paneVar)
+		b.WriteString("\" ")
+		b.WriteString(shellQuote(pane.Prompt))
+		b.WriteString("\n")
+	}
+	b.WriteString("wezterm_liza_send_prompt \"$WEZTERM_PANE\" ")
+	b.WriteString(shellQuote(panes[0].Prompt))
+	b.WriteString("\n")
+	b.WriteString("exec ")
+	b.WriteString(shellJoin(panes[0].Command))
+	b.WriteString("\n")
+	return b.String()
+}
+
+func buildCmuxLaunchCommands(opts cmuxLaunchOptions, commands [][]string) ([][]string, error) {
+	if len(commands) == 0 {
+		return nil, cliValidationError("no commands to launch")
+	}
+
+	var cmds [][]string
+
+	// Create workspace with first command
+	createArgs := []string{
+		"cmux", "new-workspace",
+		"--name", opts.Workspace,
+		"--cwd", opts.CWD,
+		"--command", shellJoin(commands[0]),
+	}
+	cmds = append(cmds, createArgs)
+
+	// Use a placeholder workspace ref for dry-run (would be parsed from output at runtime)
+	workspaceRef := "<workspace-ref-from-new-workspace-output>"
+
+	// Create panes for additional commands
+	for i, cmd := range commands[1:] {
+		direction := "right"
+		if i%2 == 1 {
+			direction = "down"
+		}
+		paneArgs := []string{
+			"cmux", "new-pane",
+			"--type", "terminal",
+			"--direction", direction,
+			"--workspace", workspaceRef,
+		}
+		cmds = append(cmds, paneArgs)
+		cmds = append(cmds, []string{"cmux", "send", "--workspace", workspaceRef, "--surface", fmt.Sprintf("<surface-ref-%d-from-new-pane-output>", i+1), shellJoin(cmd)})
+		cmds = append(cmds, []string{"cmux", "send-key", "--workspace", workspaceRef, "--surface", fmt.Sprintf("<surface-ref-%d-from-new-pane-output>", i+1), "enter"})
+	}
+
+	return cmds, nil
+}
+
+func buildCmuxInteractiveLaunchCommands(opts cmuxLaunchOptions, panes []interactivePane) ([][]string, error) {
+	if len(panes) == 0 {
+		return nil, cliValidationError("no panes to launch")
+	}
+
+	var cmds [][]string
+
+	// Create workspace with first pane (interactive CLI)
+	createArgs := []string{
+		"cmux", "new-workspace",
+		"--name", opts.Workspace,
+		"--cwd", opts.CWD,
+		"--command", shellJoin(panes[0].Command),
+	}
+	cmds = append(cmds, createArgs)
+
+	// Use a placeholder workspace ref for dry-run (would be parsed from output at runtime)
+	workspaceRef := "<workspace-ref-from-new-workspace-output>"
+
+	// Create additional panes
+	for i, pane := range panes[1:] {
+		direction := "right"
+		if i%2 == 1 {
+			direction = "down"
+		}
+		paneArgs := []string{
+			"cmux", "new-pane",
+			"--type", "terminal",
+			"--direction", direction,
+			"--workspace", workspaceRef,
+		}
+		cmds = append(cmds, paneArgs)
+		surfaceRef := fmt.Sprintf("<surface-ref-%d-from-new-pane-output>", i+1)
+		cmds = append(cmds, []string{"cmux", "send", "--workspace", workspaceRef, "--surface", surfaceRef, shellJoin(pane.Command)})
+		cmds = append(cmds, []string{"cmux", "send-key", "--workspace", workspaceRef, "--surface", surfaceRef, "enter"})
+	}
+
+	// Send prompts to all panes
+	for i, pane := range panes {
+		surfaceRef := fmt.Sprintf("<surface-ref-%d-from-new-pane-output>", i)
+		if i == 0 {
+			surfaceRef = "<surface-ref-from-new-workspace-output>"
+		}
+		// Send prompt as text (not as argv to the CLI)
+		sendArgs := []string{
+			"cmux", "send",
+			"--workspace", workspaceRef,
+			"--surface", surfaceRef,
+			pane.Prompt,
+		}
+		cmds = append(cmds, sendArgs)
+
+		// Send enter key to submit
+		enterArgs := []string{
+			"cmux", "send-key",
+			"--workspace", workspaceRef,
+			"--surface", surfaceRef,
+			"enter",
+		}
+		cmds = append(cmds, enterArgs)
+	}
+
+	return cmds, nil
+}
+
+func pairingSkillPrompt(roleOrReviewerID, boardPath string, yolo bool) string {
+	prompt := "$adversarial-pairing " + roleOrReviewerID + " " + boardPath
+	if yolo {
+		prompt += " yolo"
+	}
+	return prompt
+}
+
+func pairingInteractiveCLICommand(cliName string) []string {
+	switch cliName {
+	case "claude":
+		return []string{"claude"}
+	case "codex":
+		return []string{"codex"}
+	case "codex-acp":
+		return []string{"codex"}
+	case "opencode":
+		return []string{"opencode"}
+	case "opencode-acp":
+		return []string{"opencode"}
+	case "gemini":
+		return []string{"gemini"}
+	case "mistral":
+		return []string{"vibe"}
+	case "kimi":
+		return []string{"kimi"}
+	default:
+		return []string{cliName}
+	}
+}
+
+func parseReviewerLaunchSpec(spec string) (string, string, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", "", cliValidationError("--reviewer values must not be empty")
+	}
+	if strings.Contains(spec, "=") {
+		parts := strings.SplitN(spec, "=", 2)
+		id := strings.TrimPrefix(strings.TrimSpace(parts[0]), "reviewer-")
+		cliName := strings.TrimSpace(parts[1])
+		if id == "" || cliName == "" {
+			return "", "", cliValidationError(fmt.Sprintf("invalid reviewer spec %q; use id=cli or cli", spec))
+		}
+		return id, cliName, nil
+	}
+	id := strings.TrimPrefix(spec, "reviewer-")
+	return id, id, nil
+}
+
+func shellJoin(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = shellQuote(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+func launchShell() string {
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+	return "/bin/sh"
+}
+
+func init() {
+	rootCmd.AddCommand(launchCmd)
+	launchCmd.AddCommand(launchWeztermCmd)
+	launchWeztermCmd.AddCommand(launchWeztermMASCmd)
+	launchWeztermCmd.AddCommand(launchWeztermAdversarialPairingCmd)
+	launchCmd.AddCommand(launchCmuxCmd)
+	launchCmuxCmd.AddCommand(launchCmuxMASCmd)
+	launchCmuxCmd.AddCommand(launchCmuxAdversarialPairingCmd)
+
+	for _, c := range []*cobra.Command{launchWeztermMASCmd, launchWeztermAdversarialPairingCmd} {
+		c.Flags().String("class", "", "WezTerm window class (default depends on launch type)")
+		c.Flags().String("workspace", "", "WezTerm workspace name (defaults to --class)")
+		c.Flags().String("cwd", "", "working directory for launched panes (default: current Liza project for MAS, current directory for pairing)")
+		c.Flags().Bool("dry-run", false, "print the wezterm command without launching it")
+	}
+
+	for _, c := range []*cobra.Command{launchCmuxMASCmd, launchCmuxAdversarialPairingCmd} {
+		c.Flags().String("class", "", "workspace name (defaults to launch type)")
+		c.Flags().String("workspace", "", "CMUX workspace name (defaults to --class)")
+		c.Flags().String("cwd", "", "working directory for launched panes (default: current Liza project for MAS, current directory for pairing)")
+		c.Flags().Bool("dry-run", false, "print the cmux commands without launching them")
+	}
+
+	launchWeztermMASCmd.Flags().String("preset", "technical-spec", "role preset: technical-spec, functional-spec, general-objective")
+	launchWeztermMASCmd.Flags().StringArray("role", nil, "role to launch; repeat to override --preset")
+	launchWeztermMASCmd.Flags().String("cli", "", "CLI to pass to liza agent for every launched role")
+	launchWeztermMASCmd.Flags().Bool("no-tui", false, "do not launch liza tui in the first pane")
+
+	launchWeztermAdversarialPairingCmd.Flags().String("doer-cli", "codex", "coding CLI for the doer session")
+	launchWeztermAdversarialPairingCmd.Flags().String("goal", "", "create the blackboard with this goal when it does not exist")
+	launchWeztermAdversarialPairingCmd.Flags().StringArray("reviewer", nil, "reviewer CLI or id=cli; repeat for multiple reviewers (default: codex, codex-2=codex)")
+	launchWeztermAdversarialPairingCmd.Flags().Bool("yolo", false, "pass yolo to the doer adversarial-pairing invocation")
+
+	launchCmuxMASCmd.Flags().String("preset", "technical-spec", "role preset: technical-spec, functional-spec, general-objective")
+	launchCmuxMASCmd.Flags().StringArray("role", nil, "role to launch; repeat to override --preset")
+	launchCmuxMASCmd.Flags().String("cli", "", "CLI to pass to liza agent for every launched role")
+	launchCmuxMASCmd.Flags().Bool("no-tui", false, "do not launch liza tui in the first pane")
+
+	launchCmuxAdversarialPairingCmd.Flags().String("doer-cli", "codex", "coding CLI for the doer session")
+	launchCmuxAdversarialPairingCmd.Flags().String("goal", "", "create the blackboard with this goal when it does not exist")
+	launchCmuxAdversarialPairingCmd.Flags().StringArray("reviewer", nil, "reviewer CLI or id=cli; repeat for multiple reviewers (default: codex, codex-2=codex)")
+	launchCmuxAdversarialPairingCmd.Flags().Bool("yolo", false, "pass yolo to the doer adversarial-pairing invocation")
+}

--- a/cmd/liza/cmd_launch.go
+++ b/cmd/liza/cmd_launch.go
@@ -98,7 +98,8 @@ var launchWeztermAdversarialPairingCmd = &cobra.Command{
 		}
 		goal, _ := cmd.Flags().GetString("goal")
 		yolo, _ := cmd.Flags().GetBool("yolo")
-		if err := ensureAdversarialPairingBlackboard(boardPath, goal, yolo, cmd); err != nil {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		if err := ensureAdversarialPairingBlackboard(boardPath, goal, yolo, dryRun, cmd); err != nil {
 			return err
 		}
 		doerCLI, _ := cmd.Flags().GetString("doer-cli")
@@ -202,7 +203,8 @@ var launchCmuxAdversarialPairingCmd = &cobra.Command{
 		}
 		goal, _ := cmd.Flags().GetString("goal")
 		yolo, _ := cmd.Flags().GetBool("yolo")
-		if err := ensureAdversarialPairingBlackboard(boardPath, goal, yolo, cmd); err != nil {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		if err := ensureAdversarialPairingBlackboard(boardPath, goal, yolo, dryRun, cmd); err != nil {
 			return err
 		}
 		doerCLI, _ := cmd.Flags().GetString("doer-cli")
@@ -353,7 +355,7 @@ func resolveLaunchPath(cwd, path string) (string, error) {
 	return filepath.Abs(filepath.Join(cwd, path))
 }
 
-func ensureAdversarialPairingBlackboard(path, goal string, yolo bool, cmd *cobra.Command) error {
+func ensureAdversarialPairingBlackboard(path, goal string, yolo bool, dryRun bool, cmd *cobra.Command) error {
 	if _, err := os.Stat(path); err == nil {
 		return nil
 	} else if !os.IsNotExist(err) {
@@ -361,6 +363,9 @@ func ensureAdversarialPairingBlackboard(path, goal string, yolo bool, cmd *cobra
 	}
 	if strings.TrimSpace(goal) == "" {
 		return cliValidationError("blackboard does not exist; create it first or pass --goal to initialize it before launching reviewers")
+	}
+	if dryRun {
+		return nil
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return cliValidationWrap("create blackboard directory", err)

--- a/cmd/liza/cmd_launch.go
+++ b/cmd/liza/cmd_launch.go
@@ -110,7 +110,7 @@ var launchWeztermAdversarialPairingCmd = &cobra.Command{
 			reviewerSpecs = []string{"codex", "codex-2=codex"}
 		}
 		doerPrompt := pairingSkillPrompt("doer", boardPath, yolo)
-		panes := []interactivePane{{Command: pairingInteractiveCLICommand(doerCLI), Prompt: doerPrompt}}
+		panes := []interactivePane{pairingInteractivePane(doerCLI, doerPrompt)}
 		for _, spec := range reviewerSpecs {
 			id, cliName, err := parseReviewerLaunchSpec(spec)
 			if err != nil {
@@ -120,7 +120,7 @@ var launchWeztermAdversarialPairingCmd = &cobra.Command{
 				return cliValidationError(fmt.Sprintf("invalid reviewer CLI %q", cliName))
 			}
 			prompt := pairingSkillPrompt("reviewer-"+id, boardPath, false)
-			panes = append(panes, interactivePane{Command: pairingInteractiveCLICommand(cliName), Prompt: prompt})
+			panes = append(panes, pairingInteractivePane(cliName, prompt))
 		}
 
 		opts, err := weztermOptionsFromFlags(cmd, cwd, "liza-adversarial")
@@ -214,7 +214,7 @@ var launchCmuxAdversarialPairingCmd = &cobra.Command{
 			reviewerSpecs = []string{"codex", "codex-2=codex"}
 		}
 		doerPrompt := pairingSkillPrompt("doer", boardPath, yolo)
-		panes := []interactivePane{{Command: pairingInteractiveCLICommand(doerCLI), Prompt: doerPrompt}}
+		panes := []interactivePane{pairingInteractivePane(doerCLI, doerPrompt)}
 		for _, spec := range reviewerSpecs {
 			id, cliName, err := parseReviewerLaunchSpec(spec)
 			if err != nil {
@@ -224,7 +224,7 @@ var launchCmuxAdversarialPairingCmd = &cobra.Command{
 				return cliValidationError(fmt.Sprintf("invalid reviewer CLI %q", cliName))
 			}
 			prompt := pairingSkillPrompt("reviewer-"+id, boardPath, false)
-			panes = append(panes, interactivePane{Command: pairingInteractiveCLICommand(cliName), Prompt: prompt})
+			panes = append(panes, pairingInteractivePane(cliName, prompt))
 		}
 
 		opts, err := cmuxOptionsFromFlags(cmd, cwd, "liza-adversarial")
@@ -236,10 +236,11 @@ var launchCmuxAdversarialPairingCmd = &cobra.Command{
 }
 
 type weztermLaunchOptions struct {
-	Class     string
-	Workspace string
-	CWD       string
-	DryRun    bool
+	Class       string
+	Workspace   string
+	CWD         string
+	DryRun      bool
+	PromptDelay time.Duration
 }
 
 type cmuxLaunchOptions struct {
@@ -249,6 +250,7 @@ type cmuxLaunchOptions struct {
 }
 
 type interactivePane struct {
+	CLIName string
 	Command []string
 	Prompt  string
 }
@@ -294,6 +296,11 @@ func launchWorkingDir(cmd *cobra.Command, requireLizaProject bool) (string, erro
 		if err != nil {
 			return "", cliValidationWrap("resolve --cwd", err)
 		}
+		if requireLizaProject {
+			if err := validateLaunchProjectRoot(abs); err != nil {
+				return "", err
+			}
+		}
 		return abs, nil
 	}
 	if requireLizaProject {
@@ -304,6 +311,39 @@ func launchWorkingDir(cmd *cobra.Command, requireLizaProject bool) (string, erro
 		return "", cliValidationWrap("get current directory", err)
 	}
 	return wd, nil
+}
+
+func validateLaunchProjectRoot(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return cliValidationWrap("inspect --cwd", err)
+	}
+	if !info.IsDir() {
+		return cliValidationError(fmt.Sprintf("--cwd %q is not a directory", path))
+	}
+	output, err := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return cliValidationWrap("resolve --cwd git root", err)
+	}
+	gitRoot := strings.TrimSpace(string(output))
+	canonicalPath, err := canonicalDir(path)
+	if err != nil {
+		return cliValidationWrap("resolve --cwd", err)
+	}
+	canonicalRoot, err := canonicalDir(gitRoot)
+	if err != nil {
+		return cliValidationWrap("resolve --cwd git root", err)
+	}
+	if canonicalPath != canonicalRoot {
+		return cliValidationError(fmt.Sprintf("--cwd must be the Liza project root, got %s under git root %s", path, gitRoot))
+	}
+	if _, err := os.Stat(filepath.Join(path, ".liza", "state.yaml")); err != nil {
+		if os.IsNotExist(err) {
+			return cliValidationError(fmt.Sprintf("--cwd %s is not initialized as a Liza project", path))
+		}
+		return cliValidationWrap("inspect --cwd Liza state", err)
+	}
+	return nil
 }
 
 func resolveLaunchPath(cwd, path string) (string, error) {
@@ -407,7 +447,14 @@ func weztermOptionsFromFlags(cmd *cobra.Command, cwd, defaultClass string) (wezt
 		workspace = className
 	}
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	return weztermLaunchOptions{Class: className, Workspace: workspace, CWD: cwd, DryRun: dryRun}, nil
+	promptDelay := 2 * time.Second
+	if cmd.Flags().Lookup("prompt-delay") != nil {
+		promptDelay, _ = cmd.Flags().GetDuration("prompt-delay")
+		if promptDelay < 0 {
+			return weztermLaunchOptions{}, cliValidationError("--prompt-delay must not be negative")
+		}
+	}
+	return weztermLaunchOptions{Class: className, Workspace: workspace, CWD: cwd, DryRun: dryRun, PromptDelay: promptDelay}, nil
 }
 
 func cmuxOptionsFromFlags(cmd *cobra.Command, cwd, defaultWorkspace string) (cmuxLaunchOptions, error) {
@@ -523,7 +570,7 @@ func runCmuxLaunch(cmd *cobra.Command, opts cmuxLaunchOptions, commands [][]stri
 	}
 
 	// Create panes for additional commands
-	for i, cmd := range commands[1:] {
+	for i, paneCommand := range commands[1:] {
 		direction := "right"
 		if i%2 == 1 {
 			direction = "down"
@@ -542,7 +589,7 @@ func runCmuxLaunch(cmd *cobra.Command, opts cmuxLaunchOptions, commands [][]stri
 		if err != nil {
 			return err
 		}
-		if err := cmuxSendText(workspaceRef, surfaceRef, shellJoin(cmd)); err != nil {
+		if err := cmuxSendText(workspaceRef, surfaceRef, shellJoin(paneCommand)); err != nil {
 			return cliValidationWrap("send command to cmux pane", err)
 		}
 		if err := cmuxSendKey(workspaceRef, surfaceRef, "enter"); err != nil {
@@ -620,14 +667,14 @@ func runCmuxInteractiveLaunch(cmd *cobra.Command, opts cmuxLaunchOptions, panes 
 		}
 	}
 
-	if err := waitForCmuxInteractiveSurfaces(workspaceRef, surfaceRefs, 60*time.Second); err != nil {
+	if err := waitForCmuxInteractiveSurfaces(workspaceRef, panes, surfaceRefs, 60*time.Second); err != nil {
 		return err
 	}
 	time.Sleep(2 * time.Second)
 
 	// Send prompts to all panes
 	for i, pane := range panes {
-		if err := cmuxSendPrompt(workspaceRef, surfaceRefs[i], pane.Prompt); err != nil {
+		if err := cmuxSendPrompt(workspaceRef, surfaceRefs[i], pane); err != nil {
 			return err
 		}
 	}
@@ -643,17 +690,23 @@ func cmuxSendKey(workspaceRef, surfaceRef, key string) error {
 	return exec.Command("cmux", "send-key", "--workspace", workspaceRef, "--surface", surfaceRef, key).Run()
 }
 
-func cmuxSendPrompt(workspaceRef, surfaceRef, prompt string) error {
-	if err := cmuxSendText(workspaceRef, surfaceRef, prompt); err != nil {
+func cmuxSendPrompt(workspaceRef, surfaceRef string, pane interactivePane) error {
+	if err := cmuxSendText(workspaceRef, surfaceRef, pane.Prompt); err != nil {
 		return cliValidationWrap("send prompt to cmux pane", err)
 	}
 	for attempt := 0; attempt < 5; attempt++ {
 		if err := cmuxSendKey(workspaceRef, surfaceRef, "enter"); err != nil {
 			return cliValidationWrap("send enter key to cmux pane", err)
 		}
+		if !cmuxPaneUsesCodex(pane) {
+			return nil
+		}
 		time.Sleep(2 * time.Second)
 		screen, err := cmuxReadScreen(workspaceRef, surfaceRef)
-		if err != nil || !cmuxPromptStillPending(screen, prompt) {
+		if err != nil {
+			return cliValidationWrap("verify cmux prompt submission", err)
+		}
+		if !cmuxPromptStillPending(screen, pane.Prompt) {
 			return nil
 		}
 	}
@@ -668,12 +721,18 @@ func cmuxWorkspaceSelectedSurfaceRef(workspaceRef string) (string, error) {
 	return parseCmuxRef(output, "surface")
 }
 
-func waitForCmuxInteractiveSurfaces(workspaceRef string, surfaceRefs []string, timeout time.Duration) error {
+func waitForCmuxInteractiveSurfaces(workspaceRef string, panes []interactivePane, surfaceRefs []string, timeout time.Duration) error {
+	if len(panes) != len(surfaceRefs) {
+		return cliValidationError("internal error: cmux pane/surface count mismatch")
+	}
 	deadline := time.Now().Add(timeout)
 	hostSelectionSent := map[string]bool{}
 	for {
 		allReady := true
-		for _, surfaceRef := range surfaceRefs {
+		for i, surfaceRef := range surfaceRefs {
+			if !cmuxPaneUsesCodex(panes[i]) {
+				continue
+			}
 			screen, err := cmuxReadScreen(workspaceRef, surfaceRef)
 			if err != nil {
 				allReady = false
@@ -700,14 +759,6 @@ func waitForCmuxInteractiveSurfaces(workspaceRef string, surfaceRefs []string, t
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-}
-
-func cmuxSurfaceLooksInteractive(workspaceRef, surfaceRef string) bool {
-	screen, err := cmuxReadScreen(workspaceRef, surfaceRef)
-	if err != nil {
-		return false
-	}
-	return cmuxScreenLooksInteractive(screen)
 }
 
 func cmuxReadScreen(workspaceRef, surfaceRef string) (string, error) {
@@ -740,6 +791,13 @@ func cmuxScreenLooksInteractive(screen string) bool {
 		}
 	}
 	return strings.Contains(screen, "›")
+}
+
+func cmuxPaneUsesCodex(pane interactivePane) bool {
+	if pane.CLIName != "" {
+		return agent.CLIExecutableName(pane.CLIName) == "codex"
+	}
+	return len(pane.Command) > 0 && pane.Command[0] == "codex"
 }
 
 func parseCmuxRef(output []byte, refType string) (string, error) {
@@ -780,7 +838,9 @@ func buildWeztermInteractivePaneScript(opts weztermLaunchOptions, panes []intera
 	b.WriteString("  pane_id=\"$1\"\n")
 	b.WriteString("  prompt=\"$2\"\n")
 	b.WriteString("  (\n")
-	b.WriteString("    sleep 2\n")
+	b.WriteString("    sleep ")
+	b.WriteString(shellSleepSeconds(opts.PromptDelay))
+	b.WriteString("\n")
 	b.WriteString("    printf '%s' \"$prompt\" | wezterm cli --class ")
 	b.WriteString(shellQuote(opts.Class))
 	b.WriteString(" send-text --no-paste --pane-id \"$pane_id\"\n")
@@ -840,7 +900,7 @@ func buildCmuxLaunchCommands(opts cmuxLaunchOptions, commands [][]string) ([][]s
 	workspaceRef := "<workspace-ref-from-new-workspace-output>"
 
 	// Create panes for additional commands
-	for i, cmd := range commands[1:] {
+	for i, paneCommand := range commands[1:] {
 		direction := "right"
 		if i%2 == 1 {
 			direction = "down"
@@ -852,7 +912,7 @@ func buildCmuxLaunchCommands(opts cmuxLaunchOptions, commands [][]string) ([][]s
 			"--workspace", workspaceRef,
 		}
 		cmds = append(cmds, paneArgs)
-		cmds = append(cmds, []string{"cmux", "send", "--workspace", workspaceRef, "--surface", fmt.Sprintf("<surface-ref-%d-from-new-pane-output>", i+1), shellJoin(cmd)})
+		cmds = append(cmds, []string{"cmux", "send", "--workspace", workspaceRef, "--surface", fmt.Sprintf("<surface-ref-%d-from-new-pane-output>", i+1), shellJoin(paneCommand)})
 		cmds = append(cmds, []string{"cmux", "send-key", "--workspace", workspaceRef, "--surface", fmt.Sprintf("<surface-ref-%d-from-new-pane-output>", i+1), "enter"})
 	}
 
@@ -932,27 +992,8 @@ func pairingSkillPrompt(roleOrReviewerID, boardPath string, yolo bool) string {
 	return prompt
 }
 
-func pairingInteractiveCLICommand(cliName string) []string {
-	switch cliName {
-	case "claude":
-		return []string{"claude"}
-	case "codex":
-		return []string{"codex"}
-	case "codex-acp":
-		return []string{"codex"}
-	case "opencode":
-		return []string{"opencode"}
-	case "opencode-acp":
-		return []string{"opencode"}
-	case "gemini":
-		return []string{"gemini"}
-	case "mistral":
-		return []string{"vibe"}
-	case "kimi":
-		return []string{"kimi"}
-	default:
-		return []string{cliName}
-	}
+func pairingInteractivePane(cliName, prompt string) interactivePane {
+	return interactivePane{CLIName: cliName, Command: agent.InteractiveCLICommand(cliName), Prompt: prompt}
 }
 
 func parseReviewerLaunchSpec(spec string) (string, string, error) {
@@ -986,6 +1027,15 @@ func shellQuote(s string) string {
 		return "''"
 	}
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+func shellSleepSeconds(duration time.Duration) string {
+	if duration%time.Second == 0 {
+		return fmt.Sprintf("%d", int(duration/time.Second))
+	}
+	value := fmt.Sprintf("%.3f", duration.Seconds())
+	value = strings.TrimRight(value, "0")
+	return strings.TrimRight(value, ".")
 }
 
 func launchShell() string {
@@ -1026,6 +1076,7 @@ func init() {
 	launchWeztermAdversarialPairingCmd.Flags().String("doer-cli", "codex", "coding CLI for the doer session")
 	launchWeztermAdversarialPairingCmd.Flags().String("goal", "", "create the blackboard with this goal when it does not exist")
 	launchWeztermAdversarialPairingCmd.Flags().StringArray("reviewer", nil, "reviewer CLI or id=cli; repeat for multiple reviewers (default: codex, codex-2=codex)")
+	launchWeztermAdversarialPairingCmd.Flags().Duration("prompt-delay", 2*time.Second, "delay before injecting adversarial-pairing prompts into WezTerm panes")
 	launchWeztermAdversarialPairingCmd.Flags().Bool("yolo", false, "pass yolo to the doer adversarial-pairing invocation")
 
 	launchCmuxMASCmd.Flags().String("preset", "technical-spec", "role preset: technical-spec, functional-spec, general-objective")

--- a/cmd/liza/cmd_launch_test.go
+++ b/cmd/liza/cmd_launch_test.go
@@ -1,0 +1,776 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func TestBuildWeztermPaneScriptLaunchesSplitsThenPrimary(t *testing.T) {
+	opts := weztermLaunchOptions{
+		Class: "liza-mas-test",
+		CWD:   "/tmp/project root",
+	}
+	script := buildWeztermPaneScript(opts, [][]string{
+		{"liza", "tui"},
+		{"liza", "agent", "orchestrator"},
+		{"liza", "agent", "coder"},
+	})
+
+	for _, want := range []string{
+		"wezterm cli split-pane --right --cwd '/tmp/project root' -- 'liza' 'agent' 'orchestrator'",
+		"wezterm cli split-pane --bottom --cwd '/tmp/project root' -- 'liza' 'agent' 'coder'",
+		"exec 'liza' 'tui'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q\nscript:\n%s", want, script)
+		}
+	}
+}
+
+func TestBuildWeztermInteractivePaneScriptStartsCLIsWithInitialPrompts(t *testing.T) {
+	opts := weztermLaunchOptions{
+		Class: "liza-adversarial",
+		CWD:   "/tmp/project",
+	}
+	script := buildWeztermInteractivePaneScript(opts, []interactivePane{
+		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("doer", "/tmp/board.md", false)},
+		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)},
+	})
+
+	for _, want := range []string{
+		"printf '%s' \"$prompt\" | wezterm cli --class 'liza-adversarial' send-text --no-paste --pane-id \"$pane_id\"",
+		"printf '\\r' | wezterm cli --class 'liza-adversarial' send-text --no-paste --pane-id \"$pane_id\"",
+		"pane_id_1=$(wezterm cli --class 'liza-adversarial' split-pane --right --cwd '/tmp/project' -- 'codex')",
+		"wezterm_liza_send_prompt \"$pane_id_1\" '$adversarial-pairing reviewer-codex /tmp/board.md'",
+		"wezterm_liza_send_prompt \"$WEZTERM_PANE\" '$adversarial-pairing doer /tmp/board.md'",
+		"exec 'codex'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q\nscript:\n%s", want, script)
+		}
+	}
+}
+
+func TestPairingSkillPromptUsesCodexSkillTrigger(t *testing.T) {
+	got := pairingSkillPrompt("doer", "/tmp/board.md", true)
+	want := "$adversarial-pairing doer /tmp/board.md yolo"
+	if got != want {
+		t.Fatalf("prompt = %q, want %q", got, want)
+	}
+}
+
+func TestAdversarialPairingDefaultsToThreeCodexPanes(t *testing.T) {
+	tmpDir := t.TempDir()
+	boardPath := filepath.Join(tmpDir, ".liza", "adversarial", "board.md")
+	resetRootCmdForTest(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{
+		"launch", "wezterm", "adversarial-pairing", boardPath,
+		"--goal", "Fix retry client",
+		"--dry-run",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("command returned error: %v\noutput:\n%s", err, out.String())
+	}
+	output := out.String()
+	for _, want := range []string{
+		"'codex'",
+		"$adversarial-pairing doer " + boardPath,
+		"$adversarial-pairing reviewer-codex " + boardPath,
+		"$adversarial-pairing reviewer-codex-2 " + boardPath,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, output)
+		}
+	}
+}
+
+func TestPairingInteractiveCLICommandMapsACPToInteractiveBaseCLI(t *testing.T) {
+	cmd := pairingInteractiveCLICommand("codex-acp")
+	got := strings.Join(cmd, "\x00")
+	if got != "codex" {
+		t.Fatalf("command = %q, want codex", got)
+	}
+}
+
+func TestRunWeztermInteractiveLaunchInjectsPromptsWithNoPasteSubmit(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("create fake bin dir: %v", err)
+	}
+	logPath := filepath.Join(tmpDir, "wezterm.log")
+	counterPath := filepath.Join(tmpDir, "pane-counter")
+	if err := os.WriteFile(counterPath, []byte("100"), 0644); err != nil {
+		t.Fatalf("write pane counter: %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "wezterm"), `#!/bin/sh
+log="$LIZA_FAKE_WEZTERM_LOG"
+counter="$LIZA_FAKE_WEZTERM_COUNTER"
+if [ "$1" = "start" ]; then
+  echo "START $*" >> "$log"
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+  shift
+  PATH="$LIZA_FAKE_WEZTERM_BINDIR:$PATH" WEZTERM_PANE=primary "$@" >> "$log" 2>&1 &
+  exit 0
+fi
+if [ "$1" = "cli" ]; then
+  shift
+  class=""
+  if [ "$1" = "--class" ]; then
+    class="$2"
+    shift 2
+  fi
+  subcommand="$1"
+  shift
+  case "$subcommand" in
+    split-pane)
+      pane_id=$(cat "$counter")
+      next=$((pane_id + 1))
+      echo "$next" > "$counter"
+      echo "SPLIT class=$class pane=$pane_id args=$*" >> "$log"
+      echo "$pane_id"
+      ;;
+    send-text)
+      pane_id=""
+      while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--pane-id" ]; then
+          pane_id="$2"
+          shift 2
+          continue
+        fi
+        shift
+      done
+      payload_hex=$(od -An -tx1 | tr -d ' \n')
+      echo "SEND class=$class pane=$pane_id hex=$payload_hex" >> "$log"
+      ;;
+  esac
+fi
+`)
+	writeExecutable(t, filepath.Join(binDir, "codex"), `#!/bin/sh
+echo "CODEX $*" >> "$LIZA_FAKE_WEZTERM_LOG"
+sleep 4
+`)
+	shellPath := filepath.Join(binDir, "test-shell")
+	writeExecutable(t, shellPath, `#!/bin/sh
+if [ "$1" = "-lc" ]; then
+  shift
+  exec /bin/sh -c "$1"
+fi
+exec /bin/sh "$@"
+`)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SHELL", shellPath)
+	t.Setenv("LIZA_FAKE_WEZTERM_BINDIR", binDir)
+	t.Setenv("LIZA_FAKE_WEZTERM_LOG", logPath)
+	t.Setenv("LIZA_FAKE_WEZTERM_COUNTER", counterPath)
+
+	primaryPrompt := pairingSkillPrompt("doer", "/tmp/board.md", false)
+	splitPrompt := pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)
+	err := runWeztermInteractiveLaunch(launchWeztermAdversarialPairingCmd, weztermLaunchOptions{
+		Class:     "liza-adversarial-test",
+		Workspace: "liza-adversarial-test",
+		CWD:       tmpDir,
+	}, []interactivePane{
+		{Command: []string{"codex"}, Prompt: primaryPrompt},
+		{Command: []string{"codex"}, Prompt: splitPrompt},
+	})
+	if err != nil {
+		t.Fatalf("runWeztermInteractiveLaunch returned error: %v", err)
+	}
+
+	log := waitForFileContent(t, logPath, func(content string) bool {
+		return strings.Contains(content, "pane=primary hex="+hex.EncodeToString([]byte(primaryPrompt))) &&
+			strings.Contains(content, "pane=100 hex="+hex.EncodeToString([]byte(splitPrompt))) &&
+			strings.Count(content, "hex=0d") >= 2
+	})
+	for _, want := range []string{
+		"SPLIT class=liza-adversarial-test pane=100",
+		"SEND class=liza-adversarial-test pane=primary hex=" + hex.EncodeToString([]byte(primaryPrompt)),
+		"SEND class=liza-adversarial-test pane=100 hex=" + hex.EncodeToString([]byte(splitPrompt)),
+		"CODEX",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("fake wezterm log missing %q\nlog:\n%s", want, log)
+		}
+	}
+}
+
+func TestParseReviewerLaunchSpec(t *testing.T) {
+	id, cliName, err := parseReviewerLaunchSpec("openai=codex")
+	if err != nil {
+		t.Fatalf("parseReviewerLaunchSpec returned error: %v", err)
+	}
+	if id != "openai" || cliName != "codex" {
+		t.Fatalf("id, cli = %q, %q; want openai, codex", id, cliName)
+	}
+
+	id, cliName, err = parseReviewerLaunchSpec("reviewer-claude")
+	if err != nil {
+		t.Fatalf("parseReviewerLaunchSpec returned error: %v", err)
+	}
+	if id != "claude" || cliName != "claude" {
+		t.Fatalf("id, cli = %q, %q; want claude, claude", id, cliName)
+	}
+}
+
+func TestInitialAdversarialPairingBlackboardIncludesGoalAndYolo(t *testing.T) {
+	now := time.Date(2026, 6, 11, 4, 50, 0, 0, time.UTC)
+	content := initialAdversarialPairingBlackboard("Fix retry client", true, now)
+
+	for _, want := range []string{
+		"phase: DRAFT",
+		"yolo: true",
+		`phase_updated_at: "2026-06-11T04:50:00Z"`,
+		"## Goal\n\nFix retry client",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("blackboard missing %q\ncontent:\n%s", want, content)
+		}
+	}
+}
+
+func TestEnsureAdversarialPairingBlackboardRequiresGoalWhenMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".liza", "adversarial", "retry-client.md")
+	err := ensureAdversarialPairingBlackboard(path, "", false, launchWeztermAdversarialPairingCmd)
+	if err == nil {
+		t.Fatal("expected missing blackboard without goal to fail")
+	}
+	if !strings.Contains(err.Error(), "pass --goal") {
+		t.Fatalf("error = %q, want --goal guidance", err.Error())
+	}
+}
+
+func TestEnsureAdversarialPairingBlackboardCreatesMissingBoard(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".liza", "adversarial", "retry-client.md")
+	if err := ensureAdversarialPairingBlackboard(path, "Fix retry client", false, launchWeztermAdversarialPairingCmd); err != nil {
+		t.Fatalf("ensureAdversarialPairingBlackboard returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read created blackboard: %v", err)
+	}
+	if !strings.Contains(string(data), "Fix retry client") {
+		t.Fatalf("created blackboard missing goal:\n%s", string(data))
+	}
+}
+
+func TestResolveLaunchPathUsesProvidedWorkingDirectory(t *testing.T) {
+	got, err := resolveLaunchPath("/tmp/project", ".liza/adversarial/retry-client.md")
+	if err != nil {
+		t.Fatalf("resolveLaunchPath returned error: %v", err)
+	}
+	want := filepath.Clean("/tmp/project/.liza/adversarial/retry-client.md")
+	if got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestBuildCmuxLaunchCommandsCreatesWorkspaceAndPanes(t *testing.T) {
+	opts := cmuxLaunchOptions{
+		Workspace: "liza-mas-test",
+		CWD:       "/tmp/project root",
+	}
+	cmds, err := buildCmuxLaunchCommands(opts, [][]string{
+		{"liza", "tui"},
+		{"liza", "agent", "orchestrator"},
+		{"liza", "agent", "coder"},
+	})
+	if err != nil {
+		t.Fatalf("buildCmuxLaunchCommands returned error: %v", err)
+	}
+
+	// Check workspace creation command
+	if len(cmds) < 1 {
+		t.Fatal("expected at least 1 command")
+	}
+	createCmd := cmds[0]
+	if createCmd[0] != "cmux" || createCmd[1] != "new-workspace" {
+		t.Fatalf("first command should be cmux new-workspace, got %v", createCmd)
+	}
+	if !containsString(createCmd, "--name") || !containsString(createCmd, "liza-mas-test") {
+		t.Fatal("workspace creation command missing --name or workspace name")
+	}
+	if !containsString(createCmd, "--cwd") || !containsString(createCmd, "/tmp/project root") {
+		t.Fatal("workspace creation command missing --cwd or CWD")
+	}
+
+	// Check pane creation commands use workspace ref placeholder
+	if len(cmds) < 3 {
+		t.Fatal("expected at least 3 commands (workspace + 2 panes)")
+	}
+	pane1Cmd := cmds[1]
+	if pane1Cmd[0] != "cmux" || pane1Cmd[1] != "new-pane" {
+		t.Fatalf("second command should be cmux new-pane, got %v", pane1Cmd)
+	}
+	if !containsString(pane1Cmd, "--direction") || !containsString(pane1Cmd, "right") {
+		t.Fatal("first pane command missing --direction right")
+	}
+	// Check that it uses the workspace ref placeholder, not the name
+	if !containsString(pane1Cmd, "<workspace-ref-from-new-workspace-output>") {
+		t.Fatal("pane command should use workspace ref placeholder")
+	}
+	if containsString(pane1Cmd, "liza-mas-test") && !containsString(pane1Cmd, "--name") {
+		t.Fatal("pane command should not use workspace name in --workspace argument")
+	}
+
+	pane2Cmd := cmds[4]
+	if pane2Cmd[0] != "cmux" || pane2Cmd[1] != "new-pane" {
+		t.Fatalf("third command should be cmux new-pane, got %v", pane2Cmd)
+	}
+	if !containsString(pane2Cmd, "--direction") || !containsString(pane2Cmd, "down") {
+		t.Fatal("second pane command missing --direction down")
+	}
+}
+
+func TestBuildCmuxInteractiveLaunchCommandsSendsPromptsWithEnter(t *testing.T) {
+	opts := cmuxLaunchOptions{
+		Workspace: "liza-adversarial",
+		CWD:       "/tmp/project",
+	}
+	cmds, err := buildCmuxInteractiveLaunchCommands(opts, []interactivePane{
+		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("doer", "/tmp/board.md", false)},
+		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)},
+	})
+	if err != nil {
+		t.Fatalf("buildCmuxInteractiveLaunchCommands returned error: %v", err)
+	}
+
+	// Check workspace creation
+	if len(cmds) < 1 {
+		t.Fatal("expected at least 1 command")
+	}
+	createCmd := cmds[0]
+	if createCmd[0] != "cmux" || createCmd[1] != "new-workspace" {
+		t.Fatalf("first command should be cmux new-workspace, got %v", createCmd)
+	}
+
+	// Check that we send startup commands and prompts separately.
+	promptSendCount := 0
+	startupSendCount := 0
+	enterCount := 0
+	for _, cmd := range cmds {
+		if len(cmd) > 0 && cmd[0] == "cmux" {
+			if len(cmd) > 1 && cmd[1] == "send" {
+				cmdStr := strings.Join(cmd, " ")
+				if strings.Contains(cmdStr, "$adversarial-pairing") {
+					promptSendCount++
+				} else if strings.Contains(cmdStr, "'codex'") {
+					startupSendCount++
+				} else {
+					t.Fatalf("unexpected cmux send command: %v", cmd)
+				}
+				// Check that it uses workspace ref placeholder, not the name
+				if !containsString(cmd, "<workspace-ref-from-new-workspace-output>") {
+					t.Fatal("send command should use workspace ref placeholder")
+				}
+				if containsString(cmd, "liza-adversarial") && !containsString(cmd, "--name") {
+					t.Fatal("send command should not use workspace name in --workspace argument")
+				}
+			}
+			if len(cmd) > 1 && cmd[1] == "send-key" {
+				enterCount++
+				if !containsString(cmd, "enter") {
+					t.Fatal("send-key command missing enter")
+				}
+				// Check that it uses workspace ref placeholder, not the name
+				if !containsString(cmd, "<workspace-ref-from-new-workspace-output>") {
+					t.Fatal("send-key command should use workspace ref placeholder")
+				}
+				if containsString(cmd, "liza-adversarial") && !containsString(cmd, "--name") {
+					t.Fatal("send-key command should not use workspace name in --workspace argument")
+				}
+			}
+		}
+	}
+
+	if promptSendCount != 2 {
+		t.Fatalf("expected 2 prompt send commands (one per pane), got %d", promptSendCount)
+	}
+	if startupSendCount != 1 {
+		t.Fatalf("expected 1 startup send command for the additional pane, got %d", startupSendCount)
+	}
+	if enterCount != 3 {
+		t.Fatalf("expected 3 send-key enter commands (startup plus one prompt per pane), got %d", enterCount)
+	}
+}
+
+func TestCmuxMASDefaultsToTechnicalSpecPreset(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create a minimal Liza project structure
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".liza"), 0755); err != nil {
+		t.Fatalf("create .liza dir: %v", err)
+	}
+	statePath := filepath.Join(tmpDir, ".liza", "state.yaml")
+	stateContent := `version: 1
+goal:
+  id: goal-test
+  description: "Test goal"
+  status: IN_PROGRESS
+tasks: []
+agents: {}
+`
+	if err := os.WriteFile(statePath, []byte(stateContent), 0644); err != nil {
+		t.Fatalf("write state.yaml: %v", err)
+	}
+
+	resetRootCmdForTest(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{
+		"launch", "cmux", "mas",
+		"--cwd", tmpDir,
+		"--dry-run",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("command returned error: %v\noutput:\n%s", err, out.String())
+	}
+	output := out.String()
+	for _, want := range []string{
+		"cmux", "new-workspace",
+		"liza", "tui",
+		"liza", "agent", "orchestrator",
+		"liza", "agent", "code-planner",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, output)
+		}
+	}
+}
+
+func TestCmuxAdversarialPairingDefaultsToThreeCodexPanes(t *testing.T) {
+	tmpDir := t.TempDir()
+	boardPath := filepath.Join(tmpDir, ".liza", "adversarial", "board.md")
+	resetRootCmdForTest(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{
+		"launch", "cmux", "adversarial-pairing", boardPath,
+		"--goal", "Fix retry client",
+		"--cwd", tmpDir,
+		"--dry-run",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("command returned error: %v\noutput:\n%s", err, out.String())
+	}
+	output := out.String()
+	for _, want := range []string{
+		"cmux", "new-workspace",
+		"codex",
+		"$adversarial-pairing doer " + boardPath,
+		"$adversarial-pairing reviewer-codex " + boardPath,
+		"$adversarial-pairing reviewer-codex-2 " + boardPath,
+		"send-key", "enter",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, output)
+		}
+	}
+}
+
+func TestRunCmuxInteractiveLaunchInjectsPromptsWithSendAndEnter(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("create fake bin dir: %v", err)
+	}
+	logPath := filepath.Join(tmpDir, "cmux.log")
+	writeExecutable(t, filepath.Join(binDir, "cmux"), `#!/bin/sh
+log="$LIZA_FAKE_CMUX_LOG"
+if [ "$1" = "new-workspace" ]; then
+  echo "NEW_WORKSPACE $*" >> "$log"
+  # Return a workspace reference
+  echo "OK workspace:42"
+  exit 0
+fi
+if [ "$1" = "new-pane" ]; then
+  # Check that --workspace uses the ref, not the name
+  for arg in "$@"; do
+    if [ "$arg" = "--workspace" ]; then
+      next_arg=""
+      found=0
+      for a in "$@"; do
+        if [ "$found" = "1" ]; then
+          next_arg="$a"
+          break
+        fi
+        if [ "$a" = "--workspace" ]; then
+          found=1
+        fi
+      done
+	      if [ "$next_arg" != "workspace:42" ]; then
+	        echo "ERROR: new-pane used wrong workspace handle: $next_arg" >> "$log"
+	        exit 1
+	      fi
+    fi
+  done
+  echo "NEW_PANE $*" >> "$log"
+  # Return a surface reference
+  echo "OK surface:7 pane:7 workspace:42"
+  exit 0
+fi
+if [ "$1" = "list-pane-surfaces" ]; then
+  echo "LIST_PANE_SURFACES $*" >> "$log"
+  echo "* surface:5 'codex' [selected]"
+  exit 0
+fi
+if [ "$1" = "send" ]; then
+  # Check that --workspace uses the ref, not the name
+  for arg in "$@"; do
+    if [ "$arg" = "--workspace" ]; then
+      next_arg=""
+      found=0
+      for a in "$@"; do
+        if [ "$found" = "1" ]; then
+          next_arg="$a"
+          break
+        fi
+        if [ "$a" = "--workspace" ]; then
+          found=1
+        fi
+      done
+	      if [ "$next_arg" != "workspace:42" ]; then
+	        echo "ERROR: send used wrong workspace handle: $next_arg" >> "$log"
+	        exit 1
+	      fi
+    fi
+  done
+  surface_arg=""
+  found_surface=0
+  for a in "$@"; do
+    if [ "$found_surface" = "1" ]; then
+      surface_arg="$a"
+      break
+    fi
+    if [ "$a" = "--surface" ]; then
+      found_surface=1
+    fi
+  done
+  if [ "$surface_arg" != "surface:5" ] && [ "$surface_arg" != "surface:7" ]; then
+    echo "ERROR: send used wrong surface handle: $surface_arg" >> "$log"
+    exit 1
+  fi
+  echo "SEND $*" >> "$log"
+  exit 0
+fi
+if [ "$1" = "send-key" ]; then
+  # Check that --workspace uses the ref, not the name
+  for arg in "$@"; do
+    if [ "$arg" = "--workspace" ]; then
+      next_arg=""
+      found=0
+      for a in "$@"; do
+        if [ "$found" = "1" ]; then
+          next_arg="$a"
+          break
+        fi
+        if [ "$a" = "--workspace" ]; then
+          found=1
+        fi
+      done
+	      if [ "$next_arg" != "workspace:42" ]; then
+	        echo "ERROR: send-key used wrong workspace handle: $next_arg" >> "$log"
+	        exit 1
+	      fi
+    fi
+  done
+  surface_arg=""
+  found_surface=0
+  for a in "$@"; do
+    if [ "$found_surface" = "1" ]; then
+      surface_arg="$a"
+      break
+    fi
+    if [ "$a" = "--surface" ]; then
+      found_surface=1
+    fi
+  done
+  if [ "$surface_arg" != "surface:5" ] && [ "$surface_arg" != "surface:7" ]; then
+    echo "ERROR: send-key used wrong surface handle: $surface_arg" >> "$log"
+    exit 1
+  fi
+  echo "SEND_KEY $*" >> "$log"
+  exit 0
+fi
+if [ "$1" = "read-screen" ]; then
+  echo "READ_SCREEN $*" >> "$log"
+  echo "OpenAI Codex"
+  echo "›"
+  exit 0
+fi
+`)
+	writeExecutable(t, filepath.Join(binDir, "codex"), `#!/bin/sh
+echo "CODEX $*" >> "$LIZA_FAKE_CMUX_LOG"
+sleep 1
+`)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("LIZA_FAKE_CMUX_LOG", logPath)
+
+	primaryPrompt := pairingSkillPrompt("doer", "/tmp/board.md", false)
+	splitPrompt := pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)
+	err := runCmuxInteractiveLaunch(&cobra.Command{}, cmuxLaunchOptions{
+		Workspace: "liza-adversarial-test",
+		CWD:       tmpDir,
+	}, []interactivePane{
+		{Command: []string{"codex"}, Prompt: primaryPrompt},
+		{Command: []string{"codex"}, Prompt: splitPrompt},
+	})
+	if err != nil {
+		t.Fatalf("runCmuxInteractiveLaunch returned error: %v", err)
+	}
+
+	log := waitForFileContent(t, logPath, func(content string) bool {
+		return strings.Contains(content, "NEW_WORKSPACE") &&
+			strings.Contains(content, "NEW_PANE") &&
+			strings.Contains(content, "SEND") &&
+			strings.Contains(content, "SEND_KEY")
+	})
+	// Check that no errors occurred
+	if strings.Contains(log, "ERROR:") {
+		t.Fatalf("fake cmux detected errors:\nlog:\n%s", log)
+	}
+	for _, want := range []string{
+		"NEW_WORKSPACE",
+		"NEW_PANE",
+		primaryPrompt,
+		"SEND_KEY",
+		splitPrompt,
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("fake cmux log missing %q\nlog:\n%s", want, log)
+		}
+	}
+}
+
+func TestParseCmuxRef(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		output  string
+		refType string
+		want    string
+	}{
+		{name: "workspace ok prefix", output: "OK workspace:42\n", refType: "workspace", want: "workspace:42"},
+		{name: "surface pane workspace", output: "OK surface:7 pane:7 workspace:42\n", refType: "surface", want: "surface:7"},
+		{name: "bare ref", output: "workspace:3\n", refType: "workspace", want: "workspace:3"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCmuxRef([]byte(tt.output), tt.refType)
+			if err != nil {
+				t.Fatalf("parseCmuxRef returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ref = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCmuxScreenLooksInteractiveWaitsForReadyPrompt(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		screen string
+		ready  bool
+	}{
+		{
+			name: "not codex",
+			screen: `
+zsh
+›
+`,
+		},
+		{
+			name: "codex still starting mcps",
+			screen: `
+OpenAI Codex
+• Starting MCP servers...
+› Explain this codebase
+`,
+		},
+		{
+			name: "codex busy",
+			screen: `
+OpenAI Codex
+esc to interrupt
+• Working
+`,
+		},
+		{
+			name: "codex ready",
+			screen: `
+OpenAI Codex
+› Explain this codebase
+`,
+			ready: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cmuxScreenLooksInteractive(tt.screen); got != tt.ready {
+				t.Fatalf("cmuxScreenLooksInteractive() = %v, want %v", got, tt.ready)
+			}
+		})
+	}
+}
+
+func TestCmuxScreenNeedsHostSelection(t *testing.T) {
+	screen := `
+Pick host for agent
+> local
+  genesis
+←↓↑→ navigate • enter submit
+`
+	if !cmuxScreenNeedsHostSelection(screen) {
+		t.Fatal("expected host selection prompt to be detected")
+	}
+	if cmuxScreenNeedsHostSelection("OpenAI Codex\n› Explain this codebase") {
+		t.Fatal("did not expect normal codex prompt to need host selection")
+	}
+}
+
+func TestCmuxPromptStillPending(t *testing.T) {
+	prompt := "$adversarial-pairing doer /tmp/board.md"
+	if !cmuxPromptStillPending("› "+prompt+"\n\n  gpt-5.5 high", prompt) {
+		t.Fatal("expected prompt to be detected as still pending")
+	}
+	if cmuxPromptStillPending("› "+prompt+"\n\n• Working (1s • esc to interrupt)", prompt) {
+		t.Fatal("did not expect working prompt to be detected as still pending")
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func waitForFileContent(t *testing.T, path string, predicate func(string) bool) string {
+	t.Helper()
+	deadline := time.Now().Add(8 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		data, _ := os.ReadFile(path)
+		last = string(data)
+		if predicate(last) {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for expected file content in %s\nlast content:\n%s", path, last)
+	return ""
+}

--- a/cmd/liza/cmd_launch_test.go
+++ b/cmd/liza/cmd_launch_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/hex"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/liza-mas/liza/internal/agent"
 	"github.com/spf13/cobra"
 )
 
@@ -36,12 +38,13 @@ func TestBuildWeztermPaneScriptLaunchesSplitsThenPrimary(t *testing.T) {
 
 func TestBuildWeztermInteractivePaneScriptStartsCLIsWithInitialPrompts(t *testing.T) {
 	opts := weztermLaunchOptions{
-		Class: "liza-adversarial",
-		CWD:   "/tmp/project",
+		Class:       "liza-adversarial",
+		CWD:         "/tmp/project",
+		PromptDelay: 2 * time.Second,
 	}
 	script := buildWeztermInteractivePaneScript(opts, []interactivePane{
-		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("doer", "/tmp/board.md", false)},
-		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)},
+		{Command: agent.InteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("doer", "/tmp/board.md", false)},
+		{Command: agent.InteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)},
 	})
 
 	for _, want := range []string{
@@ -55,6 +58,21 @@ func TestBuildWeztermInteractivePaneScriptStartsCLIsWithInitialPrompts(t *testin
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q\nscript:\n%s", want, script)
 		}
+	}
+}
+
+func TestBuildWeztermInteractivePaneScriptUsesPromptDelay(t *testing.T) {
+	opts := weztermLaunchOptions{
+		Class:       "liza-adversarial",
+		CWD:         "/tmp/project",
+		PromptDelay: 1500 * time.Millisecond,
+	}
+	script := buildWeztermInteractivePaneScript(opts, []interactivePane{
+		pairingInteractivePane("codex", pairingSkillPrompt("doer", "/tmp/board.md", false)),
+	})
+
+	if !strings.Contains(script, "    sleep 1.5\n") {
+		t.Fatalf("script missing custom prompt delay\nscript:\n%s", script)
 	}
 }
 
@@ -96,7 +114,7 @@ func TestAdversarialPairingDefaultsToThreeCodexPanes(t *testing.T) {
 }
 
 func TestPairingInteractiveCLICommandMapsACPToInteractiveBaseCLI(t *testing.T) {
-	cmd := pairingInteractiveCLICommand("codex-acp")
+	cmd := agent.InteractiveCLICommand("codex-acp")
 	got := strings.Join(cmd, "\x00")
 	if got != "codex" {
 		t.Fatalf("command = %q, want codex", got)
@@ -179,12 +197,13 @@ exec /bin/sh "$@"
 	primaryPrompt := pairingSkillPrompt("doer", "/tmp/board.md", false)
 	splitPrompt := pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)
 	err := runWeztermInteractiveLaunch(launchWeztermAdversarialPairingCmd, weztermLaunchOptions{
-		Class:     "liza-adversarial-test",
-		Workspace: "liza-adversarial-test",
-		CWD:       tmpDir,
+		Class:       "liza-adversarial-test",
+		Workspace:   "liza-adversarial-test",
+		CWD:         tmpDir,
+		PromptDelay: 2 * time.Second,
 	}, []interactivePane{
-		{Command: []string{"codex"}, Prompt: primaryPrompt},
-		{Command: []string{"codex"}, Prompt: splitPrompt},
+		pairingInteractivePane("codex", primaryPrompt),
+		pairingInteractivePane("codex", splitPrompt),
 	})
 	if err != nil {
 		t.Fatalf("runWeztermInteractiveLaunch returned error: %v", err)
@@ -340,8 +359,8 @@ func TestBuildCmuxInteractiveLaunchCommandsSendsPromptsWithEnter(t *testing.T) {
 		CWD:       "/tmp/project",
 	}
 	cmds, err := buildCmuxInteractiveLaunchCommands(opts, []interactivePane{
-		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("doer", "/tmp/board.md", false)},
-		{Command: pairingInteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)},
+		{Command: agent.InteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("doer", "/tmp/board.md", false)},
+		{Command: agent.InteractiveCLICommand("codex"), Prompt: pairingSkillPrompt("reviewer-codex", "/tmp/board.md", false)},
 	})
 	if err != nil {
 		t.Fatalf("buildCmuxInteractiveLaunchCommands returned error: %v", err)
@@ -408,6 +427,7 @@ func TestBuildCmuxInteractiveLaunchCommandsSendsPromptsWithEnter(t *testing.T) {
 
 func TestCmuxMASDefaultsToTechnicalSpecPreset(t *testing.T) {
 	tmpDir := t.TempDir()
+	initGitRepoForLaunchTest(t, tmpDir)
 	// Create a minimal Liza project structure
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".liza"), 0755); err != nil {
 		t.Fatalf("create .liza dir: %v", err)
@@ -448,6 +468,27 @@ agents: {}
 		if !strings.Contains(output, want) {
 			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, output)
 		}
+	}
+}
+
+func TestMASLaunchRejectsExplicitCWDOutsideLizaProject(t *testing.T) {
+	tmpDir := t.TempDir()
+	resetRootCmdForTest(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{
+		"launch", "cmux", "mas",
+		"--cwd", tmpDir,
+		"--dry-run",
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected command to reject non-project --cwd\noutput:\n%s", out.String())
+	}
+	if !strings.Contains(err.Error(), "resolve --cwd git root") {
+		t.Fatalf("error = %q, want --cwd git root validation", err)
 	}
 }
 
@@ -628,8 +669,8 @@ sleep 1
 		Workspace: "liza-adversarial-test",
 		CWD:       tmpDir,
 	}, []interactivePane{
-		{Command: []string{"codex"}, Prompt: primaryPrompt},
-		{Command: []string{"codex"}, Prompt: splitPrompt},
+		pairingInteractivePane("codex", primaryPrompt),
+		pairingInteractivePane("codex", splitPrompt),
 	})
 	if err != nil {
 		t.Fatalf("runCmuxInteractiveLaunch returned error: %v", err)
@@ -655,6 +696,100 @@ sleep 1
 		if !strings.Contains(log, want) {
 			t.Fatalf("fake cmux log missing %q\nlog:\n%s", want, log)
 		}
+	}
+}
+
+func TestRunCmuxInteractiveLaunchAllowsNonCodexPanes(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("create fake bin dir: %v", err)
+	}
+	logPath := filepath.Join(tmpDir, "cmux.log")
+	writeExecutable(t, filepath.Join(binDir, "cmux"), `#!/bin/sh
+log="$LIZA_FAKE_CMUX_LOG"
+if [ "$1" = "new-workspace" ]; then
+  echo "NEW_WORKSPACE $*" >> "$log"
+  echo "OK workspace:42"
+  exit 0
+fi
+if [ "$1" = "new-pane" ]; then
+  echo "NEW_PANE $*" >> "$log"
+  echo "OK surface:7 pane:7 workspace:42"
+  exit 0
+fi
+if [ "$1" = "list-pane-surfaces" ]; then
+  echo "LIST_PANE_SURFACES $*" >> "$log"
+  echo "* surface:5 'claude' [selected]"
+  exit 0
+fi
+if [ "$1" = "send" ]; then
+  echo "SEND $*" >> "$log"
+  exit 0
+fi
+if [ "$1" = "send-key" ]; then
+  echo "SEND_KEY $*" >> "$log"
+  exit 0
+fi
+if [ "$1" = "read-screen" ]; then
+  echo "READ_SCREEN $*" >> "$log"
+  exit 23
+fi
+`)
+	writeExecutable(t, filepath.Join(binDir, "claude"), `#!/bin/sh
+echo "CLAUDE $*" >> "$LIZA_FAKE_CMUX_LOG"
+sleep 1
+`)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("LIZA_FAKE_CMUX_LOG", logPath)
+
+	primaryPrompt := pairingSkillPrompt("doer", "/tmp/board.md", false)
+	splitPrompt := pairingSkillPrompt("reviewer-claude", "/tmp/board.md", false)
+	err := runCmuxInteractiveLaunch(&cobra.Command{}, cmuxLaunchOptions{
+		Workspace: "liza-adversarial-test",
+		CWD:       tmpDir,
+	}, []interactivePane{
+		pairingInteractivePane("claude", primaryPrompt),
+		pairingInteractivePane("claude", splitPrompt),
+	})
+	if err != nil {
+		t.Fatalf("runCmuxInteractiveLaunch returned error: %v", err)
+	}
+
+	log := waitForFileContent(t, logPath, func(content string) bool {
+		return strings.Contains(content, primaryPrompt) && strings.Contains(content, splitPrompt)
+	})
+	if strings.Contains(log, "READ_SCREEN") {
+		t.Fatalf("non-codex panes should not use Codex read-screen readiness scraping\nlog:\n%s", log)
+	}
+}
+
+func TestCmuxSendPromptReturnsReadScreenErrorForCodex(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("create fake bin dir: %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "cmux"), `#!/bin/sh
+if [ "$1" = "send" ]; then
+  exit 0
+fi
+if [ "$1" = "send-key" ]; then
+  exit 0
+fi
+if [ "$1" = "read-screen" ]; then
+  exit 9
+fi
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := cmuxSendPrompt("workspace:1", "surface:1", pairingInteractivePane("codex", "$adversarial-pairing doer /tmp/board.md"))
+	if err == nil {
+		t.Fatal("expected read-screen verification error")
+	}
+	if !strings.Contains(err.Error(), "verify cmux prompt submission") {
+		t.Fatalf("error = %q, want verification context", err)
 	}
 }
 
@@ -773,4 +908,12 @@ func waitForFileContent(t *testing.T, path string, predicate func(string) bool) 
 	}
 	t.Fatalf("timed out waiting for expected file content in %s\nlast content:\n%s", path, last)
 	return ""
+}
+
+func initGitRepoForLaunchTest(t *testing.T, dir string) {
+	t.Helper()
+	output, err := exec.Command("git", "-C", dir, "init").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, string(output))
+	}
 }

--- a/cmd/liza/cmd_launch_test.go
+++ b/cmd/liza/cmd_launch_test.go
@@ -111,6 +111,9 @@ func TestAdversarialPairingDefaultsToThreeCodexPanes(t *testing.T) {
 			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, output)
 		}
 	}
+	if _, err := os.Stat(boardPath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created blackboard or returned unexpected stat error: %v", err)
+	}
 }
 
 func TestPairingInteractiveCLICommandMapsACPToInteractiveBaseCLI(t *testing.T) {
@@ -262,7 +265,7 @@ func TestInitialAdversarialPairingBlackboardIncludesGoalAndYolo(t *testing.T) {
 
 func TestEnsureAdversarialPairingBlackboardRequiresGoalWhenMissing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".liza", "adversarial", "retry-client.md")
-	err := ensureAdversarialPairingBlackboard(path, "", false, launchWeztermAdversarialPairingCmd)
+	err := ensureAdversarialPairingBlackboard(path, "", false, false, launchWeztermAdversarialPairingCmd)
 	if err == nil {
 		t.Fatal("expected missing blackboard without goal to fail")
 	}
@@ -273,7 +276,7 @@ func TestEnsureAdversarialPairingBlackboardRequiresGoalWhenMissing(t *testing.T)
 
 func TestEnsureAdversarialPairingBlackboardCreatesMissingBoard(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".liza", "adversarial", "retry-client.md")
-	if err := ensureAdversarialPairingBlackboard(path, "Fix retry client", false, launchWeztermAdversarialPairingCmd); err != nil {
+	if err := ensureAdversarialPairingBlackboard(path, "Fix retry client", false, false, launchWeztermAdversarialPairingCmd); err != nil {
 		t.Fatalf("ensureAdversarialPairingBlackboard returned error: %v", err)
 	}
 	data, err := os.ReadFile(path)
@@ -282,6 +285,16 @@ func TestEnsureAdversarialPairingBlackboardCreatesMissingBoard(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "Fix retry client") {
 		t.Fatalf("created blackboard missing goal:\n%s", string(data))
+	}
+}
+
+func TestEnsureAdversarialPairingBlackboardDryRunDoesNotCreateMissingBoard(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".liza", "adversarial", "retry-client.md")
+	if err := ensureAdversarialPairingBlackboard(path, "Fix retry client", false, true, launchWeztermAdversarialPairingCmd); err != nil {
+		t.Fatalf("ensureAdversarialPairingBlackboard returned error: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created blackboard or returned unexpected stat error: %v", err)
 	}
 }
 
@@ -521,6 +534,9 @@ func TestCmuxAdversarialPairingDefaultsToThreeCodexPanes(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, output)
 		}
+	}
+	if _, err := os.Stat(boardPath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created blackboard or returned unexpected stat error: %v", err)
 	}
 }
 

--- a/cmd/liza/rootcmd_test_helpers_test.go
+++ b/cmd/liza/rootcmd_test_helpers_test.go
@@ -144,6 +144,7 @@ func resetCommandFlagsForTest(t *testing.T, cmd *cobra.Command) {
 	for _, name := range []string{
 		"agent-id", "changed-by", "json", "summary", "output-summary", "active",
 		"reason", "questions", "repair-operation", "repair-target", "repair-command", "repair-evidence", "repair-validation", "recoverability-command", "assign-to", "rebase-on", "allow-dirty",
+		"class", "workspace", "cwd", "dry-run", "preset", "role", "no-tui", "doer-cli", "goal", "reviewer", "prompt-delay", "yolo",
 		"spec", "config", "entry-point", "branch", "post-worktree-cmd", "copy-worktree-env-files", "auto-resume", "no-follow-up", "default-cli", "default-doer-cli", "default-reviewer-cli", "scip-search", "scip-search-plan", "cli", "claude", "codex", "opencode", "gemini", "mistral",
 		"state", "log", "file", "id", "desc", "done", "scope", "priority", "role-pair", "output", "tasks-file",
 		"profile", "include", "exclude", "tool", "install-dir", "dry-run", "yes", "global-dir", "agent-tools", "write-shell-profile", "agents", "project",

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -156,65 +156,64 @@ agents: {}
 
 ---
 
-## Step 6: Start the Watcher (Terminal 1)
+## Step 6: Launch the Agent Window
 
-Open a terminal for monitoring:
-
-```bash
-cd hello-cli
-liza tui
-```
-
-This monitors for anomalies, alerts, and auto-checkpoints on circuit-breaker triggers. Leave it running.
-
----
-
-## Step 7: Start the Orchestrator (Terminal 2)
+Start the functional-spec role set in one WezTerm window:
 
 ```bash
 cd hello-cli
-liza agent orchestrator
+liza launch wezterm mas --preset functional-spec
 ```
 
-Agent output is automatically persisted to `.liza/agent-outputs/` for later analysis, and prompt captures can be audited with `/context-engineering` when available (see [Analyzing Agent Logs](USAGE_MULTI_AGENTS.md#analyzing-agent-logs)). Pass `--no-log` to disable. Each agent command also accepts a `--cli` flag to select the coding agent (`claude`, `codex`, `codex-acp`, `gemini`, `mistral`, or `kimi`). When omitted, the default is resolved from role-specific config (`config.default_doer_cli` for doers and orchestrators, `config.default_reviewer_cli` for reviewers), then role-specific env (`LIZA_DEFAULT_DOER_CLI` for doers and orchestrators, `LIZA_DEFAULT_REVIEWER_CLI` for reviewers), then `config.default_cli`, then `LIZA_DEFAULT_CLI`, then `claude`.
+This opens `liza tui` plus panes for orchestrator, architect,
+architecture-reviewer, code-planner, code-plan-reviewer, coder, and
+code-reviewer. Agent output is automatically persisted to
+`.liza/agent-outputs/` for later analysis, and prompt captures can be audited
+with `/context-engineering` when available (see
+[Analyzing Agent Logs](USAGE_MULTI_AGENTS.md#analyzing-agent-logs)). Each agent
+command also accepts a `--cli` flag; pass it through the launcher when you want
+one backend for every role:
+
+```bash
+liza launch wezterm mas --preset functional-spec --cli codex
+```
+
+When `--cli` is omitted, each role resolves its backend from role-specific config
+(`config.default_doer_cli` for doers and orchestrators,
+`config.default_reviewer_cli` for reviewers), then role-specific env, then
+global defaults, then `claude`.
+
+**CMUX support:** Liza also supports CMUX as an alternative to WezTerm. Use
+`liza launch cmux mas` with the same flags to launch agents in CMUX panes
+instead of WezTerm.
 
 The Orchestrator will:
 1. Read `specs/vision.md`
-2. Create the initial code-planning task
+2. Create the initial architecture task
 3. Monitor sprint progress and create checkpoints
-
-Watch the blackboard update:
-```bash
-# In another terminal
-watch -n 2 'liza get tasks --format table'
-```
 
 ---
 
-## Step 8: Start the Code Planner and Code Plan Reviewer (Terminals 3-4)
+## Step 7: Let Planning Run
+
+The architecture and code-planning agents are already running in their panes.
+They will claim work as it becomes available:
+
+1. Architect defines the implementation structure from `specs/vision.md`.
+2. Architecture reviewer approves or rejects that plan.
+3. Code planner produces coding tasks.
+4. Code plan reviewer approves or rejects those tasks.
+
+Use the TUI pane to watch tasks and alerts. For a plain table view, run this in
+another shell or an extra WezTerm pane:
 
 ```bash
-cd hello-cli
-liza agent code-planner
+watch -n 2 'liza get tasks --format table'
 ```
 
-```bash
-cd hello-cli
-liza agent code-plan-reviewer
-```
+When a planning task reaches an approved terminal state, review the plan, then
+transition to the next phase:
 
-The Code Planner will:
-1. Claim the planning task
-2. Read the spec and produce a coding plan
-3. Populate `output[]` with task definitions
-4. Submit for review
-
-The Code Plan Reviewer will:
-1. Review the plan
-2. Approve or reject with feedback
-3. On approval: merge, triggering a sprint checkpoint (HUMAN GATE)
-
-At this point the system pauses. Review the plan, then transition to coding:
 ```bash
 liza proceed <task-id> code-plan-to-coding
 liza resume
@@ -222,19 +221,10 @@ liza resume
 
 ---
 
-## Step 9: Start the Coder and Code Reviewer (Terminals 5-6)
+## Step 8: Let Coding Run
 
-Once coding tasks appear after `proceed` + `resume`:
-
-```bash
-cd hello-cli
-liza agent coder
-```
-
-```bash
-cd hello-cli
-liza agent code-reviewer
-```
+The coder and code-reviewer panes are already running. Once coding tasks appear
+after `proceed` + `resume`, they will claim and review work.
 
 The Coder will:
 1. Claim a coding task
@@ -256,7 +246,7 @@ ls -la .worktrees/
 
 ---
 
-## Step 10: Observe the Flow
+## Step 9: Observe the Flow
 
 With all agents running, watch the system:
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -5,14 +5,11 @@ Step-by-step workflows for common Liza operations. See [DEMO.md](DEMO.md) for a 
 ## Autonomous Agent System
 
 ```bash
-# Start monitoring
-liza tui > watch.log 2>&1 &
+# Start monitoring plus the default coding-phase agents in one WezTerm window
+liza launch wezterm mas --preset technical-spec
 
-# Start agents (each in background or separate terminal)
-liza agent planner --agent-id planner-1 > planner.log 2>&1 &
-liza agent coder --agent-id coder-1 > coder-1.log 2>&1 &
-liza agent coder --agent-id coder-2 > coder-2.log 2>&1 &
-liza agent code-reviewer --agent-id code-reviewer-1 > reviewer.log 2>&1 &
+# Or use CMUX instead of WezTerm
+liza launch cmux mas --preset technical-spec
 
 # Monitor progress
 watch -n 5 'liza get tasks --format table'    # Task status
@@ -22,8 +19,10 @@ tail -f .liza/alerts.log                      # Alerts
 
 # Stop when done
 liza stop --reason "work session complete"
-wait  # Wait for all agents to exit cleanly
 ```
+
+Use `--dry-run` to inspect the terminal multiplexer command before launching, or repeat
+`--role <role>` for a custom set. Both WezTerm and CMUX support the same flags and presets.
 
 ## Pause and Resume
 

--- a/internal/agent/cli.go
+++ b/internal/agent/cli.go
@@ -16,6 +16,25 @@ func ValidCLIs() []string {
 	return out
 }
 
+// CLIExecutableName returns the local executable used for a configured CLI name.
+func CLIExecutableName(cliName string) string {
+	switch cliName {
+	case "codex-acp":
+		return "codex"
+	case "opencode-acp":
+		return "opencode"
+	case "mistral":
+		return "vibe"
+	default:
+		return cliName
+	}
+}
+
+// InteractiveCLICommand returns the argv used to start an interactive CLI session.
+func InteractiveCLICommand(cliName string) []string {
+	return []string{CLIExecutableName(cliName)}
+}
+
 // NewLLMAgentForCLI creates the provider backend for a configured CLI name.
 func NewLLMAgentForCLI(cliName string, outputsDir string) LLMAgent {
 	if isACPXCLI(cliName) {

--- a/internal/agent/cli_agent.go
+++ b/internal/agent/cli_agent.go
@@ -178,10 +178,7 @@ func (d *CLIAgent) RunInteractive(ctx context.Context, req LLMAgentInteractiveRe
 		},
 	})
 
-	actualCLI := cliName
-	if cliName == "mistral" {
-		actualCLI = "vibe"
-	}
+	actualCLI := CLIExecutableName(cliName)
 
 	cmdEnv := agentProcessEnv(os.Environ(), agentID)
 	var cmd *exec.Cmd
@@ -294,10 +291,7 @@ func (d *CLIAgent) ExecuteInteractive(ctx context.Context, cliName string, agent
 }
 
 func (d *CLIAgent) buildRunCommand(ctx context.Context, cliName, agentID, prompt, projectRoot string, runtimeConfig models.Config) (*exec.Cmd, error) {
-	actualCLI := cliName
-	if cliName == "mistral" {
-		actualCLI = "vibe"
-	}
+	actualCLI := CLIExecutableName(cliName)
 
 	cmdEnv := os.Environ()
 	if actualCLI == "claude" {

--- a/internal/agent/cli_test.go
+++ b/internal/agent/cli_test.go
@@ -35,6 +35,27 @@ func TestNewLLMAgentForCLI(t *testing.T) {
 	}
 }
 
+func TestCLIExecutableNameMapsConfiguredNamesToBinaries(t *testing.T) {
+	tests := map[string]string{
+		"claude":       "claude",
+		"codex":        "codex",
+		"codex-acp":    "codex",
+		"opencode":     "opencode",
+		"opencode-acp": "opencode",
+		"gemini":       "gemini",
+		"mistral":      "vibe",
+		"kimi":         "kimi",
+	}
+
+	for cliName, want := range tests {
+		t.Run(cliName, func(t *testing.T) {
+			if got := CLIExecutableName(cliName); got != want {
+				t.Fatalf("CLIExecutableName(%q) = %q, want %q", cliName, got, want)
+			}
+		})
+	}
+}
+
 func TestCheckCLIPrerequisitesIgnoresPlainCLIs(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 

--- a/support-docs/ADVERSARIAL_PAIRING.md
+++ b/support-docs/ADVERSARIAL_PAIRING.md
@@ -69,9 +69,15 @@ liza launch wezterm adversarial-pairing .liza/adversarial/retry-client.md \
 
 When the blackboard already exists, omit `--goal` to reuse it.
 
+WezTerm prompt injection waits 2 seconds before sending the initial
+`$adversarial-pairing ...` prompt to each pane. If a CLI starts slowly because
+it loads MCP servers or other startup hooks, increase that wait with
+`--prompt-delay`, for example `--prompt-delay 6s`.
+
 **CMUX support:** Liza also supports CMUX as an alternative to WezTerm for
 adversarial-pairing launches. Use `liza launch cmux adversarial-pairing` with
-the same flags:
+the same role, reviewer, and goal flags. The doer-only `--yolo` flag is also
+available:
 
 ```bash
 liza launch cmux adversarial-pairing .liza/adversarial/retry-client.md \

--- a/support-docs/ADVERSARIAL_PAIRING.md
+++ b/support-docs/ADVERSARIAL_PAIRING.md
@@ -5,9 +5,9 @@ full Liza MAS. Use it when one agent should implement and multiple reviewers
 should challenge the work, but a full autonomous sprint would be too heavy.
 
 It runs multiple Pairing-mode sessions against a shared Markdown blackboard. Each
-agent runs in its own dedicated interactive terminal: one terminal for the doer,
-and one separate terminal for each reviewer. The typical setup is one doer and
-several reviewers on different models, so review disagreement exposes
+role typically runs in its own dedicated interactive pane: one pane for the doer
+and one pane for each reviewer. The typical setup is one doer and several
+reviewers on different models, so review disagreement exposes
 model-specific blind spots. By default, the human remains the approval authority;
 the blackboard coordinates doer/reviewer state, submitted artifacts, review
 notes, validation output, and decisions.
@@ -24,17 +24,63 @@ Use it as:
 /adversarial-pairing <role-or-reviewer-id> <blackboard-path> [yolo]
 ```
 
+In Codex interactive sessions, use `$adversarial-pairing ...` instead of a
+leading slash so the text is submitted as a normal prompt rather than handled as
+a Codex TUI command.
+
 `role-or-reviewer-id` is `doer`, `reviewer`, or `reviewer-<id>`. Use
 `reviewer-<id>` when you want the agent to receive both its reviewer role and
-the stable ID it should use when registering in the blackboard. Start the doer
-first so it can create or initialize the blackboard, then start reviewer
-sessions against the same path:
+the stable ID it should use when registering in the blackboard. If you are
+arranging panes manually, run each invocation in its own pane:
 
 ```text
 /adversarial-pairing doer .liza/adversarial/retry-client.md
-/adversarial-pairing reviewer-codex .liza/adversarial/retry-client.md
-/adversarial-pairing reviewer-claude .liza/adversarial/retry-client.md
 ```
+
+For multiple reviewer sessions, run in additional panes:
+
+```text
+/adversarial-pairing reviewer-claude .liza/adversarial/retry-client.md
+/adversarial-pairing reviewer-codex .liza/adversarial/retry-client.md
+```
+
+If you want WezTerm to do the spawning for you, use the launch command. This
+starts interactive doer plus reviewer CLI sessions in one WezTerm window with
+the `$adversarial-pairing ...` invocation as each session's initial prompt. If
+the blackboard does not exist yet, pass `--goal` so Liza can initialize it
+before reviewer panes start:
+
+```bash
+liza launch wezterm adversarial-pairing .liza/adversarial/retry-client.md \
+  --goal "Fix retry-client behavior"
+```
+
+Defaults are three Codex panes: `--doer-cli codex` plus reviewers `codex` and
+`codex-2=codex`. Customize reviewers with repeated `--reviewer` flags. Use
+`id=cli` when the stable blackboard reviewer ID should differ from the CLI name:
+
+```bash
+liza launch wezterm adversarial-pairing .liza/adversarial/retry-client.md \
+  --goal "Fix retry-client behavior" \
+  --doer-cli claude \
+  --reviewer claude \
+  --reviewer openai=codex
+```
+
+When the blackboard already exists, omit `--goal` to reuse it.
+
+**CMUX support:** Liza also supports CMUX as an alternative to WezTerm for
+adversarial-pairing launches. Use `liza launch cmux adversarial-pairing` with
+the same flags:
+
+```bash
+liza launch cmux adversarial-pairing .liza/adversarial/retry-client.md \
+  --goal "Fix retry-client behavior"
+```
+
+CMUX sends the `$adversarial-pairing ...` prompt as text to each pane and
+submits it with a real enter key event, avoiding the TUI slash command issue
+that affected the initial WezTerm implementation.
 
 Use `yolo` only on the doer session when you want the doer to proceed through
 doer-side human approval gates without pausing:

--- a/support-docs/USAGE_MULTI_AGENTS.md
+++ b/support-docs/USAGE_MULTI_AGENTS.md
@@ -157,6 +157,47 @@ The TUI (`liza tui`) is the primary way to spawn and monitor agents. Press `s` t
 
 Alternatively, spawn agents from the CLI: `liza agent <role>`. Agent identity defaults to the first `{role}-N` not already registered with a valid lease (e.g., `coder-1`, or `coder-2` if `coder-1` is active). Override with `--agent-id` or the `LIZA_AGENT_ID` environment variable. After resolution, `liza agent` exports that ID as `LIZA_AGENT_ID` to the spawned provider CLI, including `-i` interactive sessions, so hooks select Multi-Agent mode rather than Pairing mode.
 
+To launch a whole role set in one WezTerm window, use `liza launch wezterm mas`.
+It starts `liza tui` in the first pane and one `liza agent <role>` process per
+additional pane:
+
+```bash
+liza launch wezterm mas --preset technical-spec
+liza launch wezterm mas --preset functional-spec
+liza launch wezterm mas --preset general-objective
+```
+
+**CMUX support:** Liza also supports CMUX as an alternative to WezTerm. Use
+`liza launch cmux mas` with the same flags and presets:
+
+```bash
+liza launch cmux mas --preset technical-spec
+liza launch cmux mas --preset functional-spec
+liza launch cmux mas --preset general-objective
+```
+
+Both WezTerm and CMUX launchers support the same flags: `--preset`, `--role`,
+`--cli`, `--no-tui`, `--class`/`--workspace`, `--cwd`, and `--dry-run`. CMUX
+launchers create a CMUX workspace and use `cmux send` + `cmux send-key enter`
+for prompt injection, avoiding TUI slash command issues.
+
+| Launch command | Equivalent panes |
+|----------------|------------------|
+| `liza launch wezterm mas --preset technical-spec` | `liza tui`; `liza agent orchestrator`; `liza agent code-planner`; `liza agent code-plan-reviewer`; `liza agent coder`; `liza agent code-reviewer` |
+| `liza launch wezterm mas --preset functional-spec` | Everything in `technical-spec`, plus `liza agent architect`; `liza agent architecture-reviewer` |
+| `liza launch wezterm mas --preset general-objective` | Everything in `functional-spec`, plus `liza agent epic-planner`; `liza agent epic-plan-reviewer`; `liza agent us-writer`; `liza agent us-reviewer` |
+
+Pass `--cli <name>` to force the same backend for every launched role, or repeat
+`--role <role>` to launch a custom role set instead of a preset:
+
+```bash
+liza launch wezterm mas --role orchestrator --role coder --role code-reviewer --cli codex
+liza launch cmux mas --role orchestrator --role coder --role code-reviewer --cli codex
+```
+
+CMUX equivalents provide the same pane layouts as WezTerm but in a CMUX workspace.
+
+
 Supported CLI names for `--cli`, `--default-cli`, `--default-doer-cli`, and
 `--default-reviewer-cli` are `claude`, `codex`, `codex-acp`, `opencode`,
 `opencode-acp`, `gemini`, `mistral`, and `kimi`.
@@ -200,13 +241,13 @@ Roles:
 ```
 
 **Functional-spec setup (`functional-spec` or legacy `detailed-spec`) — 7 agents:**
-Spawn from the TUI (`s`): orchestrator, architect, architecture-reviewer, code-planner, code-plan-reviewer, coder, code-reviewer.
+Use `liza launch wezterm mas --preset functional-spec`, or spawn from the TUI (`s`): orchestrator, architect, architecture-reviewer, code-planner, code-plan-reviewer, coder, code-reviewer.
 
 **Technical-spec setup (`technical-spec`) — 5 agents:**
-Spawn from the TUI (`s`): orchestrator, code-planner, code-plan-reviewer, coder, code-reviewer.
+Use `liza launch wezterm mas --preset technical-spec`, or spawn from the TUI (`s`): orchestrator, code-planner, code-plan-reviewer, coder, code-reviewer.
 
 **Full pipeline (general-objective entry point) — 11 agents:**
-All of the above plus: epic-planner, epic-plan-reviewer, us-writer, us-reviewer.
+Use `liza launch wezterm mas --preset general-objective`. This launches all functional-spec roles plus: epic-planner, epic-plan-reviewer, us-writer, us-reviewer.
 
 **Integration phase** agents (integration-analyst, integration-reviewer) are spawned by the orchestrator after all coding tasks for a goal complete. They are not needed at startup — spawn them when the orchestrator triggers the integration sub-pipeline.
 
@@ -410,6 +451,7 @@ The `liza` binary provides all system operations. Key commands:
 | `liza init <goal> --spec <spec_ref> [--branch <name>]` | Initialize `.liza/` directory with blackboard (spec_ref defaults to specs/vision.md, branch defaults to integration) |
 | **Agents & Monitoring** |                                                                                                                      |
 | `liza agent <role> [--agent-id <id>]` | Agent supervisor (start, restart, backoff loop; ID auto-assigned if omitted)                                         |
+| `liza launch wezterm mas --preset <name>` | Launch `liza tui` plus a MAS role preset in one WezTerm window                                                     |
 | `liza repair-agent-pool [--cli <name>] [--dry-run]` | Spawn one agent for each claimable-work role that has no live usable agent                                         |
 | `liza tui` | Live TUI: spawn agents, monitor state, manage system                                                                 |
 | `liza status` | Show system and task status at a glance                                                                              |

--- a/support-docs/how-to-produce-a-goal.md
+++ b/support-docs/how-to-produce-a-goal.md
@@ -85,7 +85,8 @@ Continue pairing to fill gaps. A goal document is ready when:
 
 ### 7. Get reviews from other agents
 
-Open a fresh Pairing session in another terminal. Ask it to review the goal document cold — no context from the first session. A good review prompt:
+Open a fresh Pairing session in another pane or window. Ask it to review the
+goal document cold — no context from the first session. A good review prompt:
 
 ```
 Review this goal document as if you were an agent about to decompose it into tasks.


### PR DESCRIPTION
## Summary

Adds `liza launch wezterm` commands for launching MAS role presets and adversarial-pairing sessions in WezTerm panes.

The adversarial-pairing launcher now starts interactive CLIs first, captures pane ids, and injects `$adversarial-pairing ...` as normal prompt text with `wezterm cli send-text --no-paste` followed by a carriage-return submit. This avoids Codex treating `/adversarial-pairing` as a TUI slash command or pasted newline text.

Docs are updated with the WezTerm workflows and the Codex-safe `$adversarial-pairing` syntax.

https://github.com/user-attachments/assets/7b2eb006-554a-45fc-b8c9-a4b95eaec896

## Validation

- `go test ./cmd/liza`
- `go test ./internal/embedded`
- `GIT_CONFIG_GLOBAL=/dev/null go test ./...`
- Installed dry run verified the generated WezTerm command uses `send-text --no-paste` and `$adversarial-pairing ...` prompts.

## Notes

Plain `go test ./...` is sensitive to the local global Git config when `core.excludesFile` is set; isolating global Git config made the full suite pass.
