### PR TITLE
feat(orchestration): claude fable 5 rewrite

### DIFF
--- a/cmd/liza/cmd_journal.go
+++ b/cmd/liza/cmd_journal.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/liza-mas/liza/internal/commands"
+	"github.com/liza-mas/liza/internal/jsonout"
+	"github.com/spf13/cobra"
+)
+
+var (
+	journalSince  int64
+	journalTask   string
+	journalLimit  int
+	journalVerify bool
+)
+
+var journalCmd = &cobra.Command{
+	Use:   "journal",
+	Short: "Inspect the append-only event journal",
+	Long: `Read the shadow event journal (.liza/journal.jsonl) that records every
+state transition as a typed event.
+
+With --verify, additionally folds the journal into a task-status projection
+and checks it reproduces the statuses in state.yaml exactly; exits non-zero
+on divergence.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectRoot, err := requireProjectRoot()
+		if err != nil {
+			return err
+		}
+
+		result, err := commands.JournalCommand(projectRoot, commands.JournalOptions{
+			Since:  journalSince,
+			Task:   journalTask,
+			Limit:  journalLimit,
+			Verify: journalVerify,
+		})
+		if err != nil {
+			return err
+		}
+
+		if isJSON(cmd) {
+			if err := jsonout.WriteResult(os.Stdout, result, nil, nil); err != nil {
+				return err
+			}
+		} else {
+			renderJournal(result)
+		}
+
+		if result.Verification != nil && !result.Verification.Equivalent {
+			return jsonout.ErrAlreadyWritten
+		}
+		return nil
+	},
+}
+
+func renderJournal(result *commands.JournalResult) {
+	for _, ev := range result.Events {
+		var parts []string
+		parts = append(parts, fmt.Sprintf("%6d", ev.Seq), ev.Time.Format("2006-01-02T15:04:05Z07:00"), ev.Type)
+		if ev.Task != "" {
+			parts = append(parts, "task="+ev.Task)
+		}
+		if ev.Agent != "" {
+			parts = append(parts, "agent="+ev.Agent)
+		}
+		if ev.Op != "" {
+			parts = append(parts, "op="+ev.Op)
+		}
+		keys := make([]string, 0, len(ev.Fields))
+		for k := range ev.Fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%s=%v", k, ev.Fields[k]))
+		}
+		fmt.Println(strings.Join(parts, "  "))
+	}
+
+	if result.Verification == nil {
+		return
+	}
+	if result.Verification.Equivalent {
+		fmt.Printf("verify: OK — journal projection matches state.yaml (%d events)\n", result.TotalEvents)
+		return
+	}
+	fmt.Fprintln(os.Stderr, "verify: FAILED — journal projection diverges from state.yaml:")
+	for taskID, pair := range result.Verification.Diff {
+		fmt.Fprintf(os.Stderr, "  %s: journal=%q state=%q\n", taskID, pair[0], pair[1])
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(journalCmd)
+	addJSONFlag(journalCmd)
+	journalCmd.Flags().Int64Var(&journalSince, "since", 0, "only events with seq greater than this")
+	journalCmd.Flags().StringVar(&journalTask, "task", "", "filter events to a single task ID")
+	journalCmd.Flags().IntVar(&journalLimit, "limit", 50, "keep only the last N matching events (0 = all)")
+	journalCmd.Flags().BoolVar(&journalVerify, "verify", false, "check journal projection matches state.yaml")
+}

--- a/cmd/liza/cmd_schedule.go
+++ b/cmd/liza/cmd_schedule.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/liza-mas/liza/internal/commands"
+	"github.com/liza-mas/liza/internal/jsonout"
+	"github.com/liza-mas/liza/internal/scheduler"
+	"github.com/spf13/cobra"
+)
+
+var scheduleCmd = &cobra.Command{
+	Use:   "schedule",
+	Short: "Show the current runnable-work plan (read-only)",
+	Long: `Compute and display the work the system could dispatch right now,
+derived from current state: tasks needing a doer, tasks needing a reviewer,
+approved tasks awaiting merge, and expired claims to reclaim.
+
+This is a read-only diagnostic — it mutates nothing. It exposes the same
+decision the scheduler makes; use it to understand why agents are (or are
+not) picking up work.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectRoot, err := requireProjectRoot()
+		if err != nil {
+			return err
+		}
+
+		result, err := commands.ScheduleCommand(projectRoot)
+		if err != nil {
+			return err
+		}
+
+		if isJSON(cmd) {
+			return jsonout.WriteResult(os.Stdout, result, nil, nil)
+		}
+
+		renderSchedule(result)
+		return nil
+	},
+}
+
+func renderSchedule(result *commands.ScheduleResult) {
+	if len(result.Items) == 0 {
+		fmt.Println("No runnable work.")
+		return
+	}
+
+	order := []scheduler.WorkKind{scheduler.WorkMerge, scheduler.WorkReview, scheduler.WorkDoer, scheduler.WorkReclaim}
+	for _, kind := range order {
+		if result.Counts[string(kind)] == 0 {
+			continue
+		}
+		fmt.Printf("%s (%d):\n", kind, result.Counts[string(kind)])
+		for _, item := range result.Plan.ByKind(kind) {
+			line := "  " + item.TaskID
+			if item.Role != "" {
+				line += "  role=" + item.Role
+			}
+			if item.AgentID != "" {
+				line += "  agent=" + item.AgentID
+			}
+			if item.Detail != "" {
+				line += "  (" + item.Detail + ")"
+			}
+			fmt.Println(line)
+		}
+	}
+
+	kinds := make([]string, 0, len(result.Counts))
+	total := 0
+	for k, n := range result.Counts {
+		kinds = append(kinds, k)
+		total += n
+	}
+	sort.Strings(kinds)
+	fmt.Printf("\n%d runnable item(s).\n", total)
+}
+
+func init() {
+	rootCmd.AddCommand(scheduleCmd)
+	addJSONFlag(scheduleCmd)
+}

--- a/docs/event-journal-migration.md
+++ b/docs/event-journal-migration.md
@@ -1,0 +1,107 @@
+# Event-Journal Migration — Status & Concerns
+
+Status of the strangler migration toward an event-journal architecture, and
+the concerns a reviewer (and the next implementer) must know before continuing.
+This is a **work-in-progress migration**, not a finished system: `state.yaml`
+remains the source of truth. Everything here is additive and reversible.
+
+## Why this migration
+
+Liza's orchestration complexity is largely compensation for one early choice: a
+mutable, denormalized `state.yaml` that ~55 commands mutate in place. Because
+that model *permits* invalid states, the system grew an immune system to repair
+them after the fact (a 2k-line `statevalidate`, a transcript-scrubbing
+`statehygiene`, ~10 repair commands, five overlapping supervisor progress
+trackers, lazy read-path migrations, duplicated ownership/lease fields).
+
+The redesign inverts the foundation: an **append-only event journal** with
+derived state, **one** progress policy, **one** scheduler, and a write funnel
+that makes invalid states *unwritable* instead of *repairable*.
+
+## What has landed (all behind `state.yaml`-as-truth; additive)
+
+| Area | Package / file | Notes |
+|------|----------------|-------|
+| Append-only journal | `internal/journal` | Plain JSONL (`.liza/journal.jsonl`), **no SQLite** (per code-owner constraint). fsync, field-size caps, torn-tail tolerance. |
+| Shadow derivation | `internal/db/blackboard.go` | Every `Modify`/`Write` derives typed events by diffing before/after; appended inside the state lock. No call-site changes. |
+| Op provenance | `Blackboard.ModifyOp(op, fn)` | Named operations flow into journal `Op` field + lock diagnostics. ~70 write sites migrated to named ops. |
+| Progress policy | `internal/agent/progress.go` | Five overlapping trackers (exit42/crash/spin/runtime-failure/success-no-progress) → one `progressLedger` + one threshold table. |
+| Structural invariants | `internal/taskinvariants` | Per-task field rules extracted as a leaf package; **enforced fail-closed at the write funnel** for named ops (no-worse-than-before semantics). |
+| Claims as entities | `internal/models/claim.go`, `internal/ops/claim_records.go` | First-class claim records, dual-written alongside legacy ownership fields. `SweepExpiredClaims` primitive. Contradiction warnings in `statevalidate`. |
+| Journal rotation | `internal/journal/rotate.go` | Archives at threshold with a snapshot event seeding the projection; projection stays equivalent across rotation. Unbounded growth solved. |
+| Scheduler core | `internal/scheduler` | Pure `Compute(state, resolver, now) → Plan` for doer/review/merge/reclaim work. Surfaced read-only via `liza schedule`. **Not yet wired into the live loop.** |
+| Verification | `liza journal --verify`, `liza validate` | Folds journal → reconstructed view; warns on divergence across task statuses, claim holders, and system singletons (sprint/circuit-breaker/goal/mode). |
+
+Two real bugs were found *by* the fail-closed write funnel during migration:
+stale/missing `base_commit` on rejected-task reclaim, and `release-claim`
+stranding submitted tasks as unreviewable zombies. Both fixed.
+
+## Concerns / risks (read before continuing)
+
+### 1. The journal events are lossy diffs, not snapshots — this is load-bearing
+The derived events capture status *changes*, claim grant/release, and appended
+anomalies — **not full task bodies** (description, worktree, base_commit,
+history, output). Consequences:
+
+- A literal "fold the journal back into `state.yaml`" is **impossible today**.
+  `journal.Reconstruct` deliberately covers only the fully-captured dimensions
+  (task statuses, claim holders, system singletons) and documents the gap.
+- Therefore "make the journal the source of truth" is **not** a precursor step —
+  the precursor (a complete, lossless per-field event vocabulary) *is the bulk
+  of the flip itself*. Do not under-scope it.
+
+### 2. The scheduler core is proven but NOT live
+`scheduler.Compute` is pure and unit-tested against the production pipeline
+config, and exposed read-only via `liza schedule`. The supervisor still
+self-schedules per-agent (fsnotify wait loops, 8 orchestrator wake triggers,
+reviewer-PreWork merges). Rewiring the hot path is the remaining risk and
+**cannot be verified by unit tests alone** — it needs real multi-agent runs.
+
+### 3. Dual-write means two sources that can drift
+Claims are dual-written with legacy `AssignedTo`/`ReviewingBy`/lease fields.
+`statevalidate` warns (not errors) on contradiction. Until legacy fields are
+removed (a later strangler phase), a write path that updates one and not the
+other silently diverges. The `liza validate` claim-divergence check is the
+backstop; keep it green.
+
+### 4. Orchestrator wake detection was NOT consolidated into the scheduler
+It lives in `internal/agent/workdetection.go` and is referenced across `agent`,
+`commands`, and `prompts`. Moving it is a cross-package change deferred to keep
+increments safe. The scheduler `Plan` is therefore incomplete: it omits
+orchestrator readiness. Consolidate before the scheduler goes live.
+
+### 5. Write-funnel enforcement is intentionally permissive (for now)
+`ModifyOp` fail-closed validation is skipped for generic `modify`/`write` ops
+and for projects without a frozen pipeline config, and uses no-worse-than-before
+semantics (touching an already-invalid task is allowed). These fail-open paths
+should ratchet closed as legacy writers disappear and at-rest corruption is
+extinguished — but doing so prematurely will reject legitimate repair operations.
+
+### 6. Verification surface vs. rotation
+`liza journal --verify` (task statuses) relies on the rotation snapshot seed.
+The broader claim/singleton checks have **no** snapshot seed, so they fold over
+`ReadAllIncludingArchives` (full history). If rotation archiving is ever
+changed, re-confirm both paths stay equivalent.
+
+## Remaining roadmap (each its own focused effort)
+
+1. **Live scheduler rewiring** — replace per-agent self-scheduling with one
+   dispatcher off `scheduler.Compute`; first fold orchestrator wake detection in
+   (concern #4). Verify with real agent runs.
+2. **Complete event vocabulary → journal as source of truth** — emit lossless
+   per-field task events, add full `apply()`, demote `state.yaml` to a rendered
+   read-only view. Keep `liza validate` divergence silent throughout. (concern #1)
+3. **Ratchet the funnel closed** — drop fail-open paths as legacy writers vanish;
+   declare op preconditions; shrink `statevalidate` to a debug backstop. (concern #5)
+4. **Remove duplicated ownership/lease fields** once claims are the sole source. (concern #3)
+5. **Stage-parameterized lifecycle** — collapse the 26+ status cross-product into
+   one lifecycle × stage; cheapest once the journal is authoritative (event
+   upcaster maps old status names during replay).
+
+## Invariants the migration must keep
+
+All of `INVARIANTS.md` still holds. The redesign's job is to make invalid states
+*unrepresentable*, not to relax any invariant. The most binding ones for this
+work: Tier-0 contract rules, doer/reviewer structural separation, commit-SHA
+verification, three-phase claim TOCTOU protection, blackboard-as-source-of-truth
+(the journal *becomes* that blackboard; it does not bypass it).

--- a/internal/agent/claiming.go
+++ b/internal/agent/claiming.go
@@ -448,7 +448,7 @@ func handleCleanTaskCleanup(projectRoot string) error {
 		// Finalize: mirror non-git cleanup from the merge path.
 		// Records completion handoff event and releases the assigned agent.
 		taskID := task.ID
-		if err := bb.Modify(func(s *models.State) error {
+		if err := bb.ModifyOp("clean_task_cleanup", func(s *models.State) error {
 			t := s.FindTask(taskID)
 			if t == nil {
 				return nil

--- a/internal/agent/heartbeat.go
+++ b/internal/agent/heartbeat.go
@@ -94,13 +94,25 @@ func (h *Heartbeat) beat() error {
 			if task := state.FindTask(*agent.CurrentTask); task != nil {
 				if task.AssignedTo != nil && *task.AssignedTo == h.agentID && task.LeaseExpires != nil {
 					task.LeaseExpires = &newLease
+					renewClaimLease(state, task.ID, models.ClaimKindDoer, h.agentID, newLease)
 				}
 				if task.ReviewingBy != nil && *task.ReviewingBy == h.agentID && task.ReviewLeaseExpires != nil {
 					task.ReviewLeaseExpires = &newLease
+					renewClaimLease(state, task.ID, models.ClaimKindReviewer, h.agentID, newLease)
 				}
 			}
 		}
 
 		return nil
 	})
+}
+
+// renewClaimLease bumps the lease expiry of the matching claim record in
+// lockstep with the legacy task lease fields (strangler dual-write). Old
+// state files have no claims, so a missing claim is simply skipped.
+func renewClaimLease(state *models.State, taskID, kind, agentID string, expires time.Time) {
+	if c := state.FindClaim(taskID, kind); c != nil && c.AgentID == agentID {
+		exp := expires
+		c.ExpiresAt = &exp
+	}
 }

--- a/internal/agent/progress.go
+++ b/internal/agent/progress.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// progressClass classifies why the supervisor is counting consecutive
+// non-progress turns for a subject. Every loop-detection concern (exit-42
+// restarts, crashes, spinning, successful no-progress turns, observed
+// runtime failures) is a classification feeding the same counting
+// mechanism: increment while the progress signature is unchanged, reset on
+// progress, block when the class's threshold is exceeded.
+type progressClass string
+
+const (
+	classExit42            progressClass = "exit42"
+	classCrash             progressClass = "crash"
+	classSpin              progressClass = "spin"
+	classSuccessNoProgress progressClass = "success_no_progress"
+	classRuntimeFailure    progressClass = "runtime_failure"
+)
+
+// thresholdFor returns the configured consecutive-non-progress threshold for
+// a class. This is the single policy table for supervisor loop detection.
+func thresholdFor(class progressClass, cfg models.Config) int {
+	switch class {
+	case classExit42:
+		return effectiveExit42RestartLimit(cfg)
+	case classCrash:
+		return effectiveCrashRestartThreshold(cfg)
+	default:
+		// Spinning, successful no-progress, and runtime-failure loops share
+		// the spinning threshold.
+		return effectiveSpinningRestartThreshold(cfg)
+	}
+}
+
+type progressKey struct {
+	subject string
+	class   progressClass
+}
+
+type progressState struct {
+	count     int
+	signature string
+}
+
+// progressLedger is the supervisor's single non-progress counting mechanism.
+// A subject is whatever the class observes: a task ID, "orchestrator", or an
+// exit-42 tracker key. Counters for different classes on the same subject are
+// independent — their interplay (e.g. a runtime failure suppressing the spin
+// counter) is policy expressed at the call sites, not in the ledger.
+//
+// Not safe for concurrent use; the supervisor loop is single-goroutine.
+type progressLedger struct {
+	byKey map[progressKey]progressState
+}
+
+func newProgressLedger() *progressLedger {
+	return &progressLedger{byKey: make(map[progressKey]progressState)}
+}
+
+// Observe records one non-progress observation and returns the consecutive
+// count. A signature change means progress: the counter restarts at 1. Empty
+// signatures never reset (unknown state is not evidence of progress).
+func (l *progressLedger) Observe(subject string, class progressClass, signature string) int {
+	key := progressKey{subject: subject, class: class}
+	prev := l.byKey[key]
+	if prev.signature != "" && signature != "" && prev.signature != signature {
+		prev.count = 0
+	}
+	prev.count++
+	prev.signature = signature
+	l.byKey[key] = prev
+	return prev.count
+}
+
+// Reset clears the given classes for a subject (all classes when none given).
+func (l *progressLedger) Reset(subject string, classes ...progressClass) {
+	if subject == "" {
+		return
+	}
+	if len(classes) == 0 {
+		classes = []progressClass{
+			classExit42, classCrash, classSpin, classSuccessNoProgress, classRuntimeFailure,
+		}
+	}
+	for _, class := range classes {
+		delete(l.byKey, progressKey{subject: subject, class: class})
+	}
+}
+
+// exit42Backoff returns the exponential restart delay for a consecutive
+// exit-42 count, capped at the configured maximum.
+func exit42Backoff(restartCount int, cfg models.Config) time.Duration {
+	return computeExit42BackoffDelay(restartCount, effectiveExit42MaxBackoff(cfg))
+}

--- a/internal/agent/provider_audit.go
+++ b/internal/agent/provider_audit.go
@@ -77,7 +77,7 @@ func handleProviderAuditDegraded(bb *db.Blackboard, config SupervisorConfig, tas
 	}
 
 	if bb != nil {
-		if err := bb.Modify(func(state *models.State) error {
+		if err := bb.ModifyOp("provider_audit_degraded", func(state *models.State) error {
 			state.Anomalies = append(state.Anomalies, models.Anomaly{
 				Timestamp: time.Now().UTC(),
 				Task:      taskID,

--- a/internal/agent/registration.go
+++ b/internal/agent/registration.go
@@ -262,6 +262,7 @@ func releaseTaskClaim(state *models.State, task *models.Task, role, agentID stri
 		}
 		task.AssignedTo = nil
 		task.LeaseExpires = nil
+		state.ReleaseClaimRecord(task.ID, models.ClaimKindDoer)
 
 	case "reviewer":
 		if task.ReviewingBy != nil && *task.ReviewingBy == agentID {
@@ -276,6 +277,7 @@ func releaseTaskClaim(state *models.State, task *models.Task, role, agentID stri
 			}
 			task.ReviewingBy = nil
 			task.ReviewLeaseExpires = nil
+			state.ReleaseClaimRecord(task.ID, models.ClaimKindReviewer)
 		}
 
 	default:
@@ -287,6 +289,7 @@ func releaseTaskClaim(state *models.State, task *models.Task, role, agentID stri
 			}
 			task.AssignedTo = nil
 			task.LeaseExpires = nil
+			state.ReleaseClaimRecord(task.ID, models.ClaimKindDoer)
 		} else if task.ReviewingBy != nil && *task.ReviewingBy == agentID {
 			activeReviewing, releasedSubmitted, err := resolveReviewerRelease()
 			if err != nil {
@@ -299,6 +302,7 @@ func releaseTaskClaim(state *models.State, task *models.Task, role, agentID stri
 			}
 			task.ReviewingBy = nil
 			task.ReviewLeaseExpires = nil
+			state.ReleaseClaimRecord(task.ID, models.ClaimKindReviewer)
 		} else {
 			return nil
 		}

--- a/internal/agent/strategy_orchestrator.go
+++ b/internal/agent/strategy_orchestrator.go
@@ -75,7 +75,7 @@ func (s *orchestratorStrategy) PreWork(_ context.Context, bb *db.Blackboard, con
 
 	// Clear trigger even if transitions failed — the human approved, so don't
 	// re-checkpoint. Transition errors are logged; retry is manual.
-	if err := bb.Modify(func(s *models.State) error {
+	if err := bb.ModifyOp("clear_checkpoint_trigger", func(s *models.State) error {
 		s.Sprint.CheckpointTrigger = ""
 		return nil
 	}); err != nil {

--- a/internal/agent/supervisor.go
+++ b/internal/agent/supervisor.go
@@ -38,32 +38,32 @@ type SupervisorConfig struct {
 
 var waitWhilePausedForSupervisor = waitWhilePaused
 
-type exit42RestartState struct {
-	RestartCount int
-	Signature    string
-}
-
 type exit42RestartOutcome struct {
 	Delay        time.Duration
 	RestartCount int
 	BlockedTask  bool
 }
 
+// exit42RestartTracker layers exit-42 policy (exponential backoff, persisted
+// restart count, blocking the task once the limit is exceeded) on top of the
+// shared progressLedger counting mechanism.
 type exit42RestartTracker struct {
-	byKey map[string]exit42RestartState
+	ledger *progressLedger
 }
 
 func newExit42RestartTracker() *exit42RestartTracker {
-	return &exit42RestartTracker{
-		byKey: make(map[string]exit42RestartState),
-	}
+	return &exit42RestartTracker{ledger: newProgressLedger()}
+}
+
+func newExit42RestartTrackerWithLedger(ledger *progressLedger) *exit42RestartTracker {
+	return &exit42RestartTracker{ledger: ledger}
 }
 
 func (t *exit42RestartTracker) reset(taskID string) {
 	if taskID == "" {
 		return
 	}
-	delete(t.byKey, "task:"+taskID)
+	t.ledger.Reset("task:"+taskID, classExit42)
 }
 
 func (t *exit42RestartTracker) Handle(bb *db.Blackboard, projectRoot, role, taskID, agentID string) (exit42RestartOutcome, error) {
@@ -72,10 +72,8 @@ func (t *exit42RestartTracker) Handle(bb *db.Blackboard, projectRoot, role, task
 		return exit42RestartOutcome{}, fmt.Errorf("read state for exit-42 tracking: %w", err)
 	}
 
-	maxBackoff := effectiveExit42MaxBackoff(state.Config)
-	restartLimit := effectiveExit42RestartLimit(state.Config)
+	restartLimit := thresholdFor(classExit42, state.Config)
 	key := exit42TrackerKey(taskID, role, agentID)
-	prev := t.byKey[key]
 
 	var signature string
 	if taskID != "" {
@@ -85,20 +83,15 @@ func (t *exit42RestartTracker) Handle(bb *db.Blackboard, projectRoot, role, task
 		}
 	}
 
-	if prev.Signature != "" && signature != "" && prev.Signature != signature {
-		prev.RestartCount = 0
-	}
-
-	prev.RestartCount++
-	prev.Signature = signature
+	restartCount := t.ledger.Observe(key, classExit42, signature)
 
 	outcome := exit42RestartOutcome{
-		Delay:        computeExit42BackoffDelay(prev.RestartCount, maxBackoff),
-		RestartCount: prev.RestartCount,
+		Delay:        exit42Backoff(restartCount, state.Config),
+		RestartCount: restartCount,
 	}
 
 	blockedTask := false
-	if err := bb.Modify(func(s *models.State) error {
+	if err := bb.ModifyOp("block_task_supervisor", func(s *models.State) error {
 		if taskID == "" {
 			return nil
 		}
@@ -153,6 +146,8 @@ func (t *exit42RestartTracker) Handle(bb *db.Blackboard, projectRoot, role, task
 		task.LeaseExpires = nil
 		task.ReviewingBy = nil
 		task.ReviewLeaseExpires = nil
+		s.ReleaseClaimRecord(taskID, models.ClaimKindDoer)
+		s.ReleaseClaimRecord(taskID, models.ClaimKindReviewer)
 		task.History = append(task.History, models.TaskHistoryEntry{
 			Time:   now,
 			Event:  models.TaskEventBlocked,
@@ -168,11 +163,8 @@ func (t *exit42RestartTracker) Handle(bb *db.Blackboard, projectRoot, role, task
 	outcome.BlockedTask = blockedTask
 	if blockedTask {
 		outcome.Delay = 0
-		delete(t.byKey, key)
-		return outcome, nil
+		t.ledger.Reset(key, classExit42)
 	}
-
-	t.byKey[key] = prev
 	return outcome, nil
 }
 
@@ -318,7 +310,7 @@ func blockTaskFromSupervisor(bb *db.Blackboard, projectRoot, taskID, agentID, re
 		return
 	}
 
-	if err := bb.Modify(func(s *models.State) error {
+	if err := bb.ModifyOp("block_task_supervisor", func(s *models.State) error {
 		task := s.FindTask(taskID)
 		if task == nil {
 			return nil
@@ -336,6 +328,8 @@ func blockTaskFromSupervisor(bb *db.Blackboard, projectRoot, taskID, agentID, re
 		task.LeaseExpires = nil
 		task.ReviewingBy = nil
 		task.ReviewLeaseExpires = nil
+		s.ReleaseClaimRecord(taskID, models.ClaimKindDoer)
+		s.ReleaseClaimRecord(taskID, models.ClaimKindReviewer)
 		task.History = append(task.History, models.TaskHistoryEntry{
 			Time:   now,
 			Event:  models.TaskEventBlocked,
@@ -358,70 +352,6 @@ func blockTaskFromSupervisor(bb *db.Blackboard, projectRoot, taskID, agentID, re
 	}
 }
 
-// --- Crash restart tracker ---
-
-type crashRestartState struct {
-	Count     int
-	Signature string
-}
-
-type crashRestartTracker struct {
-	byTask map[string]crashRestartState
-}
-
-func newCrashRestartTracker() *crashRestartTracker {
-	return &crashRestartTracker{byTask: make(map[string]crashRestartState)}
-}
-
-func (t *crashRestartTracker) reset(taskID string) {
-	delete(t.byTask, taskID)
-}
-
-// Increment records a crash for the task and returns the new count.
-// Resets the counter if task state has changed (progress detected).
-func (t *crashRestartTracker) Increment(taskID string, currentSignature string) int {
-	prev := t.byTask[taskID]
-	if prev.Signature != "" && currentSignature != "" && prev.Signature != currentSignature {
-		prev.Count = 0
-	}
-	prev.Count++
-	prev.Signature = currentSignature
-	t.byTask[taskID] = prev
-	return prev.Count
-}
-
-// --- Spinning (same-task re-execution) tracker ---
-
-type spinningState struct {
-	Count     int
-	Signature string
-}
-
-type spinningTracker struct {
-	byTask map[string]spinningState
-}
-
-func newSpinningTracker() *spinningTracker {
-	return &spinningTracker{byTask: make(map[string]spinningState)}
-}
-
-// Track records an execution for the task and returns the new count.
-// Resets when task ID changes (caller responsibility) or task state progresses.
-func (t *spinningTracker) Track(taskID string, currentSignature string) int {
-	prev := t.byTask[taskID]
-	if prev.Signature != "" && currentSignature != "" && prev.Signature != currentSignature {
-		prev.Count = 0
-	}
-	prev.Count++
-	prev.Signature = currentSignature
-	t.byTask[taskID] = prev
-	return prev.Count
-}
-
-func (t *spinningTracker) reset(taskID string) {
-	delete(t.byTask, taskID)
-}
-
 const unknownLizaJSONCommand = "liza-json-envelope"
 
 type observedRuntimeFailure struct {
@@ -429,37 +359,10 @@ type observedRuntimeFailure struct {
 	Code    string
 }
 
+// key is the runtime-failure progress signature: a different failing
+// command/code pair counts as progress and restarts the counter.
 func (f observedRuntimeFailure) key() string {
 	return f.Command + "\x00" + f.Code
-}
-
-type runtimeFailureState struct {
-	Count int
-	Key   string
-}
-
-type runtimeFailureTracker struct {
-	byTask map[string]runtimeFailureState
-}
-
-func newRuntimeFailureTracker() *runtimeFailureTracker {
-	return &runtimeFailureTracker{byTask: make(map[string]runtimeFailureState)}
-}
-
-func (t *runtimeFailureTracker) Track(taskID string, failure observedRuntimeFailure) int {
-	prev := t.byTask[taskID]
-	key := failure.key()
-	if prev.Key != "" && prev.Key != key {
-		prev.Count = 0
-	}
-	prev.Count++
-	prev.Key = key
-	t.byTask[taskID] = prev
-	return prev.Count
-}
-
-func (t *runtimeFailureTracker) reset(taskID string) {
-	delete(t.byTask, taskID)
 }
 
 func detectObservedRuntimeFailure(output string) *observedRuntimeFailure {
@@ -568,17 +471,18 @@ func handleObservedRuntimeFailureRetry(
 	taskID string,
 	runtimeConfig models.Config,
 	failure observedRuntimeFailure,
-	runtimeTracker *runtimeFailureTracker,
-	spinTracker *spinningTracker,
+	ledger *progressLedger,
 ) bool {
 	if taskID == "" {
 		return false
 	}
 
-	spinTracker.reset(taskID)
+	// An observed structured failure is an expected-retry situation; it must
+	// not also count toward the generic spin detector.
+	ledger.Reset(taskID, classSpin)
 
-	count := runtimeTracker.Track(taskID, failure)
-	threshold := effectiveSpinningRestartThreshold(runtimeConfig)
+	count := ledger.Observe(taskID, classRuntimeFailure, failure.key())
+	threshold := thresholdFor(classRuntimeFailure, runtimeConfig)
 	if count <= threshold {
 		GetLogger().Warn("Observed structured CLI/runtime failure; suppressing no-progress spin count",
 			"task_id", taskID,
@@ -602,8 +506,7 @@ func handleObservedRuntimeFailureRetry(
 		GetLogger().Warn("Failed to write tool failure retry alert", "error", alertErr)
 	}
 	blockTaskFromSupervisor(bb, config.ProjectRoot, taskID, config.AgentID, reason)
-	runtimeTracker.reset(taskID)
-	spinTracker.reset(taskID)
+	ledger.Reset(taskID, classRuntimeFailure, classSpin)
 	return true
 }
 
@@ -737,11 +640,10 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 		config.ExecutionProgressTimeout = effectiveAgentProgressTimeout(state.Config)
 	}
 
-	exit42Tracker := newExit42RestartTracker()
-	crashTracker := newCrashRestartTracker()
-	spinTracker := newSpinningTracker()
-	successNoProgressTracker := newSpinningTracker()
-	runtimeFailureTracker := newRuntimeFailureTracker()
+	// Single non-progress ledger backing every loop-detection class
+	// (exit-42, crash, spin, success-no-progress, runtime-failure).
+	ledger := newProgressLedger()
+	exit42Tracker := newExit42RestartTrackerWithLedger(ledger)
 	readSuccessProgressSnapshot := func(taskID string) (string, bool) {
 		if taskID == "" {
 			return "", false
@@ -855,8 +757,8 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 			if task := stateBefore.FindTask(effectiveTask); task != nil {
 				sig = exit42TaskProgressSignature(task)
 			}
-			spinCount := spinTracker.Track(effectiveTask, sig)
-			spinThreshold := effectiveSpinningRestartThreshold(stateBefore.Config)
+			spinCount := ledger.Observe(effectiveTask, classSpin, sig)
+			spinThreshold := thresholdFor(classSpin, stateBefore.Config)
 			if spinCount > spinThreshold {
 				reason := fmt.Sprintf("spinning detected: %d consecutive executions for task %s without progress (threshold=%d)",
 					spinCount, effectiveTask, spinThreshold)
@@ -868,7 +770,7 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 					GetLogger().Warn("Failed to write spinning alert", "error", alertErr)
 				}
 				blockTaskFromSupervisor(bb, config.ProjectRoot, effectiveTask, config.AgentID, reason)
-				spinTracker.reset(effectiveTask)
+				ledger.Reset(effectiveTask, classSpin)
 				continue
 			}
 		} else {
@@ -876,8 +778,8 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 			// signature. If the orchestrator keeps executing without changing
 			// sprint status, sprint number, or task count, it is spinning.
 			sig := orchestratorProgressSignature(stateBefore)
-			spinCount := spinTracker.Track("orchestrator", sig)
-			spinThreshold := effectiveSpinningRestartThreshold(stateBefore.Config)
+			spinCount := ledger.Observe("orchestrator", classSpin, sig)
+			spinThreshold := thresholdFor(classSpin, stateBefore.Config)
 			if spinCount > spinThreshold {
 				reason := fmt.Sprintf("orchestrator spinning detected: %d consecutive executions without state progress (threshold=%d)",
 					spinCount, spinThreshold)
@@ -903,8 +805,7 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 					"task_id", claimedTaskID,
 					"error", err)
 				blockTaskFromSupervisor(bb, config.ProjectRoot, claimedTaskID, config.AgentID, reason)
-				spinTracker.reset(effectiveTask)
-				successNoProgressTracker.reset(effectiveTask)
+				ledger.Reset(effectiveTask, classSpin, classSuccessNoProgress)
 				continue
 			}
 			return fmt.Errorf("failed to build prompt: %w", err)
@@ -927,13 +828,12 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 
 		if exitCode == 0 && effectiveTask != "" {
 			if failure := detectObservedRuntimeFailure(currentOutput); failure != nil {
-				handleObservedRuntimeFailureRetry(bb, config, effectiveTask, stateBefore.Config, *failure, runtimeFailureTracker, spinTracker)
-				successNoProgressTracker.reset(effectiveTask)
+				handleObservedRuntimeFailureRetry(bb, config, effectiveTask, stateBefore.Config, *failure, ledger)
+				ledger.Reset(effectiveTask, classSuccessNoProgress, classCrash)
 				if err := resetAgentAfterExit(bb, config.AgentID, config.ProjectRoot); err != nil {
 					GetLogger().Warn("Failed to reset agent status after runtime failure", "error", err, "agent_id", config.AgentID)
 				}
 				exit42Tracker.reset(taskID)
-				crashTracker.reset(effectiveTask)
 				continue
 			}
 		}
@@ -956,7 +856,7 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 		switch exitCode {
 		case 0:
 			if effectiveTask != "" {
-				runtimeFailureTracker.reset(effectiveTask)
+				ledger.Reset(effectiveTask, classRuntimeFailure)
 			}
 
 			GetLogger().Info("Agent completed, checking for more work")
@@ -966,8 +866,8 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 			if effectiveTask != "" {
 				successSignature := successfulTurnProgressSignature(config.CLIName, currentOutput, postSuccessSnapshot)
 				if postSuccessEligible && successSignature != "" {
-					noProgressCount := successNoProgressTracker.Track(effectiveTask, successSignature)
-					spinThreshold := effectiveSpinningRestartThreshold(stateBefore.Config)
+					noProgressCount := ledger.Observe(effectiveTask, classSuccessNoProgress, successSignature)
+					spinThreshold := thresholdFor(classSuccessNoProgress, stateBefore.Config)
 					if noProgressCount > spinThreshold {
 						reason := fmt.Sprintf("successful no-progress loop detected: %d consecutive successful executions for task %s without task, state, or worktree progress (threshold=%d)",
 							noProgressCount, effectiveTask, spinThreshold)
@@ -979,22 +879,21 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 							GetLogger().Warn("Failed to write no-progress alert", "error", alertErr)
 						}
 						blockTaskFromSupervisor(bb, config.ProjectRoot, effectiveTask, config.AgentID, reason)
-						successNoProgressTracker.reset(effectiveTask)
-						spinTracker.reset(effectiveTask)
+						ledger.Reset(effectiveTask, classSuccessNoProgress, classSpin)
 						continue
 					}
 				} else {
-					successNoProgressTracker.reset(effectiveTask)
+					ledger.Reset(effectiveTask, classSuccessNoProgress)
 				}
 			}
 			exit42Tracker.reset(taskID)
-			crashTracker.reset(effectiveTask)
+			ledger.Reset(effectiveTask, classCrash)
 		case 42:
 			restartTaskID := claimedTaskID
 			if restartTaskID == "" {
 				restartTaskID = taskID
 			}
-			runtimeFailureTracker.reset(restartTaskID)
+			ledger.Reset(restartTaskID, classRuntimeFailure)
 
 			outcome, trackErr := exit42Tracker.Handle(bb, config.ProjectRoot, config.Role, restartTaskID, config.AgentID)
 			if trackErr != nil {
@@ -1024,7 +923,7 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 			}
 		default:
 			exit42Tracker.reset(taskID)
-			runtimeFailureTracker.reset(effectiveTask)
+			ledger.Reset(effectiveTask, classRuntimeFailure)
 
 			// Check if crash was caused by a provider-scoped failure.
 			if handleClassifiedProviderCrash(config, currentOutput) {
@@ -1039,8 +938,8 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 						sig = exit42TaskProgressSignature(task)
 					}
 				}
-				crashCount := crashTracker.Increment(effectiveTask, sig)
-				crashThreshold := effectiveCrashRestartThreshold(stateBefore.Config)
+				crashCount := ledger.Observe(effectiveTask, classCrash, sig)
+				crashThreshold := thresholdFor(classCrash, stateBefore.Config)
 				if crashCount > crashThreshold {
 					reason := fmt.Sprintf("crash restart loop detected: %d consecutive crashes for task %s without progress (threshold=%d, last exit code=%d)",
 						crashCount, effectiveTask, crashThreshold, exitCode)
@@ -1053,7 +952,7 @@ func RunSupervisor(ctx context.Context, config SupervisorConfig) error {
 						GetLogger().Warn("Failed to write crash alert", "error", alertErr)
 					}
 					blockTaskFromSupervisor(bb, config.ProjectRoot, effectiveTask, config.AgentID, reason)
-					crashTracker.reset(effectiveTask)
+					ledger.Reset(effectiveTask, classCrash)
 					continue
 				}
 			}

--- a/internal/agent/supervisor_test.go
+++ b/internal/agent/supervisor_test.go
@@ -1118,68 +1118,91 @@ func TestExit42RestartTracker_BlocksNonCoderRoles(t *testing.T) {
 	}
 }
 
-func TestCrashRestartTracker_BlocksAfterThreshold(t *testing.T) {
-	tracker := newCrashRestartTracker()
+func TestProgressLedger_CrashClass_BlocksAfterThreshold(t *testing.T) {
+	ledger := newProgressLedger()
 	threshold := 3
 
 	// Same signature (no progress) — count accumulates.
 	for i := 1; i <= threshold; i++ {
-		count := tracker.Increment("task-1", "same-sig")
+		count := ledger.Observe("task-1", classCrash, "same-sig")
 		if count != i {
-			t.Fatalf("Increment() = %d, want %d", count, i)
+			t.Fatalf("Observe() = %d, want %d", count, i)
 		}
 	}
 
 	// Over threshold.
-	count := tracker.Increment("task-1", "same-sig")
+	count := ledger.Observe("task-1", classCrash, "same-sig")
 	if count != threshold+1 {
-		t.Fatalf("Increment() = %d, want %d", count, threshold+1)
+		t.Fatalf("Observe() = %d, want %d", count, threshold+1)
 	}
 
 	// Reset clears.
-	tracker.reset("task-1")
-	count = tracker.Increment("task-1", "same-sig")
+	ledger.Reset("task-1", classCrash)
+	count = ledger.Observe("task-1", classCrash, "same-sig")
 	if count != 1 {
-		t.Fatalf("after reset, Increment() = %d, want 1", count)
+		t.Fatalf("after reset, Observe() = %d, want 1", count)
 	}
 }
 
-func TestCrashRestartTracker_ResetsOnProgress(t *testing.T) {
-	tracker := newCrashRestartTracker()
+func TestProgressLedger_CrashClass_ResetsOnProgress(t *testing.T) {
+	ledger := newProgressLedger()
 
-	tracker.Increment("task-1", "sig-a")
-	tracker.Increment("task-1", "sig-a")
+	ledger.Observe("task-1", classCrash, "sig-a")
+	ledger.Observe("task-1", classCrash, "sig-a")
 
 	// Signature changes — progress detected, counter resets.
-	count := tracker.Increment("task-1", "sig-b")
+	count := ledger.Observe("task-1", classCrash, "sig-b")
 	if count != 1 {
-		t.Fatalf("Increment() after progress = %d, want 1", count)
+		t.Fatalf("Observe() after progress = %d, want 1", count)
 	}
 }
 
-func TestSpinningTracker_BlocksAfterThreshold(t *testing.T) {
-	tracker := newSpinningTracker()
+func TestProgressLedger_SpinClass_CountsConsecutiveExecutions(t *testing.T) {
+	ledger := newProgressLedger()
 	threshold := 5
 
 	for i := 1; i <= threshold+1; i++ {
-		count := tracker.Track("task-1", "same-sig")
+		count := ledger.Observe("task-1", classSpin, "same-sig")
 		if count != i {
-			t.Fatalf("Track() = %d, want %d", count, i)
+			t.Fatalf("Observe() = %d, want %d", count, i)
 		}
 	}
 }
 
-func TestSpinningTracker_ResetsOnProgress(t *testing.T) {
-	tracker := newSpinningTracker()
+func TestProgressLedger_SpinClass_ResetsOnProgress(t *testing.T) {
+	ledger := newProgressLedger()
 
-	tracker.Track("task-1", "sig-a")
-	tracker.Track("task-1", "sig-a")
-	tracker.Track("task-1", "sig-a")
+	ledger.Observe("task-1", classSpin, "sig-a")
+	ledger.Observe("task-1", classSpin, "sig-a")
+	ledger.Observe("task-1", classSpin, "sig-a")
 
 	// Progress detected.
-	count := tracker.Track("task-1", "sig-b")
+	count := ledger.Observe("task-1", classSpin, "sig-b")
 	if count != 1 {
-		t.Fatalf("Track() after progress = %d, want 1", count)
+		t.Fatalf("Observe() after progress = %d, want 1", count)
+	}
+}
+
+func TestProgressLedger_ClassesAreIndependent(t *testing.T) {
+	ledger := newProgressLedger()
+
+	ledger.Observe("task-1", classSpin, "sig-a")
+	ledger.Observe("task-1", classSpin, "sig-a")
+	ledger.Observe("task-1", classCrash, "sig-a")
+
+	// Resetting one class must not disturb another.
+	ledger.Reset("task-1", classCrash)
+	if count := ledger.Observe("task-1", classSpin, "sig-a"); count != 3 {
+		t.Fatalf("spin count after crash reset = %d, want 3", count)
+	}
+	if count := ledger.Observe("task-1", classCrash, "sig-a"); count != 1 {
+		t.Fatalf("crash count after reset = %d, want 1", count)
+	}
+
+	// Reset with no classes clears everything for the subject.
+	ledger.Reset("task-1")
+	if count := ledger.Observe("task-1", classSpin, "sig-a"); count != 1 {
+		t.Fatalf("spin count after full reset = %d, want 1", count)
 	}
 }
 
@@ -1244,20 +1267,20 @@ func TestDetectObservedRuntimeFailure_CodexCommandEventAggregatedOutput(t *testi
 	}
 }
 
-func TestRuntimeFailureTracker_ResetsOnDifferentFailure(t *testing.T) {
-	tracker := newRuntimeFailureTracker()
+func TestProgressLedger_RuntimeFailureClass_ResetsOnDifferentFailure(t *testing.T) {
+	ledger := newProgressLedger()
 
 	first := observedRuntimeFailure{Command: "submit-verdict", Code: "internal"}
 	second := observedRuntimeFailure{Command: "submit-verdict", Code: "permission_denied"}
 
-	if count := tracker.Track("task-1", first); count != 1 {
-		t.Fatalf("first Track() = %d, want 1", count)
+	if count := ledger.Observe("task-1", classRuntimeFailure, first.key()); count != 1 {
+		t.Fatalf("first Observe() = %d, want 1", count)
 	}
-	if count := tracker.Track("task-1", first); count != 2 {
-		t.Fatalf("second Track() = %d, want 2", count)
+	if count := ledger.Observe("task-1", classRuntimeFailure, first.key()); count != 2 {
+		t.Fatalf("second Observe() = %d, want 2", count)
 	}
-	if count := tracker.Track("task-1", second); count != 1 {
-		t.Fatalf("Track() after different failure = %d, want 1", count)
+	if count := ledger.Observe("task-1", classRuntimeFailure, second.key()); count != 1 {
+		t.Fatalf("Observe() after different failure = %d, want 1", count)
 	}
 }
 
@@ -1286,24 +1309,23 @@ func TestObservedRuntimeFailureRetry_BlocksWithoutGenericSpin(t *testing.T) {
 		StatePath:   statePath,
 		CLIName:     "codex",
 	}
-	spinTracker := newSpinningTracker()
-	runtimeTracker := newRuntimeFailureTracker()
+	ledger := newProgressLedger()
 	failure := observedRuntimeFailure{Command: "submit-verdict", Code: "internal"}
 	signature := "same-task-state"
 
 	for i := 1; i <= state.Config.SpinningRestartThreshold; i++ {
-		if count := spinTracker.Track(taskID, signature); count != 1 {
+		if count := ledger.Observe(taskID, classSpin, signature); count != 1 {
 			t.Fatalf("spin count before runtime failure %d = %d, want 1", i, count)
 		}
-		if blocked := handleObservedRuntimeFailureRetry(bb, config, taskID, state.Config, failure, runtimeTracker, spinTracker); blocked {
+		if blocked := handleObservedRuntimeFailureRetry(bb, config, taskID, state.Config, failure, ledger); blocked {
 			t.Fatalf("runtime failure attempt %d blocked, want below threshold", i)
 		}
 	}
 
-	if count := spinTracker.Track(taskID, signature); count != 1 {
+	if count := ledger.Observe(taskID, classSpin, signature); count != 1 {
 		t.Fatalf("spin count before blocking runtime failure = %d, want 1", count)
 	}
-	if blocked := handleObservedRuntimeFailureRetry(bb, config, taskID, state.Config, failure, runtimeTracker, spinTracker); !blocked {
+	if blocked := handleObservedRuntimeFailureRetry(bb, config, taskID, state.Config, failure, ledger); !blocked {
 		t.Fatal("runtime failure over threshold did not block task")
 	}
 

--- a/internal/agent/systemctl_test.go
+++ b/internal/agent/systemctl_test.go
@@ -852,20 +852,20 @@ func TestOrchestratorProgressSignature(t *testing.T) {
 
 // TestOrchestratorSpinningTracker verifies spinning detection for orchestrator.
 func TestOrchestratorSpinningTracker(t *testing.T) {
-	tracker := newSpinningTracker()
+	ledger := newProgressLedger()
 	sig := "sprint:IN_PROGRESS:1:tasks:3:planned:3"
 
 	// Same signature N times → count increases
 	for i := 1; i <= 5; i++ {
-		count := tracker.Track("orchestrator", sig)
+		count := ledger.Observe("orchestrator", classSpin, sig)
 		if count != i {
-			t.Errorf("Track() = %d, want %d", count, i)
+			t.Errorf("Observe() = %d, want %d", count, i)
 		}
 	}
 
 	// Different signature → resets
-	count := tracker.Track("orchestrator", "sprint:CHECKPOINT:1:tasks:3:planned:3")
+	count := ledger.Observe("orchestrator", classSpin, "sprint:CHECKPOINT:1:tasks:3:planned:3")
 	if count != 1 {
-		t.Errorf("Track() after signature change = %d, want 1", count)
+		t.Errorf("Observe() after signature change = %d, want 1", count)
 	}
 }

--- a/internal/agent/worktree_check.go
+++ b/internal/agent/worktree_check.go
@@ -126,7 +126,7 @@ func ensureReviewerWorktree(projectRoot string, bb *db.Blackboard, taskID, agent
 	}
 
 	// Record recovery in history.
-	if modErr := bb.Modify(func(s *models.State) error {
+	if modErr := bb.ModifyOp("ensure_reviewer_worktree", func(s *models.State) error {
 		t := s.FindTask(taskID)
 		if t != nil {
 			agentPtr := agentID
@@ -149,7 +149,7 @@ func ensureReviewerWorktree(projectRoot string, bb *db.Blackboard, taskID, agent
 // transition validation. This handles the exceptional case where a reviewer
 // task's worktree is unrecoverable and no valid transition path to BLOCKED exists.
 func blockReviewerTask(bb *db.Blackboard, taskID, agentID, reason string) {
-	if err := bb.Modify(func(state *models.State) error {
+	if err := bb.ModifyOp("block_reviewer_task", func(state *models.State) error {
 		t := state.FindTask(taskID)
 		if t == nil {
 			return nil
@@ -171,6 +171,7 @@ func blockReviewerTask(bb *db.Blackboard, taskID, agentID, reason string) {
 		// Clear reviewer claim.
 		t.ReviewingBy = nil
 		t.ReviewLeaseExpires = nil
+		state.ReleaseClaimRecord(t.ID, models.ClaimKindReviewer)
 
 		now := time.Now().UTC()
 		t.History = append(t.History, models.TaskHistoryEntry{

--- a/internal/commands/journal.go
+++ b/internal/commands/journal.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"github.com/liza-mas/liza/internal/db"
+	"github.com/liza-mas/liza/internal/journal"
+	"github.com/liza-mas/liza/internal/paths"
+)
+
+// JournalOptions controls JournalCommand filtering and verification.
+type JournalOptions struct {
+	// Since returns only events with Seq strictly greater than this value.
+	Since int64
+	// Task filters events to a single task ID ("" disables the filter).
+	Task string
+	// Limit keeps only the last N matching events (0 disables the limit).
+	Limit int
+	// Verify additionally checks that folding the journal reproduces the
+	// task statuses currently in state.yaml.
+	Verify bool
+}
+
+// JournalVerification reports the journal/state equivalence check.
+type JournalVerification struct {
+	Equivalent bool `json:"equivalent"`
+	// Diff maps task ID → [projected status, actual status] for divergences.
+	Diff map[string][2]string `json:"diff,omitempty"`
+}
+
+// JournalResult is the output of JournalCommand.
+type JournalResult struct {
+	Events       []journal.Event      `json:"events"`
+	TotalEvents  int                  `json:"total_events"`
+	Verification *JournalVerification `json:"verification,omitempty"`
+}
+
+// JournalCommand reads the shadow event journal, applies filters, and
+// optionally verifies projection equivalence against state.yaml.
+func JournalCommand(projectRoot string, opts JournalOptions) (*JournalResult, error) {
+	lp := paths.New(projectRoot)
+	store := journal.ForStatePath(lp.StatePath())
+
+	all, err := store.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &JournalResult{TotalEvents: len(all)}
+
+	filtered := make([]journal.Event, 0, len(all))
+	for _, ev := range all {
+		if ev.Seq <= opts.Since {
+			continue
+		}
+		if opts.Task != "" && ev.Task != opts.Task {
+			continue
+		}
+		filtered = append(filtered, ev)
+	}
+	if opts.Limit > 0 && len(filtered) > opts.Limit {
+		filtered = filtered[len(filtered)-opts.Limit:]
+	}
+	result.Events = filtered
+
+	if opts.Verify {
+		state, err := db.For(lp.StatePath()).Read()
+		if err != nil {
+			return nil, err
+		}
+		actual := map[string]string{}
+		for _, task := range state.Tasks {
+			actual[task.ID] = string(task.Status)
+		}
+		diff := journal.ProjectTaskStatuses(all).Diff(actual)
+		result.Verification = &JournalVerification{
+			Equivalent: len(diff) == 0,
+		}
+		if len(diff) > 0 {
+			result.Verification.Diff = diff
+		}
+	}
+
+	return result, nil
+}

--- a/internal/commands/schedule.go
+++ b/internal/commands/schedule.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/liza-mas/liza/internal/db"
+	"github.com/liza-mas/liza/internal/paths"
+	"github.com/liza-mas/liza/internal/pipeline"
+	"github.com/liza-mas/liza/internal/scheduler"
+)
+
+// ScheduleResult is the read-only output of ScheduleCommand: the runnable-work
+// Plan the scheduler derives from current state.
+type ScheduleResult struct {
+	Counts map[string]int       `json:"counts"`
+	Items  []scheduler.WorkItem `json:"items"`
+	Plan   scheduler.Plan       `json:"-"`
+}
+
+// ScheduleCommand computes the current runnable-work plan (doer/review/merge/
+// reclaim) without mutating anything. It is a diagnostic view of the same
+// decision a future scheduler loop will dispatch from.
+func ScheduleCommand(projectRoot string) (*ScheduleResult, error) {
+	lp := paths.New(projectRoot)
+	state, err := db.For(lp.StatePath()).Read()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := pipeline.LoadFrozen(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	resolver := pipeline.NewResolver(cfg)
+
+	plan := scheduler.Compute(state, resolver, time.Now().UTC())
+
+	counts := map[string]int{}
+	for kind, n := range plan.Counts() {
+		counts[string(kind)] = n
+	}
+
+	return &ScheduleResult{
+		Counts: counts,
+		Items:  plan.Items,
+		Plan:   plan,
+	}, nil
+}

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/liza-mas/liza/internal/db"
 	lizaerrors "github.com/liza-mas/liza/internal/errors"
+	"github.com/liza-mas/liza/internal/journal"
 	"github.com/liza-mas/liza/internal/models"
 	"github.com/liza-mas/liza/internal/ops"
 	"github.com/liza-mas/liza/internal/procscan"
@@ -90,7 +91,49 @@ func ValidateCommandWithOptions(statePath string, opts ValidateOptions) error {
 			return &lizaerrors.ValidationError{Message: err.Error(), Err: err}
 		}
 	}
+	warnJournalDivergence(statePath, state, warnings)
 	return nil
+}
+
+// warnJournalDivergence reports where the journal-reconstructed view
+// contradicts state.yaml across the dimensions the journal fully captures:
+// task statuses, claim holders, and the system singletons (sprint, circuit
+// breaker, goal, mode). Warning-level while the journal is a shadow log —
+// state.yaml remains authoritative. Reads the full history (including rotated
+// archives) so the claim/singleton folds, which have no rotation snapshot,
+// stay complete. Dimensions the journal has no opinion on (pre-journal tasks,
+// unseen singletons) are intentionally silent.
+func warnJournalDivergence(statePath string, state *models.State, warnings io.Writer) {
+	events, err := journal.ForStatePath(statePath).ReadAllIncludingArchives()
+	if err != nil {
+		fmt.Fprintf(warnings, "WARNING: journal unreadable, skipping coherence check: %v\n", err)
+		return
+	}
+	if len(events) == 0 {
+		return
+	}
+
+	recon := journal.Reconstruct(events)
+
+	for i := range state.Tasks {
+		task := &state.Tasks[i]
+		projected, journaled := recon.TaskStatuses[task.ID]
+		if !journaled {
+			continue
+		}
+		if projected != string(task.Status) {
+			fmt.Fprintf(warnings,
+				"WARNING: journal/state divergence for task %s: journal=%q state=%q (investigate with `liza journal --task %s`)\n",
+				task.ID, projected, task.Status, task.ID)
+		}
+	}
+
+	for _, d := range recon.DiffClaims(state) {
+		fmt.Fprintf(warnings, "WARNING: journal/state divergence: %s\n", d)
+	}
+	for _, d := range recon.DiffSingletons(state) {
+		fmt.Fprintf(warnings, "WARNING: journal/state divergence: %s\n", d)
+	}
 }
 
 func validateNoZombieAgents(state *models.State, projectRoot string, warnings io.Writer) error {

--- a/internal/commands/validate_journal_test.go
+++ b/internal/commands/validate_journal_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/liza-mas/liza/internal/journal"
+	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/testhelpers"
+)
+
+func TestWarnJournalDivergence_ReportsContradiction(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.yaml")
+
+	state := testhelpers.CreateValidState()
+	state.Tasks = []models.Task{
+		{ID: "task-journaled", Status: "READY"},
+		{ID: "task-pre-journal", Status: "MERGED"},
+	}
+
+	// Journal knows task-journaled with a contradicting status, and has never
+	// seen task-pre-journal (upgraded project) — only the former may warn.
+	store := journal.ForStatePath(statePath)
+	err := store.Append([]journal.Event{
+		{Type: journal.EventTaskCreated, Task: "task-journaled", Fields: map[string]any{"status": "IMPLEMENTING_CODE"}},
+	})
+	if err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	var warnings strings.Builder
+	warnJournalDivergence(statePath, state, &warnings)
+
+	out := warnings.String()
+	if !strings.Contains(out, "task-journaled") || !strings.Contains(out, `journal="IMPLEMENTING_CODE"`) {
+		t.Errorf("expected divergence warning for task-journaled, got: %q", out)
+	}
+	if strings.Contains(out, "task-pre-journal") {
+		t.Errorf("pre-journal task must not warn, got: %q", out)
+	}
+}
+
+func TestWarnJournalDivergence_SilentWhenCoherent(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.yaml")
+
+	state := testhelpers.CreateValidState()
+	state.Tasks = []models.Task{{ID: "task-1", Status: "READY"}}
+
+	store := journal.ForStatePath(statePath)
+	err := store.Append([]journal.Event{
+		{Type: journal.EventTaskCreated, Task: "task-1", Fields: map[string]any{"status": "READY"}},
+	})
+	if err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	var warnings strings.Builder
+	warnJournalDivergence(statePath, state, &warnings)
+	if warnings.Len() != 0 {
+		t.Errorf("expected no warnings for coherent journal, got: %q", warnings.String())
+	}
+}
+
+func TestWarnJournalDivergence_SilentWithoutJournal(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.yaml")
+
+	state := testhelpers.CreateValidState()
+	state.Tasks = []models.Task{{ID: "task-1", Status: "READY"}}
+
+	var warnings strings.Builder
+	warnJournalDivergence(statePath, state, &warnings)
+	if warnings.Len() != 0 {
+		t.Errorf("expected no warnings without a journal file, got: %q", warnings.String())
+	}
+}

--- a/internal/db/blackboard.go
+++ b/internal/db/blackboard.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -12,9 +13,12 @@ import (
 
 	"github.com/liza-mas/liza/internal/errors"
 	"github.com/liza-mas/liza/internal/filelock"
+	"github.com/liza-mas/liza/internal/journal"
 	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/pipeline"
 	"github.com/liza-mas/liza/internal/roles"
 	"github.com/liza-mas/liza/internal/statehygiene"
+	"github.com/liza-mas/liza/internal/taskinvariants"
 	"gopkg.in/yaml.v3"
 )
 
@@ -36,6 +40,12 @@ type Blackboard struct {
 	cacheMu     sync.RWMutex
 	cachedData  []byte
 	cachedMtime time.Time
+
+	// Structural-invariant classifier for write-funnel enforcement, loaded
+	// lazily from the frozen pipeline config. nil when the config is absent
+	// (legacy projects, unit tests) — enforcement is then skipped.
+	invariantsOnce sync.Once
+	invariants     *taskinvariants.StatusClassifier
 }
 
 // New creates a Blackboard backed by the given state file path.
@@ -329,11 +339,20 @@ func marshalStateForWrite(state *models.State) ([]byte, error) {
 // Write writes the state to the state file atomically with fsync
 func (bb *Blackboard) Write(state *models.State) error {
 	err := bb.fileLock.WithLockOperation("write", func() error {
+		before, beforeOK := bb.readStateForDiff()
+
 		data, err := marshalStateForWrite(state)
 		if err != nil {
 			return err
 		}
-		return bb.writeStateData(data)
+		if err := bb.writeStateData(data); err != nil {
+			return err
+		}
+
+		if beforeOK {
+			bb.appendDerivedEvents("write", before, state)
+		}
+		return nil
 	})
 
 	if err == nil {
@@ -343,9 +362,145 @@ func (bb *Blackboard) Write(state *models.State) error {
 	return err
 }
 
-// Modify performs an atomic read-modify-write operation
+// WriteInvariantError reports a named operation that attempted to write a
+// task violating a structural invariant. The write is aborted — state.yaml
+// is untouched.
+type WriteInvariantError struct {
+	Op     string
+	TaskID string
+	Err    error
+}
+
+func (e *WriteInvariantError) Error() string {
+	return fmt.Sprintf("operation %q rejected: would write structurally invalid task %s: %v", e.Op, e.TaskID, e.Err)
+}
+
+func (e *WriteInvariantError) Unwrap() error { return e.Err }
+
+// checkWriteInvariants enforces structural per-task invariants at the write
+// funnel for named operations with no-worse-than-before semantics: an
+// operation may not INTRODUCE a structural violation (create an invalid task,
+// or turn a valid task invalid), but touching a task that was already invalid
+// is allowed — otherwise pre-existing corruption would wedge the very
+// operations that repair it.
+//
+// Fail-open cases, deliberate during the strangler migration:
+//   - generic "modify"/"write" operations (unmigrated call sites, fixtures);
+//   - no frozen pipeline config (legacy projects, most unit tests).
+func (bb *Blackboard) checkWriteInvariants(op string, before, after *models.State) error {
+	if op == "modify" || op == "write" {
+		return nil
+	}
+	sc := bb.statusClassifier()
+	if sc == nil {
+		return nil
+	}
+
+	beforeTasks := make(map[string]*models.Task, len(before.Tasks))
+	for i := range before.Tasks {
+		beforeTasks[before.Tasks[i].ID] = &before.Tasks[i]
+	}
+	for i := range after.Tasks {
+		task := &after.Tasks[i]
+		prev := beforeTasks[task.ID]
+		if prev != nil && reflect.DeepEqual(*prev, *task) {
+			continue
+		}
+		err := taskinvariants.ValidateStatusFields(task, sc)
+		if err == nil {
+			continue
+		}
+		if prev != nil && taskinvariants.ValidateStatusFields(prev, sc) != nil {
+			// Pre-existing violation on this task; the op did not introduce it.
+			continue
+		}
+		return &WriteInvariantError{Op: op, TaskID: task.ID, Err: err}
+	}
+	return nil
+}
+
+// statusClassifier lazily loads the structural classifier from the frozen
+// pipeline config next to the state file. Returns nil when unavailable.
+func (bb *Blackboard) statusClassifier() *taskinvariants.StatusClassifier {
+	bb.invariantsOnce.Do(func() {
+		projectRoot := filepath.Dir(filepath.Dir(bb.statePath))
+		cfg, err := pipeline.LoadFrozen(projectRoot)
+		if err != nil {
+			return
+		}
+		sc := taskinvariants.NewStatusClassifier(pipeline.NewResolver(cfg), cfg)
+		bb.invariants = &sc
+	})
+	return bb.invariants
+}
+
+// readStateForDiff reads and parses the current state file as the "before"
+// snapshot for journal derivation. A missing file is a valid empty before
+// state (project initialization); any other failure disables journaling for
+// this write rather than failing the state operation.
+func (bb *Blackboard) readStateForDiff() (*models.State, bool) {
+	data, err := os.ReadFile(bb.statePath)
+	if os.IsNotExist(err) {
+		return &models.State{}, true
+	}
+	if err != nil {
+		return nil, false
+	}
+	var state models.State
+	if err := yaml.Unmarshal(data, &state); err != nil {
+		return nil, false
+	}
+	normalizeAgentRoles(&state)
+	normalizeTaskAttempts(&state)
+	return &state, true
+}
+
+// appendDerivedEvents derives journal events from a state transition and
+// appends them to the shadow journal. Must be called while holding the state
+// file lock so appends serialize with state writes.
+//
+// During the shadow-journal phase state.yaml remains the source of truth, so
+// an append failure must not fail (or invite a retry of) a state write that
+// already succeeded — it is reported on stderr and surfaces in
+// `liza journal --verify` instead.
+func (bb *Blackboard) appendDerivedEvents(op string, before, after *models.State) {
+	events := journal.Derive(before, after)
+	if len(events) == 0 {
+		return
+	}
+	for i := range events {
+		events[i].Op = op
+	}
+	store := journal.ForStatePath(bb.statePath)
+	if err := store.Append(events); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: journal append failed (state write succeeded): %v\n", err)
+		return
+	}
+	// Rotation check is O(1) per append: MaybeRotate stats the file and only
+	// counts events once the size heuristic says the threshold may be
+	// exceeded. We hold the state file lock here, satisfying Rotate's
+	// contract. Failures are non-fatal — the journal just keeps growing and
+	// the next append retries.
+	if _, err := store.MaybeRotate(journal.DefaultRotateThreshold); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: journal rotation failed (state write succeeded): %v\n", err)
+	}
+}
+
+// Modify performs an atomic read-modify-write operation under the generic
+// "modify" operation name. Prefer ModifyOp at call sites that represent a
+// named lifecycle operation — the name flows into lock-owner diagnostics and
+// journal event provenance.
 func (bb *Blackboard) Modify(fn func(*models.State) error) error {
-	err := bb.fileLock.WithLockOperation("modify", func() error {
+	return bb.ModifyOp("modify", fn)
+}
+
+// ModifyOp performs an atomic read-modify-write operation attributed to the
+// named operation.
+func (bb *Blackboard) ModifyOp(op string, fn func(*models.State) error) error {
+	if op == "" {
+		op = "modify"
+	}
+	err := bb.fileLock.WithLockOperation(op, func() error {
 		data, err := os.ReadFile(bb.statePath)
 		if err != nil {
 			return fmt.Errorf("failed to read state: %w", err)
@@ -356,18 +511,36 @@ func (bb *Blackboard) Modify(fn func(*models.State) error) error {
 			return &errors.StateSchemaError{Operation: "state modify", Err: err}
 		}
 
+		// Second unmarshal of the same bytes: an independent "before" snapshot
+		// for journal derivation that fn cannot reach through shared pointers.
+		var before models.State
+		if err := yaml.Unmarshal(data, &before); err != nil {
+			return &errors.StateSchemaError{Operation: "state modify", Err: err}
+		}
+
 		normalizeAgentRoles(&state)
 		normalizeTaskAttempts(&state)
+		normalizeAgentRoles(&before)
+		normalizeTaskAttempts(&before)
 
 		if err := fn(&state); err != nil {
 			return fmt.Errorf("modification function failed: %w", err)
+		}
+
+		if err := bb.checkWriteInvariants(op, &before, &state); err != nil {
+			return err
 		}
 
 		data, err = marshalStateForWrite(&state)
 		if err != nil {
 			return err
 		}
-		return bb.writeStateData(data)
+		if err := bb.writeStateData(data); err != nil {
+			return err
+		}
+
+		bb.appendDerivedEvents(op, &before, &state)
+		return nil
 	})
 
 	if err == nil {
@@ -403,7 +576,7 @@ func (bb *Blackboard) GetAgent(agentID string) (*models.Agent, error) {
 
 // UpdateTask atomically updates a task by ID
 func (bb *Blackboard) UpdateTask(taskID string, fn func(*models.Task) error) error {
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("update_task", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -414,7 +587,7 @@ func (bb *Blackboard) UpdateTask(taskID string, fn func(*models.Task) error) err
 
 // UpdateAgent atomically updates an agent by ID
 func (bb *Blackboard) UpdateAgent(agentID string, fn func(*models.Agent) error) error {
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("update_agent", func(state *models.State) error {
 		agent, ok := state.Agents[agentID]
 		if !ok {
 			return &errors.NotFoundError{Entity: "agent", ID: agentID}

--- a/internal/db/blackboard_invariants_test.go
+++ b/internal/db/blackboard_invariants_test.go
@@ -1,0 +1,182 @@
+package db
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/liza-mas/liza/internal/embedded"
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// invariantTestBlackboard sets up a project dir with a frozen pipeline config
+// (so the write funnel's classifier loads) and an initial state with one
+// DRAFT_CODE coding-pair task.
+func invariantTestBlackboard(t *testing.T) *Blackboard {
+	t.Helper()
+	root := t.TempDir()
+	lizaDir := filepath.Join(root, ".liza")
+	if err := os.MkdirAll(lizaDir, 0755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := embedded.WritePipelineConfig(lizaDir, nil); err != nil {
+		t.Fatalf("WritePipelineConfig failed: %v", err)
+	}
+
+	bb := New(filepath.Join(lizaDir, "state.yaml"))
+	if err := bb.Write(&models.State{
+		Version: 1,
+		Tasks: []models.Task{
+			{ID: "task-1", Status: "DRAFT_CODE", RolePair: "coding-pair"},
+		},
+		Agents: map[string]models.Agent{},
+	}); err != nil {
+		t.Fatalf("initial Write failed: %v", err)
+	}
+	return bb
+}
+
+func TestWriteFunnel_RejectsInvalidTaskFromNamedOp(t *testing.T) {
+	bb := invariantTestBlackboard(t)
+
+	// Claim without worktree/lease/base_commit — structurally invalid.
+	err := bb.ModifyOp("claim_task", func(state *models.State) error {
+		task := state.FindTask("task-1")
+		task.Status = "IMPLEMENTING_CODE"
+		agent := "coder-1"
+		task.AssignedTo = &agent
+		return nil
+	})
+
+	var invErr *WriteInvariantError
+	if !errors.As(err, &invErr) {
+		t.Fatalf("expected WriteInvariantError, got %v", err)
+	}
+	if invErr.Op != "claim_task" || invErr.TaskID != "task-1" {
+		t.Errorf("unexpected error attribution: %+v", invErr)
+	}
+
+	// The write must have been aborted: state.yaml untouched.
+	state, readErr := bb.Read()
+	if readErr != nil {
+		t.Fatalf("Read failed: %v", readErr)
+	}
+	if got := state.FindTask("task-1").Status; got != "DRAFT_CODE" {
+		t.Errorf("state mutated despite rejection: status = %s", got)
+	}
+}
+
+func TestWriteFunnel_AcceptsValidTaskFromNamedOp(t *testing.T) {
+	bb := invariantTestBlackboard(t)
+
+	err := bb.ModifyOp("claim_task", func(state *models.State) error {
+		task := state.FindTask("task-1")
+		task.Status = "IMPLEMENTING_CODE"
+		agent := "coder-1"
+		worktree := ".worktrees/task-1"
+		base := "abc123"
+		lease := time.Now().Add(30 * time.Minute)
+		task.AssignedTo = &agent
+		task.Worktree = &worktree
+		task.BaseCommit = &base
+		task.LeaseExpires = &lease
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("valid claim rejected: %v", err)
+	}
+}
+
+func TestWriteFunnel_GenericModifyRemainsPermissive(t *testing.T) {
+	bb := invariantTestBlackboard(t)
+
+	// The same invalid mutation through unmigrated generic Modify must pass
+	// (fail-open during the strangler migration).
+	err := bb.Modify(func(state *models.State) error {
+		task := state.FindTask("task-1")
+		task.Status = "IMPLEMENTING_CODE"
+		agent := "coder-1"
+		task.AssignedTo = &agent
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("generic modify unexpectedly rejected: %v", err)
+	}
+}
+
+func TestWriteFunnel_UntouchedCorruptTaskDoesNotBlockOtherWrites(t *testing.T) {
+	bb := invariantTestBlackboard(t)
+
+	// Introduce pre-existing corruption through the permissive generic path.
+	if err := bb.Modify(func(state *models.State) error {
+		task := state.FindTask("task-1")
+		task.Status = "IMPLEMENTING_CODE" // invalid: no worktree/lease
+		agent := "coder-1"
+		task.AssignedTo = &agent
+		return nil
+	}); err != nil {
+		t.Fatalf("setup modify failed: %v", err)
+	}
+
+	// A named op touching a DIFFERENT task must still be writable, otherwise
+	// corruption would wedge the whole system.
+	err := bb.ModifyOp("add_task", func(state *models.State) error {
+		state.Tasks = append(state.Tasks, models.Task{
+			ID: "task-2", Status: "DRAFT_CODE", RolePair: "coding-pair",
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("named op blocked by unrelated pre-existing corruption: %v", err)
+	}
+}
+
+func TestWriteFunnel_TouchingPreExistingInvalidTaskAllowed(t *testing.T) {
+	bb := invariantTestBlackboard(t)
+
+	// Pre-existing corruption introduced through the permissive generic path.
+	if err := bb.Modify(func(state *models.State) error {
+		task := state.FindTask("task-1")
+		task.Status = "IMPLEMENTING_CODE" // invalid: no worktree/lease
+		agent := "coder-1"
+		task.AssignedTo = &agent
+		return nil
+	}); err != nil {
+		t.Fatalf("setup modify failed: %v", err)
+	}
+
+	// A named op touching the already-invalid task without introducing the
+	// violation (no-worse-than-before) must be allowed — e.g. a handoff
+	// appending an event.
+	err := bb.ModifyOp("handoff", func(state *models.State) error {
+		task := state.FindTask("task-1")
+		task.HandoffPending = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("op touching pre-existing-invalid task rejected: %v", err)
+	}
+}
+
+func TestWriteFunnel_SkipsWithoutPipelineConfig(t *testing.T) {
+	dir := t.TempDir()
+	bb := New(filepath.Join(dir, "state.yaml"))
+	if err := bb.Write(&models.State{
+		Version: 1,
+		Tasks:   []models.Task{{ID: "task-1", Status: "DRAFT_CODE"}},
+		Agents:  map[string]models.Agent{},
+	}); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// No frozen pipeline config → enforcement skipped even for named ops.
+	err := bb.ModifyOp("claim_task", func(state *models.State) error {
+		state.FindTask("task-1").Status = "IMPLEMENTING_CODE"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected fail-open without pipeline config, got: %v", err)
+	}
+}

--- a/internal/db/blackboard_journal_test.go
+++ b/internal/db/blackboard_journal_test.go
@@ -1,0 +1,205 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/liza-mas/liza/internal/journal"
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// TestShadowJournalTracksModifications drives a realistic task lifecycle
+// through Blackboard.Write/Modify and asserts that folding the shadow journal
+// reproduces exactly the task statuses in state.yaml — the equivalence
+// property the journal migration depends on.
+func TestShadowJournalTracksModifications(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.yaml")
+	bb := New(statePath)
+
+	initial := &models.State{
+		Version: 1,
+		Tasks: []models.Task{
+			{ID: "task-1", Status: "READY", Description: "first"},
+		},
+		Agents: map[string]models.Agent{},
+	}
+	if err := bb.Write(initial); err != nil {
+		t.Fatalf("initial Write failed: %v", err)
+	}
+
+	// Register an agent and claim the task (history entry + status change).
+	err := bb.Modify(func(state *models.State) error {
+		state.Agents["coder-1"] = models.Agent{
+			Role:   "coder",
+			Status: models.AgentStatusIdle,
+		}
+		task := state.FindTask("task-1")
+		task.Status = "IMPLEMENTING_CODE"
+		agent := "coder-1"
+		task.AssignedTo = &agent
+		task.History = append(task.History, models.TaskHistoryEntry{
+			Time:  time.Now(),
+			Event: models.TaskEventClaimed,
+			Agent: &agent,
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("claim Modify failed: %v", err)
+	}
+
+	// Add a second task and merge the first.
+	err = bb.Modify(func(state *models.State) error {
+		state.Tasks = append(state.Tasks, models.Task{
+			ID: "task-2", Status: "DRAFT_CODE", Description: "second",
+		})
+		task := state.FindTask("task-1")
+		task.Status = "MERGED"
+		task.AssignedTo = nil
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("merge Modify failed: %v", err)
+	}
+
+	// A pure lease-renewal write must not emit events (heartbeat noise).
+	store := journal.ForStatePath(statePath)
+	seqBeforeHeartbeat, err := store.LastSeq()
+	if err != nil {
+		t.Fatalf("LastSeq failed: %v", err)
+	}
+	err = bb.Modify(func(state *models.State) error {
+		agent := state.Agents["coder-1"]
+		agent.Heartbeat = time.Now()
+		state.Agents["coder-1"] = agent
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("heartbeat Modify failed: %v", err)
+	}
+	seqAfterHeartbeat, err := store.LastSeq()
+	if err != nil {
+		t.Fatalf("LastSeq failed: %v", err)
+	}
+	if seqAfterHeartbeat != seqBeforeHeartbeat {
+		t.Errorf("heartbeat-only write emitted %d events; want 0",
+			seqAfterHeartbeat-seqBeforeHeartbeat)
+	}
+
+	events, err := store.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected shadow journal events, got none")
+	}
+
+	var sawClaim, sawAgentRegistered bool
+	for _, ev := range events {
+		switch ev.Type {
+		case "task.claimed":
+			sawClaim = ev.Task == "task-1" && ev.Agent == "coder-1"
+		case journal.EventAgentRegistered:
+			sawAgentRegistered = ev.Agent == "coder-1"
+		}
+	}
+	if !sawClaim || !sawAgentRegistered {
+		t.Errorf("missing events: claim=%v registered=%v\n%+v", sawClaim, sawAgentRegistered, events)
+	}
+
+	// Equivalence: projection over the journal == statuses in state.yaml.
+	state, err := bb.Read()
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	actual := map[string]string{}
+	for _, task := range state.Tasks {
+		actual[task.ID] = string(task.Status)
+	}
+	diff := journal.ProjectTaskStatuses(events).Diff(actual)
+	if len(diff) != 0 {
+		t.Errorf("journal projection diverges from state.yaml: %+v", diff)
+	}
+}
+
+// TestShadowJournalOpProvenance verifies that events derived from a named
+// operation carry that operation name, and that plain Modify falls back to
+// the generic "modify" provenance.
+func TestShadowJournalOpProvenance(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.yaml")
+	bb := New(statePath)
+
+	if err := bb.Write(&models.State{
+		Version: 1,
+		Tasks:   []models.Task{{ID: "task-1", Status: "READY"}},
+		Agents:  map[string]models.Agent{},
+	}); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	err := bb.ModifyOp("claim_task", func(state *models.State) error {
+		state.FindTask("task-1").Status = "IMPLEMENTING_CODE"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ModifyOp failed: %v", err)
+	}
+	err = bb.Modify(func(state *models.State) error {
+		state.FindTask("task-1").Status = "MERGED"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Modify failed: %v", err)
+	}
+
+	events, err := journal.ForStatePath(statePath).ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	ops := map[string]string{}
+	for _, ev := range events {
+		if ev.Type == journal.EventTaskStatusChanged {
+			ops[ev.Fields["to"].(string)] = ev.Op
+		} else if ev.Type == journal.EventTaskCreated {
+			ops["created"] = ev.Op
+		}
+	}
+	if ops["created"] != "write" {
+		t.Errorf("initial write op = %q, want \"write\"", ops["created"])
+	}
+	if ops["IMPLEMENTING_CODE"] != "claim_task" {
+		t.Errorf("named op = %q, want \"claim_task\"", ops["IMPLEMENTING_CODE"])
+	}
+	if ops["MERGED"] != "modify" {
+		t.Errorf("generic op = %q, want \"modify\"", ops["MERGED"])
+	}
+}
+
+// TestShadowJournalOnInitialWrite verifies that the very first Write (project
+// init, no pre-existing state file) journals creation events from an empty
+// before-state.
+func TestShadowJournalOnInitialWrite(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.yaml")
+	bb := New(statePath)
+
+	if err := bb.Write(&models.State{
+		Version: 1,
+		Tasks:   []models.Task{{ID: "task-1", Status: "DRAFT_CODE"}},
+		Agents:  map[string]models.Agent{},
+	}); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	events, err := journal.ForStatePath(statePath).ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if len(events) != 1 || events[0].Type != journal.EventTaskCreated || events[0].Task != "task-1" {
+		t.Fatalf("expected single task.created event, got %+v", events)
+	}
+}

--- a/internal/journal/derive.go
+++ b/internal/journal/derive.go
@@ -1,0 +1,329 @@
+package journal
+
+import (
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// Event type names emitted by Derive. Task-history-backed events use the
+// history vocabulary prefixed with "task." (e.g. "task.claimed").
+const (
+	EventTaskCreated       = "task.created"
+	EventTaskRemoved       = "task.removed"
+	EventTaskStatusChanged = "task.status_changed"
+
+	EventAgentRegistered    = "agent.registered"
+	EventAgentUnregistered  = "agent.unregistered"
+	EventAgentStatusChanged = "agent.status_changed"
+
+	EventClaimGranted  = "claim.granted"
+	EventClaimReleased = "claim.released"
+
+	EventAnomalyLogged    = "anomaly.logged"
+	EventDiscoveryLogged  = "discovery.logged"
+	EventSpecChanged      = "spec.changed"
+	EventHumanNoteAdded   = "human_note.added"
+	EventSprintAdvanced   = "sprint.advanced"
+	EventSprintStatus     = "sprint.status_changed"
+	EventCircuitBreaker   = "circuit_breaker.status_changed"
+	EventGoalStatus       = "goal.status_changed"
+	EventSystemMode       = "system.mode_changed"
+	EventStateModified    = "state.modified"
+	taskHistoryEventScope = "task."
+)
+
+// Derive computes the journal events implied by a state transition. It is a
+// pure function over (before, after); the shadow-journal wiring in db calls
+// it inside the write lock so derived events serialize with the state write.
+//
+// Derivation sources, in order of fidelity:
+//  1. New task history entries (the system's existing, proven event log).
+//  2. Structural diffs history does not carry: task creation/removal, status
+//     changes, agent registry changes, appended anomalies/discoveries/notes,
+//     sprint, circuit breaker, and goal transitions.
+func Derive(before, after *models.State) []Event {
+	var events []Event
+
+	beforeTasks := make(map[string]*models.Task, len(before.Tasks))
+	for i := range before.Tasks {
+		beforeTasks[before.Tasks[i].ID] = &before.Tasks[i]
+	}
+	afterTasks := make(map[string]*models.Task, len(after.Tasks))
+
+	for i := range after.Tasks {
+		task := &after.Tasks[i]
+		afterTasks[task.ID] = task
+		prev := beforeTasks[task.ID]
+
+		if prev == nil {
+			events = append(events, Event{
+				Type: EventTaskCreated,
+				Task: task.ID,
+				Fields: map[string]any{
+					"status":    string(task.Status),
+					"type":      string(task.Type),
+					"role_pair": task.RolePair,
+				},
+			})
+		}
+
+		events = append(events, deriveHistoryEvents(prev, task)...)
+
+		prevStatus := models.TaskStatus("")
+		if prev != nil {
+			prevStatus = prev.Status
+		}
+		if prev != nil && prevStatus != task.Status {
+			events = append(events, Event{
+				Type: EventTaskStatusChanged,
+				Task: task.ID,
+				Fields: map[string]any{
+					"from": string(prevStatus),
+					"to":   string(task.Status),
+				},
+			})
+		}
+	}
+
+	for id := range beforeTasks {
+		if _, ok := afterTasks[id]; !ok {
+			events = append(events, Event{Type: EventTaskRemoved, Task: id})
+		}
+	}
+
+	events = append(events, deriveAgentEvents(before, after)...)
+	events = append(events, deriveClaimEvents(before, after)...)
+	events = append(events, deriveAppendOnlyEvents(before, after)...)
+	events = append(events, deriveSystemEvents(before, after)...)
+
+	return events
+}
+
+// deriveClaimEvents diffs first-class claim records keyed by TaskID+Kind.
+// Pure ExpiresAt (and GrantedAt) changes are lease renewals — deliberate
+// noise that emits nothing. A claim whose AgentID changed under the same key
+// emits a release for the old holder followed by a grant for the new one.
+func deriveClaimEvents(before, after *models.State) []Event {
+	type claimKey struct {
+		taskID string
+		kind   string
+	}
+
+	beforeClaims := make(map[claimKey]models.Claim, len(before.Claims))
+	for _, c := range before.Claims {
+		beforeClaims[claimKey{c.TaskID, c.Kind}] = c
+	}
+
+	var events []Event
+	afterKeys := make(map[claimKey]bool, len(after.Claims))
+	for _, c := range after.Claims {
+		k := claimKey{c.TaskID, c.Kind}
+		afterKeys[k] = true
+		prev, existed := beforeClaims[k]
+		if existed && prev.AgentID == c.AgentID {
+			continue
+		}
+		if existed {
+			events = append(events, claimEvent(EventClaimReleased, prev))
+		}
+		events = append(events, claimEvent(EventClaimGranted, c))
+	}
+	for _, c := range before.Claims {
+		if !afterKeys[claimKey{c.TaskID, c.Kind}] {
+			events = append(events, claimEvent(EventClaimReleased, c))
+		}
+	}
+	return events
+}
+
+func claimEvent(eventType string, c models.Claim) Event {
+	return Event{
+		Type:  eventType,
+		Task:  c.TaskID,
+		Agent: c.AgentID,
+		Fields: map[string]any{
+			"kind": c.Kind,
+		},
+	}
+}
+
+func deriveHistoryEvents(prev, task *models.Task) []Event {
+	start := 0
+	if prev != nil {
+		start = len(prev.History)
+	}
+	if start >= len(task.History) {
+		return nil
+	}
+
+	var events []Event
+	for _, entry := range task.History[start:] {
+		ev := Event{
+			Type: taskHistoryEventScope + entry.Event,
+			Time: entry.Time,
+			Task: task.ID,
+		}
+		if entry.Agent != nil {
+			ev.Agent = *entry.Agent
+		}
+		fields := map[string]any{}
+		if entry.Reason != nil {
+			fields["reason"] = *entry.Reason
+		}
+		if entry.Commit != nil {
+			fields["commit"] = *entry.Commit
+		}
+		if entry.Note != nil {
+			fields["note"] = *entry.Note
+		}
+		if entry.PreviousAssignee != nil {
+			fields["previous_assignee"] = *entry.PreviousAssignee
+		}
+		if len(fields) > 0 {
+			ev.Fields = fields
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func deriveAgentEvents(before, after *models.State) []Event {
+	var events []Event
+	for id, agent := range after.Agents {
+		prev, existed := before.Agents[id]
+		if !existed {
+			events = append(events, Event{
+				Type:  EventAgentRegistered,
+				Agent: id,
+				Fields: map[string]any{
+					"role":     agent.Role,
+					"provider": agent.Provider,
+				},
+			})
+			continue
+		}
+		if prev.Status != agent.Status {
+			events = append(events, Event{
+				Type:  EventAgentStatusChanged,
+				Agent: id,
+				Fields: map[string]any{
+					"from": string(prev.Status),
+					"to":   string(agent.Status),
+				},
+			})
+		}
+	}
+	for id := range before.Agents {
+		if _, ok := after.Agents[id]; !ok {
+			events = append(events, Event{Type: EventAgentUnregistered, Agent: id})
+		}
+	}
+	return events
+}
+
+func deriveAppendOnlyEvents(before, after *models.State) []Event {
+	var events []Event
+
+	for _, a := range tailOf(before.Anomalies, after.Anomalies) {
+		events = append(events, Event{
+			Type:  EventAnomalyLogged,
+			Time:  a.Timestamp,
+			Task:  a.Task,
+			Agent: a.Reporter,
+			Fields: map[string]any{
+				"anomaly_type": a.Type,
+			},
+		})
+	}
+	for _, d := range tailOf(before.Discovered, after.Discovered) {
+		events = append(events, Event{
+			Type:  EventDiscoveryLogged,
+			Time:  d.Created,
+			Agent: d.By,
+			Fields: map[string]any{
+				"id":       d.ID,
+				"severity": d.Severity,
+				"urgency":  d.Urgency,
+			},
+		})
+	}
+	for _, sc := range tailOf(before.SpecChanges, after.SpecChanges) {
+		events = append(events, Event{
+			Type: EventSpecChanged,
+			Time: sc.Timestamp,
+			Fields: map[string]any{
+				"spec":         sc.Spec,
+				"triggered_by": sc.TriggeredBy,
+			},
+		})
+	}
+	for _, n := range tailOf(before.HumanNotes, after.HumanNotes) {
+		events = append(events, Event{
+			Type: EventHumanNoteAdded,
+			Time: n.Timestamp,
+			Fields: map[string]any{
+				"for":     n.For,
+				"message": n.Message,
+			},
+		})
+	}
+	return events
+}
+
+func deriveSystemEvents(before, after *models.State) []Event {
+	var events []Event
+	if before.Sprint.Number != after.Sprint.Number {
+		events = append(events, Event{
+			Type: EventSprintAdvanced,
+			Fields: map[string]any{
+				"from": before.Sprint.Number,
+				"to":   after.Sprint.Number,
+			},
+		})
+	}
+	if before.Sprint.Status != after.Sprint.Status {
+		events = append(events, Event{
+			Type: EventSprintStatus,
+			Fields: map[string]any{
+				"from": string(before.Sprint.Status),
+				"to":   string(after.Sprint.Status),
+			},
+		})
+	}
+	if before.CircuitBreaker.Status != after.CircuitBreaker.Status {
+		events = append(events, Event{
+			Type: EventCircuitBreaker,
+			Fields: map[string]any{
+				"from": before.CircuitBreaker.Status,
+				"to":   after.CircuitBreaker.Status,
+			},
+		})
+	}
+	if before.Goal.Status != after.Goal.Status {
+		events = append(events, Event{
+			Type: EventGoalStatus,
+			Fields: map[string]any{
+				"from": string(before.Goal.Status),
+				"to":   string(after.Goal.Status),
+			},
+		})
+	}
+	if before.Config.Mode != after.Config.Mode {
+		fields := map[string]any{
+			"from": string(before.Config.Mode),
+			"to":   string(after.Config.Mode),
+		}
+		if after.Config.ModeChangedBy != nil {
+			fields["changed_by"] = *after.Config.ModeChangedBy
+		}
+		events = append(events, Event{Type: EventSystemMode, Fields: fields})
+	}
+	return events
+}
+
+// tailOf returns the entries appended to an append-only slice.
+func tailOf[T any](before, after []T) []T {
+	if len(after) <= len(before) {
+		return nil
+	}
+	return after[len(before):]
+}

--- a/internal/journal/journal.go
+++ b/internal/journal/journal.go
@@ -1,0 +1,191 @@
+// Package journal provides an append-only event journal for the blackboard.
+//
+// The journal records every state change as a typed event in a JSONL file
+// next to state.yaml. During the migration period the journal is a shadow
+// log: state.yaml remains the source of truth and events are derived from
+// state diffs inside db.Blackboard write operations (which hold the state
+// file lock, serializing appends).
+//
+// Event types reuse the task-history vocabulary from internal/models
+// (e.g. "task.claimed", "task.rejected") plus structural events the history
+// does not carry ("task.status_changed", "agent.registered", "anomaly.logged").
+package journal
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Filename is the journal file name, stored alongside state.yaml.
+const Filename = "journal.jsonl"
+
+// maxFieldBytes caps each string field value at the journal boundary so a
+// misbehaving writer can never bloat the journal the way raw provider
+// transcripts bloated state.yaml (the failure statehygiene exists for).
+const maxFieldBytes = 4096
+
+// truncationSuffix marks capped field values.
+const truncationSuffix = "…[truncated by journal]"
+
+// Event is a single journal entry.
+type Event struct {
+	Seq   int64     `json:"seq"`
+	Time  time.Time `json:"time"`
+	Type  string    `json:"type"`
+	Task  string    `json:"task,omitempty"`
+	Agent string    `json:"agent,omitempty"`
+	// Op is the named write operation that produced this event (e.g.
+	// "claim_task", "submit_verdict") — provenance for audit. Writes that
+	// have not been migrated to named operations carry "modify" or "write".
+	Op     string         `json:"op,omitempty"`
+	Fields map[string]any `json:"fields,omitempty"`
+}
+
+// Store is an append-only JSONL event store.
+//
+// Concurrency: Append must be called while holding the state file lock
+// (db.Blackboard guarantees this by appending inside its lock window).
+// Reads scan the file without locking; a torn trailing line from a crashed
+// writer is tolerated and skipped.
+type Store struct {
+	path string
+}
+
+// ForStatePath returns the Store for the journal living next to the given
+// state.yaml path.
+func ForStatePath(statePath string) *Store {
+	return &Store{path: filepath.Join(filepath.Dir(statePath), Filename)}
+}
+
+// Path returns the journal file path.
+func (s *Store) Path() string {
+	return s.path
+}
+
+// Append assigns sequence numbers and timestamps, caps field sizes, and
+// appends the events as JSON lines with fsync. The caller must hold the
+// state file lock.
+func (s *Store) Append(events []Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	last, err := s.LastSeq()
+	if err != nil {
+		return fmt.Errorf("journal: failed to determine last sequence: %w", err)
+	}
+
+	now := time.Now().UTC()
+	var buf []byte
+	for i := range events {
+		events[i].Seq = last + int64(i) + 1
+		if events[i].Time.IsZero() {
+			events[i].Time = now
+		}
+		capFields(events[i].Fields)
+
+		line, err := json.Marshal(events[i])
+		if err != nil {
+			return fmt.Errorf("journal: failed to marshal event %q: %w", events[i].Type, err)
+		}
+		buf = append(buf, line...)
+		buf = append(buf, '\n')
+	}
+
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("journal: failed to open journal: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(buf); err != nil {
+		return fmt.Errorf("journal: failed to append events: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("journal: failed to sync journal: %w", err)
+	}
+	return nil
+}
+
+// ReadAll returns every event in the journal in order. A torn trailing line
+// (crash during append) is skipped; a malformed line anywhere else is an
+// integrity error.
+func (s *Store) ReadAll() ([]Event, error) {
+	return s.ReadSince(0)
+}
+
+// ReadSince returns events with Seq strictly greater than seq, in order.
+func (s *Store) ReadSince(seq int64) ([]Event, error) {
+	return readEventsFile(s.path, seq)
+}
+
+// readEventsFile reads one JSONL event file, returning events with Seq
+// strictly greater than seq. A missing file yields no events; a torn trailing
+// line is tolerated; a malformed line anywhere else is an integrity error.
+func readEventsFile(path string, seq int64) ([]Event, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("journal: failed to open journal: %w", err)
+	}
+	defer f.Close()
+
+	var events []Event
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	var pendingErr error
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		// A malformed line is only tolerable if it turns out to be the last
+		// one (torn append); remember the error and fail if more lines follow.
+		if pendingErr != nil {
+			return nil, pendingErr
+		}
+		var ev Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			pendingErr = fmt.Errorf("journal: malformed event at %s line %d: %w", filepath.Base(path), lineNo, err)
+			continue
+		}
+		if ev.Seq > seq {
+			events = append(events, ev)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("journal: failed to scan journal: %w", err)
+	}
+	return events, nil
+}
+
+// LastSeq returns the sequence number of the last well-formed event, or 0 for
+// a missing or empty journal.
+func (s *Store) LastSeq() (int64, error) {
+	events, err := s.ReadAll()
+	if err != nil {
+		return 0, err
+	}
+	if len(events) == 0 {
+		return 0, nil
+	}
+	return events[len(events)-1].Seq, nil
+}
+
+func capFields(fields map[string]any) {
+	for k, v := range fields {
+		str, ok := v.(string)
+		if !ok || len(str) <= maxFieldBytes {
+			continue
+		}
+		fields[k] = str[:maxFieldBytes] + truncationSuffix
+	}
+}

--- a/internal/journal/journal_test.go
+++ b/internal/journal/journal_test.go
@@ -1,0 +1,338 @@
+package journal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+func storeForTest(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	return ForStatePath(filepath.Join(dir, "state.yaml"))
+}
+
+func TestAppendAndReadRoundTrip(t *testing.T) {
+	s := storeForTest(t)
+
+	in := []Event{
+		{Type: "task.created", Task: "task-1", Fields: map[string]any{"status": "READY"}},
+		{Type: "task.claimed", Task: "task-1", Agent: "coder-1"},
+	}
+	if err := s.Append(in); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	out, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(out))
+	}
+	if out[0].Seq != 1 || out[1].Seq != 2 {
+		t.Errorf("expected seq 1,2 got %d,%d", out[0].Seq, out[1].Seq)
+	}
+	if out[1].Agent != "coder-1" || out[1].Type != "task.claimed" {
+		t.Errorf("unexpected event: %+v", out[1])
+	}
+	if out[0].Time.IsZero() {
+		t.Error("expected timestamp to be assigned")
+	}
+}
+
+func TestSeqContinuityAcrossStoreInstances(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.yaml")
+
+	s1 := ForStatePath(statePath)
+	if err := s1.Append([]Event{{Type: "a"}, {Type: "b"}}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	s2 := ForStatePath(statePath)
+	if err := s2.Append([]Event{{Type: "c"}}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	out, err := s2.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if len(out) != 3 || out[2].Seq != 3 {
+		t.Fatalf("expected 3 events ending at seq 3, got %d events, last seq %d", len(out), out[len(out)-1].Seq)
+	}
+}
+
+func TestReadSince(t *testing.T) {
+	s := storeForTest(t)
+	if err := s.Append([]Event{{Type: "a"}, {Type: "b"}, {Type: "c"}}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	out, err := s.ReadSince(2)
+	if err != nil {
+		t.Fatalf("ReadSince failed: %v", err)
+	}
+	if len(out) != 1 || out[0].Type != "c" {
+		t.Fatalf("expected only event c, got %+v", out)
+	}
+}
+
+func TestFieldCapping(t *testing.T) {
+	s := storeForTest(t)
+	huge := strings.Repeat("x", maxFieldBytes*2)
+	if err := s.Append([]Event{{Type: "a", Fields: map[string]any{"note": huge}}}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	out, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	note := out[0].Fields["note"].(string)
+	if len(note) > maxFieldBytes+len(truncationSuffix) {
+		t.Errorf("field not capped: %d bytes", len(note))
+	}
+	if !strings.HasSuffix(note, truncationSuffix) {
+		t.Error("expected truncation marker suffix")
+	}
+}
+
+func TestTornTrailingLineTolerated(t *testing.T) {
+	s := storeForTest(t)
+	if err := s.Append([]Event{{Type: "a"}}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	// Simulate a crash mid-append: partial JSON with no newline.
+	f, err := os.OpenFile(s.Path(), os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	if _, err := f.WriteString(`{"seq":2,"type":"tor`); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	f.Close()
+
+	out, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("expected torn tail to be tolerated, got: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(out))
+	}
+
+	// The next append must continue from the last well-formed seq.
+	if err := s.Append([]Event{{Type: "b"}}); err != nil {
+		t.Fatalf("Append after torn tail failed: %v", err)
+	}
+}
+
+func TestMalformedMiddleLineIsError(t *testing.T) {
+	s := storeForTest(t)
+	if err := os.WriteFile(s.Path(), []byte("not json\n{\"seq\":1,\"type\":\"a\"}\n"), 0644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if _, err := s.ReadAll(); err == nil {
+		t.Fatal("expected integrity error for malformed non-tail line")
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestDeriveTaskLifecycle(t *testing.T) {
+	before := &models.State{
+		Tasks: []models.Task{
+			{ID: "task-1", Status: "READY"},
+		},
+		Agents: map[string]models.Agent{},
+	}
+	after := &models.State{
+		Tasks: []models.Task{
+			{
+				ID:     "task-1",
+				Status: "IMPLEMENTING_CODE",
+				History: []models.TaskHistoryEntry{
+					{Time: time.Now(), Event: models.TaskEventClaimed, Agent: strPtr("coder-1")},
+				},
+			},
+			{ID: "task-2", Status: "DRAFT_CODE", Type: "coding", RolePair: "code-pair"},
+		},
+		Agents: map[string]models.Agent{
+			"coder-1": {Role: "coder", Status: models.AgentStatusIdle},
+		},
+	}
+
+	events := Derive(before, after)
+
+	wantTypes := map[string]bool{
+		"task.claimed":         false,
+		EventTaskStatusChanged: false,
+		EventTaskCreated:       false,
+		EventAgentRegistered:   false,
+	}
+	for _, ev := range events {
+		if _, ok := wantTypes[ev.Type]; ok {
+			wantTypes[ev.Type] = true
+		}
+	}
+	for typ, seen := range wantTypes {
+		if !seen {
+			t.Errorf("expected derived event %q, got %+v", typ, events)
+		}
+	}
+
+	for _, ev := range events {
+		if ev.Type == EventTaskStatusChanged {
+			if ev.Fields["from"] != "READY" || ev.Fields["to"] != "IMPLEMENTING_CODE" {
+				t.Errorf("unexpected status change fields: %+v", ev.Fields)
+			}
+		}
+		if ev.Type == "task.claimed" && ev.Agent != "coder-1" {
+			t.Errorf("expected claim agent coder-1, got %q", ev.Agent)
+		}
+	}
+}
+
+func TestDeriveRemovalAndAppendOnly(t *testing.T) {
+	before := &models.State{
+		Tasks:  []models.Task{{ID: "task-1", Status: "MERGED"}},
+		Agents: map[string]models.Agent{"coder-1": {Role: "coder"}},
+	}
+	after := &models.State{
+		Tasks:  []models.Task{},
+		Agents: map[string]models.Agent{},
+		Anomalies: []models.Anomaly{
+			{Task: "task-1", Reporter: "coder-1", Type: "retry_loop"},
+		},
+	}
+
+	events := Derive(before, after)
+
+	var sawRemoved, sawUnregistered, sawAnomaly bool
+	for _, ev := range events {
+		switch ev.Type {
+		case EventTaskRemoved:
+			sawRemoved = ev.Task == "task-1"
+		case EventAgentUnregistered:
+			sawUnregistered = ev.Agent == "coder-1"
+		case EventAnomalyLogged:
+			sawAnomaly = ev.Fields["anomaly_type"] == "retry_loop"
+		}
+	}
+	if !sawRemoved || !sawUnregistered || !sawAnomaly {
+		t.Errorf("missing derived events: removed=%v unregistered=%v anomaly=%v\n%+v",
+			sawRemoved, sawUnregistered, sawAnomaly, events)
+	}
+}
+
+func TestProjectionFoldsToCurrentStatuses(t *testing.T) {
+	events := []Event{
+		{Type: EventTaskCreated, Task: "t1", Fields: map[string]any{"status": "READY"}},
+		{Type: EventTaskStatusChanged, Task: "t1", Fields: map[string]any{"from": "READY", "to": "IMPLEMENTING_CODE"}},
+		{Type: EventTaskCreated, Task: "t2", Fields: map[string]any{"status": "DRAFT_CODE"}},
+		{Type: EventTaskStatusChanged, Task: "t1", Fields: map[string]any{"from": "IMPLEMENTING_CODE", "to": "MERGED"}},
+		{Type: EventTaskRemoved, Task: "t2"},
+	}
+	proj := ProjectTaskStatuses(events)
+	if proj["t1"] != "MERGED" {
+		t.Errorf("expected t1=MERGED, got %q", proj["t1"])
+	}
+	if _, ok := proj["t2"]; ok {
+		t.Error("expected t2 removed from projection")
+	}
+
+	diff := proj.Diff(map[string]string{"t1": "MERGED"})
+	if len(diff) != 0 {
+		t.Errorf("expected empty diff, got %+v", diff)
+	}
+	diff = proj.Diff(map[string]string{"t1": "BLOCKED"})
+	if len(diff) != 1 {
+		t.Errorf("expected 1 diff entry, got %+v", diff)
+	}
+}
+
+func TestDeriveClaimEvents(t *testing.T) {
+	now := time.Now().UTC()
+	exp := now.Add(time.Hour)
+	renewed := now.Add(2 * time.Hour)
+
+	tasks := []models.Task{
+		{ID: "task-1", Status: "IMPLEMENTING_CODE"},
+		{ID: "task-2", Status: "REVIEWING_CODE"},
+		{ID: "task-3", Status: "IMPLEMENTING_CODE"},
+		{ID: "task-4", Status: "IMPLEMENTING_CODE"},
+	}
+	before := &models.State{
+		Tasks:  tasks,
+		Agents: map[string]models.Agent{},
+		Claims: []models.Claim{
+			// Released in after (claim.released expected).
+			{TaskID: "task-2", AgentID: "reviewer-1", Kind: models.ClaimKindReviewer, GrantedAt: now, ExpiresAt: &exp},
+			// Pure lease renewal in after (no event expected).
+			{TaskID: "task-3", AgentID: "coder-2", Kind: models.ClaimKindDoer, GrantedAt: now, ExpiresAt: &exp},
+			// Agent changes in after (release + grant expected).
+			{TaskID: "task-4", AgentID: "coder-3", Kind: models.ClaimKindDoer, GrantedAt: now, ExpiresAt: &exp},
+		},
+	}
+	after := &models.State{
+		Tasks:  tasks,
+		Agents: map[string]models.Agent{},
+		Claims: []models.Claim{
+			// Newly granted (claim.granted expected).
+			{TaskID: "task-1", AgentID: "coder-1", Kind: models.ClaimKindDoer, GrantedAt: now, ExpiresAt: &exp},
+			// Same claim, renewed lease only.
+			{TaskID: "task-3", AgentID: "coder-2", Kind: models.ClaimKindDoer, GrantedAt: now, ExpiresAt: &renewed},
+			// Same task+kind, different agent.
+			{TaskID: "task-4", AgentID: "coder-4", Kind: models.ClaimKindDoer, GrantedAt: renewed, ExpiresAt: &renewed},
+		},
+	}
+
+	events := Derive(before, after)
+
+	var claimEvents []Event
+	for _, ev := range events {
+		if ev.Type == EventClaimGranted || ev.Type == EventClaimReleased {
+			claimEvents = append(claimEvents, ev)
+		}
+	}
+	if len(claimEvents) != 4 {
+		t.Fatalf("expected 4 claim events, got %d: %+v", len(claimEvents), claimEvents)
+	}
+
+	type want struct {
+		eventType string
+		agent     string
+		kind      string
+	}
+	wants := map[string][]want{
+		"task-1": {{EventClaimGranted, "coder-1", models.ClaimKindDoer}},
+		"task-2": {{EventClaimReleased, "reviewer-1", models.ClaimKindReviewer}},
+		"task-4": {
+			{EventClaimReleased, "coder-3", models.ClaimKindDoer},
+			{EventClaimGranted, "coder-4", models.ClaimKindDoer},
+		},
+	}
+	got := map[string][]want{}
+	for _, ev := range claimEvents {
+		if ev.Task == "task-3" {
+			t.Errorf("lease renewal must not emit claim events, got %+v", ev)
+			continue
+		}
+		got[ev.Task] = append(got[ev.Task], want{ev.Type, ev.Agent, ev.Fields["kind"].(string)})
+	}
+	for taskID, wantEvents := range wants {
+		gotEvents := got[taskID]
+		if len(gotEvents) != len(wantEvents) {
+			t.Errorf("task %s: got %+v, want %+v", taskID, gotEvents, wantEvents)
+			continue
+		}
+		for i := range wantEvents {
+			if gotEvents[i] != wantEvents[i] {
+				t.Errorf("task %s event %d: got %+v, want %+v", taskID, i, gotEvents[i], wantEvents[i])
+			}
+		}
+	}
+}

--- a/internal/journal/projection.go
+++ b/internal/journal/projection.go
@@ -1,0 +1,85 @@
+package journal
+
+// TaskStatusProjection is the journal-derived view of every known task's
+// current status. It is the first projection used to verify that the shadow
+// journal is complete: folding it over the journal must reproduce exactly
+// the task statuses in state.yaml.
+type TaskStatusProjection map[string]string
+
+// ProjectTaskStatuses folds status-bearing events into the current status of
+// every task that appears in the journal. Removed tasks are dropped, matching
+// state.yaml semantics (archival/deletion removes the task entry).
+//
+// A journal.rotated snapshot event re-seeds the projection from its
+// task_statuses field — the full fold of everything archived — so folding a
+// rotated journal stays exactly equivalent to folding the full history.
+func ProjectTaskStatuses(events []Event) TaskStatusProjection {
+	proj := TaskStatusProjection{}
+	for _, ev := range events {
+		switch ev.Type {
+		case EventJournalRotated:
+			if seed, ok := taskStatusSeed(ev.Fields["task_statuses"]); ok {
+				proj = seed
+			}
+		case EventTaskCreated:
+			if status, ok := ev.Fields["status"].(string); ok {
+				proj[ev.Task] = status
+			}
+		case EventTaskStatusChanged:
+			if status, ok := ev.Fields["to"].(string); ok {
+				proj[ev.Task] = status
+			}
+		case EventTaskRemoved:
+			delete(proj, ev.Task)
+		}
+	}
+	return proj
+}
+
+// taskStatusSeed extracts the task_statuses snapshot from a journal.rotated
+// event. In-memory events carry map[string]string; events read back from the
+// JSONL file carry map[string]any after the JSON round-trip — both forms are
+// handled. Non-string statuses are skipped.
+func taskStatusSeed(v any) (TaskStatusProjection, bool) {
+	switch m := v.(type) {
+	case map[string]string:
+		seed := make(TaskStatusProjection, len(m))
+		for id, status := range m {
+			seed[id] = status
+		}
+		return seed, true
+	case TaskStatusProjection:
+		seed := make(TaskStatusProjection, len(m))
+		for id, status := range m {
+			seed[id] = status
+		}
+		return seed, true
+	case map[string]any:
+		seed := make(TaskStatusProjection, len(m))
+		for id, status := range m {
+			if s, ok := status.(string); ok {
+				seed[id] = s
+			}
+		}
+		return seed, true
+	}
+	return nil, false
+}
+
+// Diff returns, for each task where the projection disagrees with the given
+// statuses, a pair [projected, actual] ("" marks a missing entry). An empty
+// result means the journal fully explains the current task statuses.
+func (p TaskStatusProjection) Diff(actual map[string]string) map[string][2]string {
+	diff := map[string][2]string{}
+	for id, status := range actual {
+		if p[id] != status {
+			diff[id] = [2]string{p[id], status}
+		}
+	}
+	for id, status := range p {
+		if _, ok := actual[id]; !ok {
+			diff[id] = [2]string{status, ""}
+		}
+	}
+	return diff
+}

--- a/internal/journal/reconstruct.go
+++ b/internal/journal/reconstruct.go
@@ -1,0 +1,147 @@
+package journal
+
+import (
+	"fmt"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// Reconstruction is the subset of blackboard state that the journal's event
+// stream FULLY captures, folded from events. These dimensions can be rebuilt
+// exactly from the journal alone, so they are verifiable against state.yaml.
+//
+// What is NOT here is the point of the source-of-truth migration: task bodies
+// (description, worktree, base_commit, history, output, …) are only partially
+// evented (status changes, claim grants), so the journal cannot yet rebuild a
+// whole task. Closing that gap — emitting complete per-field task events — is
+// the remaining work before the journal can replace state.yaml. ClaimKey and
+// the singletons below are the dimensions already across that line.
+type Reconstruction struct {
+	// TaskStatuses is the folded current status of every task (also available
+	// via ProjectTaskStatuses; included here for one-call reconstruction).
+	TaskStatuses TaskStatusProjection
+	// Claims is the folded set of live claim holders, keyed by task+kind.
+	Claims map[ClaimKey]string
+	// System singletons, each fully determined by its *.status_changed event.
+	SprintNumber        int
+	SprintStatus        string
+	CircuitBreakerState string
+	GoalStatus          string
+	SystemMode          string
+	// sprintSeen tracks whether any sprint event set the number, so an unset
+	// reconstruction (0) is distinguishable from an explicit advance to 0.
+	sprintSeen bool
+}
+
+// ClaimKey identifies a claim by task and kind (doer/reviewer).
+type ClaimKey struct {
+	TaskID string
+	Kind   string
+}
+
+// Reconstruct folds the fully-captured dimensions from an event stream.
+// Pass ReadAllIncludingArchives() output for a complete (rotation-safe) fold;
+// for claims and singletons there is no snapshot seeding, so the live journal
+// alone is only complete when no rotation has occurred.
+func Reconstruct(events []Event) Reconstruction {
+	r := Reconstruction{
+		TaskStatuses: ProjectTaskStatuses(events),
+		Claims:       map[ClaimKey]string{},
+	}
+	for _, ev := range events {
+		switch ev.Type {
+		case EventClaimGranted:
+			if kind, ok := ev.Fields["kind"].(string); ok {
+				r.Claims[ClaimKey{ev.Task, kind}] = ev.Agent
+			}
+		case EventClaimReleased:
+			if kind, ok := ev.Fields["kind"].(string); ok {
+				delete(r.Claims, ClaimKey{ev.Task, kind})
+			}
+		case EventSprintAdvanced:
+			if n, ok := intField(ev.Fields["to"]); ok {
+				r.SprintNumber = n
+				r.sprintSeen = true
+			}
+		case EventSprintStatus:
+			if to, ok := ev.Fields["to"].(string); ok {
+				r.SprintStatus = to
+			}
+		case EventCircuitBreaker:
+			if to, ok := ev.Fields["to"].(string); ok {
+				r.CircuitBreakerState = to
+			}
+		case EventGoalStatus:
+			if to, ok := ev.Fields["to"].(string); ok {
+				r.GoalStatus = to
+			}
+		case EventSystemMode:
+			if to, ok := ev.Fields["to"].(string); ok {
+				r.SystemMode = to
+			}
+		}
+	}
+	return r
+}
+
+// intField coerces a numeric event field, tolerating the float64 that JSON
+// round-trips integers to.
+func intField(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+// DiffClaims compares the reconstructed claim set against the live state's
+// claim records, returning a human-readable line per discrepancy. Only the
+// holder (task+kind+agent) is compared — lease expiry is deliberately not
+// evented, so it is not checked here. An empty result means the journal fully
+// explains the current claim holders.
+func (r Reconstruction) DiffClaims(state *models.State) []string {
+	live := map[ClaimKey]string{}
+	for _, c := range state.Claims {
+		live[ClaimKey{c.TaskID, c.Kind}] = c.AgentID
+	}
+
+	var diffs []string
+	for key, agent := range live {
+		if r.Claims[key] != agent {
+			diffs = append(diffs, fmt.Sprintf("claim %s/%s: journal=%q state=%q",
+				key.TaskID, key.Kind, r.Claims[key], agent))
+		}
+	}
+	for key, agent := range r.Claims {
+		if _, ok := live[key]; !ok {
+			diffs = append(diffs, fmt.Sprintf("claim %s/%s: journal=%q state=<none>",
+				key.TaskID, key.Kind, agent))
+		}
+	}
+	return diffs
+}
+
+// DiffSingletons compares the reconstructed system singletons against live
+// state. A singleton is only checked once the journal has observed at least
+// one event setting it (empty string / unseen sprint = no journal opinion),
+// so a freshly-upgraded project with pre-journal singletons does not warn.
+func (r Reconstruction) DiffSingletons(state *models.State) []string {
+	var diffs []string
+	check := func(name, journaled, actual string) {
+		if journaled != "" && journaled != actual {
+			diffs = append(diffs, fmt.Sprintf("%s: journal=%q state=%q", name, journaled, actual))
+		}
+	}
+	check("sprint.status", r.SprintStatus, string(state.Sprint.Status))
+	check("circuit_breaker", r.CircuitBreakerState, state.CircuitBreaker.Status)
+	check("goal.status", r.GoalStatus, string(state.Goal.Status))
+	check("system.mode", r.SystemMode, string(state.Config.Mode))
+	if r.sprintSeen && r.SprintNumber != state.Sprint.Number {
+		diffs = append(diffs, fmt.Sprintf("sprint.number: journal=%d state=%d", r.SprintNumber, state.Sprint.Number))
+	}
+	return diffs
+}

--- a/internal/journal/reconstruct_test.go
+++ b/internal/journal/reconstruct_test.go
@@ -1,0 +1,104 @@
+package journal
+
+import (
+	"testing"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+func TestReconstruct_ClaimsFold(t *testing.T) {
+	events := []Event{
+		{Type: EventClaimGranted, Task: "t1", Agent: "coder-1", Fields: map[string]any{"kind": "doer"}},
+		{Type: EventClaimGranted, Task: "t1", Agent: "code-reviewer-1", Fields: map[string]any{"kind": "reviewer"}},
+		{Type: EventClaimReleased, Task: "t1", Agent: "coder-1", Fields: map[string]any{"kind": "doer"}},
+		{Type: EventClaimGranted, Task: "t2", Agent: "coder-2", Fields: map[string]any{"kind": "doer"}},
+	}
+	r := Reconstruct(events)
+
+	if _, ok := r.Claims[ClaimKey{"t1", "doer"}]; ok {
+		t.Error("released doer claim on t1 should be gone")
+	}
+	if r.Claims[ClaimKey{"t1", "reviewer"}] != "code-reviewer-1" {
+		t.Errorf("t1 reviewer claim = %q, want code-reviewer-1", r.Claims[ClaimKey{"t1", "reviewer"}])
+	}
+	if r.Claims[ClaimKey{"t2", "doer"}] != "coder-2" {
+		t.Errorf("t2 doer claim = %q, want coder-2", r.Claims[ClaimKey{"t2", "doer"}])
+	}
+}
+
+func TestReconstruct_DiffClaimsAgainstState(t *testing.T) {
+	events := []Event{
+		{Type: EventClaimGranted, Task: "t1", Agent: "coder-1", Fields: map[string]any{"kind": "doer"}},
+	}
+	r := Reconstruct(events)
+
+	// Coherent: state matches journal.
+	coherent := &models.State{Claims: []models.Claim{{TaskID: "t1", AgentID: "coder-1", Kind: "doer"}}}
+	if d := r.DiffClaims(coherent); len(d) != 0 {
+		t.Errorf("expected no diff, got %v", d)
+	}
+
+	// Holder mismatch.
+	mismatch := &models.State{Claims: []models.Claim{{TaskID: "t1", AgentID: "coder-9", Kind: "doer"}}}
+	if d := r.DiffClaims(mismatch); len(d) != 1 {
+		t.Errorf("expected 1 holder-mismatch diff, got %v", d)
+	}
+
+	// Journal has a claim state doesn't.
+	empty := &models.State{}
+	if d := r.DiffClaims(empty); len(d) != 1 {
+		t.Errorf("expected 1 journal-only diff, got %v", d)
+	}
+}
+
+func TestReconstruct_SingletonsFoldAndDiff(t *testing.T) {
+	events := []Event{
+		{Type: EventSprintAdvanced, Fields: map[string]any{"to": float64(2)}}, // JSON round-trip
+		{Type: EventSprintStatus, Fields: map[string]any{"to": "IN_PROGRESS"}},
+		{Type: EventCircuitBreaker, Fields: map[string]any{"to": "OK"}},
+		{Type: EventGoalStatus, Fields: map[string]any{"to": "IN_PROGRESS"}},
+		{Type: EventSystemMode, Fields: map[string]any{"to": "PAUSED"}},
+	}
+	r := Reconstruct(events)
+	if r.SprintNumber != 2 || !r.sprintSeen {
+		t.Errorf("sprint number = %d seen=%v, want 2/true", r.SprintNumber, r.sprintSeen)
+	}
+
+	coherent := &models.State{}
+	coherent.Sprint.Number = 2
+	coherent.Sprint.Status = "IN_PROGRESS"
+	coherent.CircuitBreaker.Status = "OK"
+	coherent.Goal.Status = "IN_PROGRESS"
+	coherent.Config.Mode = "PAUSED"
+	if d := r.DiffSingletons(coherent); len(d) != 0 {
+		t.Errorf("expected no singleton diff, got %v", d)
+	}
+
+	drift := &models.State{}
+	drift.Sprint.Number = 3
+	drift.Sprint.Status = "CHECKPOINT"
+	drift.CircuitBreaker.Status = "TRIGGERED"
+	drift.Goal.Status = "COMPLETED"
+	drift.Config.Mode = "RUNNING"
+	if d := r.DiffSingletons(drift); len(d) != 5 {
+		t.Errorf("expected 5 singleton diffs, got %d: %v", len(d), d)
+	}
+}
+
+func TestReconstruct_UnseenSingletonsDoNotWarn(t *testing.T) {
+	// Empty journal has no opinion on any singleton — a pre-journal project
+	// with populated state must not produce divergence noise.
+	r := Reconstruct(nil)
+	state := &models.State{}
+	state.Sprint.Number = 5
+	state.Sprint.Status = "IN_PROGRESS"
+	state.CircuitBreaker.Status = "OK"
+	state.Goal.Status = "IN_PROGRESS"
+	state.Config.Mode = "RUNNING"
+	if d := r.DiffSingletons(state); len(d) != 0 {
+		t.Errorf("unseen singletons should not warn, got %v", d)
+	}
+	if d := r.DiffClaims(&models.State{Claims: []models.Claim{{TaskID: "t", AgentID: "a", Kind: "doer"}}}); len(d) != 1 {
+		t.Errorf("a state claim with no journal record IS a divergence, got %v", d)
+	}
+}

--- a/internal/journal/rotate.go
+++ b/internal/journal/rotate.go
@@ -1,0 +1,214 @@
+package journal
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// EventJournalRotated is the snapshot event that seeds a fresh journal after
+// rotation. Its Fields carry:
+//
+//	archived_file        — archive path relative to the journal directory
+//	archived_through_seq — Seq of the last event moved to the archive
+//	task_statuses        — full ProjectTaskStatuses fold of everything archived
+//
+// Projections seed from task_statuses so folding the live journal alone stays
+// exactly equivalent to folding the full (archives + live) history.
+const EventJournalRotated = "journal.rotated"
+
+// ArchiveDirName is the directory (next to the journal) holding rotated
+// journal segments.
+const ArchiveDirName = "journal-archive"
+
+// DefaultRotateThreshold is the event count above which the automatic
+// rotation trigger in db.Blackboard rotates the journal.
+const DefaultRotateThreshold int64 = 10000
+
+// minEventBytes is a deliberately LOW estimate of the smallest realistic
+// journal line (a minimal event — seq, RFC3339 time, type — is ~80 bytes;
+// typical derived events run 150–300). MaybeRotate uses it as a cheap size
+// gate: a journal smaller than threshold*minEventBytes cannot plausibly hold
+// more than threshold events, so the per-append cost stays at one os.Stat.
+// Because the estimate is low, by the time the gate opens the real count is
+// almost certainly over the threshold, so full-file counting scans are rare.
+const minEventBytes = 64
+
+// RotateResult describes a completed rotation.
+type RotateResult struct {
+	// ArchivedFile is the absolute path of the archive segment.
+	ArchivedFile string
+	// ArchivedThroughSeq is the Seq of the last archived event; the snapshot
+	// event seeding the fresh journal carries ArchivedThroughSeq+1.
+	ArchivedThroughSeq int64
+	// ArchivedEvents is the number of events moved to the archive.
+	ArchivedEvents int
+}
+
+// Rotate archives the current journal when it holds more than threshold
+// events and starts a fresh one seeded with a single EventJournalRotated
+// snapshot event. Returns (nil, nil) when the journal is at or under the
+// threshold.
+//
+// The archived file moves to journal-archive/journal-<firstseq>-<lastseq>.jsonl
+// (zero-padded so lexicographic order matches sequence order). The snapshot
+// event continues the sequence at lastseq+1 — LastSeq keeps increasing
+// monotonically across rotation, never resetting.
+//
+// Concurrency: the caller must hold the state file lock — the same contract
+// as Append (db.Blackboard rotates inside its lock window).
+//
+// Crash safety: the fresh journal is fully written and fsynced to a temp file
+// before the current journal is renamed into the archive, so the only crash
+// window is between the two renames; ReadAllIncludingArchives still sees the
+// full history in that case.
+func (s *Store) Rotate(threshold int64) (*RotateResult, error) {
+	events, err := s.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("journal: rotate failed to read journal: %w", err)
+	}
+	if int64(len(events)) <= threshold {
+		return nil, nil
+	}
+
+	firstSeq := events[0].Seq
+	lastSeq := events[len(events)-1].Seq
+
+	dir := filepath.Dir(s.path)
+	archiveDir := filepath.Join(dir, ArchiveDirName)
+	if err := os.MkdirAll(archiveDir, 0755); err != nil {
+		return nil, fmt.Errorf("journal: failed to create archive directory: %w", err)
+	}
+	archiveName := fmt.Sprintf("journal-%012d-%012d.jsonl", firstSeq, lastSeq)
+	archivePath := filepath.Join(archiveDir, archiveName)
+
+	snapshot := Event{
+		Seq:  lastSeq + 1,
+		Time: time.Now().UTC(),
+		Type: EventJournalRotated,
+		Fields: map[string]any{
+			"archived_file":        filepath.Join(ArchiveDirName, archiveName),
+			"archived_through_seq": lastSeq,
+			"task_statuses":        map[string]string(ProjectTaskStatuses(events)),
+		},
+	}
+	line, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("journal: failed to marshal rotation snapshot: %w", err)
+	}
+
+	tmpPath, err := writeFreshJournal(dir, append(line, '\n'))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Rename(s.path, archivePath); err != nil {
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("journal: failed to archive journal: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("journal: failed to install fresh journal: %w", err)
+	}
+
+	return &RotateResult{
+		ArchivedFile:       archivePath,
+		ArchivedThroughSeq: lastSeq,
+		ArchivedEvents:     len(events),
+	}, nil
+}
+
+// writeFreshJournal writes and fsyncs the seeded journal content to a temp
+// file in dir, returning its path.
+func writeFreshJournal(dir string, content []byte) (string, error) {
+	f, err := os.CreateTemp(dir, Filename+".rotate.*")
+	if err != nil {
+		return "", fmt.Errorf("journal: failed to create fresh journal: %w", err)
+	}
+	tmpPath := f.Name()
+	cleanup := func(err error) (string, error) {
+		f.Close()
+		os.Remove(tmpPath)
+		return "", err
+	}
+	if err := f.Chmod(0644); err != nil {
+		return cleanup(fmt.Errorf("journal: failed to set fresh journal permissions: %w", err))
+	}
+	if _, err := f.Write(content); err != nil {
+		return cleanup(fmt.Errorf("journal: failed to write fresh journal: %w", err))
+	}
+	if err := f.Sync(); err != nil {
+		return cleanup(fmt.Errorf("journal: failed to sync fresh journal: %w", err))
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("journal: failed to close fresh journal: %w", err)
+	}
+	return tmpPath, nil
+}
+
+// MaybeRotate rotates only when the journal plausibly exceeds threshold
+// events, at O(1) cost per call: it stats the file and skips entirely while
+// the size is under threshold*minEventBytes. Only past that gate does it pay
+// for the full event count (inside Rotate, which no-ops if the count is still
+// at or under the threshold).
+//
+// Same lock contract as Rotate: the caller must hold the state file lock.
+func (s *Store) MaybeRotate(threshold int64) (*RotateResult, error) {
+	fi, err := os.Stat(s.path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("journal: failed to stat journal: %w", err)
+	}
+	if fi.Size() < threshold*minEventBytes {
+		return nil, nil
+	}
+	return s.Rotate(threshold)
+}
+
+// ReadAllIncludingArchives returns the full event history for audit: every
+// archived segment in sequence order, then the live journal. The snapshot
+// events written by Rotate appear in-stream; their task_statuses seed equals
+// the fold of everything before them, so projections over this stream match
+// projections over the live journal alone.
+func (s *Store) ReadAllIncludingArchives() ([]Event, error) {
+	archiveDir := filepath.Join(filepath.Dir(s.path), ArchiveDirName)
+	entries, err := os.ReadDir(archiveDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("journal: failed to read archive directory: %w", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(e.Name(), "journal-") && strings.HasSuffix(e.Name(), ".jsonl") {
+			names = append(names, e.Name())
+		}
+	}
+	// Zero-padded sequence ranges in the names make lexicographic order
+	// equal to sequence order.
+	sort.Strings(names)
+
+	var all []Event
+	for _, name := range names {
+		events, err := readEventsFile(filepath.Join(archiveDir, name), 0)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, events...)
+	}
+
+	live, err := s.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	return append(all, live...), nil
+}

--- a/internal/journal/rotate_test.go
+++ b/internal/journal/rotate_test.go
@@ -1,0 +1,229 @@
+package journal
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// buildLifecycleEvents returns events exercising create / status-change /
+// remove so the projection has non-trivial content.
+func buildLifecycleEvents() []Event {
+	return []Event{
+		{Type: EventTaskCreated, Task: "t1", Fields: map[string]any{"status": "READY"}},
+		{Type: EventTaskCreated, Task: "t2", Fields: map[string]any{"status": "READY"}},
+		{Type: EventTaskCreated, Task: "t3", Fields: map[string]any{"status": "DRAFT_CODE"}},
+		{Type: EventTaskStatusChanged, Task: "t1", Fields: map[string]any{"from": "READY", "to": "IMPLEMENTING_CODE"}},
+		{Type: EventTaskStatusChanged, Task: "t2", Fields: map[string]any{"from": "READY", "to": "MERGED"}},
+		{Type: EventTaskRemoved, Task: "t3"},
+		{Type: EventTaskStatusChanged, Task: "t1", Fields: map[string]any{"from": "IMPLEMENTING_CODE", "to": "MERGED"}},
+	}
+}
+
+func TestRotateNoOpUnderThreshold(t *testing.T) {
+	s := storeForTest(t)
+	if err := s.Append([]Event{{Type: "a"}, {Type: "b"}, {Type: "c"}}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	res, err := s.Rotate(10)
+	if err != nil {
+		t.Fatalf("Rotate failed: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected no-op rotation under threshold, got %+v", res)
+	}
+	// Exactly at the threshold is also a no-op (rotation requires MORE than threshold).
+	if res, err = s.Rotate(3); err != nil || res != nil {
+		t.Fatalf("expected no-op at exact threshold, got res=%+v err=%v", res, err)
+	}
+
+	events, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("journal modified by no-op rotation: %d events", len(events))
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(s.Path()), ArchiveDirName)); !os.IsNotExist(err) {
+		t.Errorf("expected no archive directory after no-op, stat err: %v", err)
+	}
+}
+
+func TestRotatePreservesProjectionEquivalence(t *testing.T) {
+	s := storeForTest(t)
+	if err := s.Append(buildLifecycleEvents()); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	beforeEvents, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	before := ProjectTaskStatuses(beforeEvents)
+
+	res, err := s.Rotate(2)
+	if err != nil {
+		t.Fatalf("Rotate failed: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected rotation above threshold")
+	}
+
+	// The rotated journal (snapshot event only, read back from disk so
+	// task_statuses went through the JSON round-trip as map[string]any)
+	// must project identically.
+	afterEvents, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll after rotate failed: %v", err)
+	}
+	if len(afterEvents) != 1 || afterEvents[0].Type != EventJournalRotated {
+		t.Fatalf("expected fresh journal with single snapshot event, got %+v", afterEvents)
+	}
+	if _, isAny := afterEvents[0].Fields["task_statuses"].(map[string]any); !isAny {
+		t.Fatalf("expected JSON round-tripped task_statuses to be map[string]any, got %T",
+			afterEvents[0].Fields["task_statuses"])
+	}
+	after := ProjectTaskStatuses(afterEvents)
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("projection diverged across rotation:\nbefore: %+v\nafter:  %+v", before, after)
+	}
+
+	// Post-rotation appends keep folding correctly on top of the seed.
+	post := []Event{
+		{Type: EventTaskStatusChanged, Task: "t2", Fields: map[string]any{"from": "MERGED", "to": "ARCHIVED"}},
+		{Type: EventTaskCreated, Task: "t4", Fields: map[string]any{"status": "READY"}},
+		{Type: EventTaskRemoved, Task: "t1"},
+	}
+	if err := s.Append(post); err != nil {
+		t.Fatalf("Append after rotation failed: %v", err)
+	}
+
+	liveEvents, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	fullEvents, err := s.ReadAllIncludingArchives()
+	if err != nil {
+		t.Fatalf("ReadAllIncludingArchives failed: %v", err)
+	}
+
+	liveProj := ProjectTaskStatuses(liveEvents)
+	fullProj := ProjectTaskStatuses(fullEvents)
+	want := TaskStatusProjection{"t2": "ARCHIVED", "t4": "READY"}
+	if !reflect.DeepEqual(liveProj, want) {
+		t.Errorf("live projection mismatch: got %+v want %+v", liveProj, want)
+	}
+	if !reflect.DeepEqual(fullProj, want) {
+		t.Errorf("full-history projection mismatch: got %+v want %+v", fullProj, want)
+	}
+}
+
+func TestRotateSeqMonotonicity(t *testing.T) {
+	s := storeForTest(t)
+	if err := s.Append(buildLifecycleEvents()); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	lastBefore, err := s.LastSeq()
+	if err != nil {
+		t.Fatalf("LastSeq failed: %v", err)
+	}
+
+	res, err := s.Rotate(1)
+	if err != nil {
+		t.Fatalf("Rotate failed: %v", err)
+	}
+	if res.ArchivedThroughSeq != lastBefore {
+		t.Errorf("expected ArchivedThroughSeq %d, got %d", lastBefore, res.ArchivedThroughSeq)
+	}
+
+	events, err := s.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if events[0].Seq != lastBefore+1 {
+		t.Errorf("snapshot event seq: got %d, want %d (no reset)", events[0].Seq, lastBefore+1)
+	}
+
+	if err := s.Append([]Event{{Type: "post-rotate"}}); err != nil {
+		t.Fatalf("Append after rotation failed: %v", err)
+	}
+	lastAfter, err := s.LastSeq()
+	if err != nil {
+		t.Fatalf("LastSeq failed: %v", err)
+	}
+	if lastAfter != lastBefore+2 {
+		t.Errorf("expected seq to continue at %d, got %d", lastBefore+2, lastAfter)
+	}
+}
+
+func TestReadAllIncludingArchivesOrdering(t *testing.T) {
+	s := storeForTest(t)
+
+	// Two rotation cycles so multiple archive segments exist.
+	for cycle := 0; cycle < 2; cycle++ {
+		if err := s.Append(buildLifecycleEvents()); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
+		if res, err := s.Rotate(1); err != nil || res == nil {
+			t.Fatalf("Rotate failed: res=%+v err=%v", res, err)
+		}
+	}
+	if err := s.Append([]Event{{Type: "tail"}}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	all, err := s.ReadAllIncludingArchives()
+	if err != nil {
+		t.Fatalf("ReadAllIncludingArchives failed: %v", err)
+	}
+	// 7 lifecycle + snapshot + 7 lifecycle + snapshot + tail = 17, seq 1..17.
+	if len(all) != 17 {
+		t.Fatalf("expected 17 events across archives + live, got %d", len(all))
+	}
+	for i, ev := range all {
+		if ev.Seq != int64(i+1) {
+			t.Fatalf("ordering broken at index %d: seq %d (full: %+v)", i, ev.Seq, all)
+		}
+	}
+
+	archiveDir := filepath.Join(filepath.Dir(s.Path()), ArchiveDirName)
+	entries, err := os.ReadDir(archiveDir)
+	if err != nil {
+		t.Fatalf("reading archive dir failed: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 archive segments, got %d", len(entries))
+	}
+}
+
+func TestMaybeRotateSizeGate(t *testing.T) {
+	s := storeForTest(t)
+
+	// Missing journal: cheap no-op.
+	if res, err := s.MaybeRotate(DefaultRotateThreshold); err != nil || res != nil {
+		t.Fatalf("expected no-op on missing journal, got res=%+v err=%v", res, err)
+	}
+
+	if err := s.Append(buildLifecycleEvents()); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	// Default threshold: file is far below the size gate — no rotation.
+	if res, err := s.MaybeRotate(DefaultRotateThreshold); err != nil || res != nil {
+		t.Fatalf("expected size gate to skip rotation, got res=%+v err=%v", res, err)
+	}
+
+	// Tiny threshold: gate opens and the event count (7 > 2) triggers rotation.
+	res, err := s.MaybeRotate(2)
+	if err != nil {
+		t.Fatalf("MaybeRotate failed: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected rotation once size gate opens and count exceeds threshold")
+	}
+	if res.ArchivedEvents != 7 {
+		t.Errorf("expected 7 archived events, got %d", res.ArchivedEvents)
+	}
+}

--- a/internal/models/claim.go
+++ b/internal/models/claim.go
@@ -1,0 +1,70 @@
+package models
+
+import "time"
+
+// Claim kinds. A claim records one ownership relation between an agent and a
+// task: "doer" mirrors AssignedTo/LeaseExpires, "reviewer" mirrors
+// ReviewingBy/ReviewLeaseExpires.
+const (
+	ClaimKindDoer     = "doer"
+	ClaimKindReviewer = "reviewer"
+)
+
+// Claim is a first-class ownership record (strangler phase 1). During the
+// dual-write phase claims are written alongside the legacy task/agent
+// ownership fields; they do not yet drive any behavior. Old state files have
+// no claims, so absence of a claim for an owned task is expected and valid.
+type Claim struct {
+	TaskID    string     `yaml:"task_id"`
+	AgentID   string     `yaml:"agent_id"`
+	Kind      string     `yaml:"kind"`
+	GrantedAt time.Time  `yaml:"granted_at"`
+	ExpiresAt *time.Time `yaml:"expires_at,omitempty"`
+}
+
+// FindClaim returns a pointer to the claim for (taskID, kind), or nil if no
+// such claim exists. The pointer refers to the element within s.Claims, so
+// mutations are reflected in the state (useful inside Blackboard.Modify
+// closures, e.g. lease renewals updating ExpiresAt in place).
+func (s *State) FindClaim(taskID, kind string) *Claim {
+	for i := range s.Claims {
+		if s.Claims[i].TaskID == taskID && s.Claims[i].Kind == kind {
+			return &s.Claims[i]
+		}
+	}
+	return nil
+}
+
+// ClaimsForAgent returns copies of all claims held by agentID.
+func (s *State) ClaimsForAgent(agentID string) []Claim {
+	var claims []Claim
+	for _, c := range s.Claims {
+		if c.AgentID == agentID {
+			claims = append(claims, c)
+		}
+	}
+	return claims
+}
+
+// GrantClaim records a claim, replacing any existing claim with the same
+// TaskID+Kind. There is at most one claim per (task, kind).
+func (s *State) GrantClaim(c Claim) {
+	if existing := s.FindClaim(c.TaskID, c.Kind); existing != nil {
+		*existing = c
+		return
+	}
+	s.Claims = append(s.Claims, c)
+}
+
+// ReleaseClaimRecord removes the claim for (taskID, kind). Returns true if a
+// claim was removed. Releasing an absent claim is a no-op (old state files
+// have no claims), so callers may release unconditionally.
+func (s *State) ReleaseClaimRecord(taskID, kind string) bool {
+	for i := range s.Claims {
+		if s.Claims[i].TaskID == taskID && s.Claims[i].Kind == kind {
+			s.Claims = append(s.Claims[:i], s.Claims[i+1:]...)
+			return true
+		}
+	}
+	return false
+}

--- a/internal/models/claim_test.go
+++ b/internal/models/claim_test.go
@@ -1,0 +1,135 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+func claimTestState() *State {
+	exp := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	return &State{
+		Claims: []Claim{
+			{TaskID: "task-1", AgentID: "coder-1", Kind: ClaimKindDoer, GrantedAt: exp.Add(-time.Hour), ExpiresAt: &exp},
+			{TaskID: "task-1", AgentID: "reviewer-1", Kind: ClaimKindReviewer, GrantedAt: exp.Add(-time.Hour), ExpiresAt: &exp},
+			{TaskID: "task-2", AgentID: "coder-1", Kind: ClaimKindDoer, GrantedAt: exp.Add(-time.Hour)},
+		},
+	}
+}
+
+func TestFindClaim(t *testing.T) {
+	s := claimTestState()
+
+	c := s.FindClaim("task-1", ClaimKindDoer)
+	if c == nil {
+		t.Fatal("FindClaim(task-1, doer) = nil, want claim")
+	}
+	if c.AgentID != "coder-1" {
+		t.Errorf("AgentID = %q, want coder-1", c.AgentID)
+	}
+
+	if got := s.FindClaim("task-1", ClaimKindReviewer); got == nil || got.AgentID != "reviewer-1" {
+		t.Errorf("FindClaim(task-1, reviewer) = %+v, want reviewer-1", got)
+	}
+	if got := s.FindClaim("task-3", ClaimKindDoer); got != nil {
+		t.Errorf("FindClaim(task-3, doer) = %+v, want nil", got)
+	}
+	if got := s.FindClaim("task-2", ClaimKindReviewer); got != nil {
+		t.Errorf("FindClaim(task-2, reviewer) = %+v, want nil", got)
+	}
+}
+
+func TestFindClaimReturnsPointerIntoState(t *testing.T) {
+	s := claimTestState()
+
+	c := s.FindClaim("task-2", ClaimKindDoer)
+	if c == nil {
+		t.Fatal("FindClaim(task-2, doer) = nil, want claim")
+	}
+	newExp := time.Date(2026, 6, 12, 18, 0, 0, 0, time.UTC)
+	c.ExpiresAt = &newExp
+
+	again := s.FindClaim("task-2", ClaimKindDoer)
+	if again.ExpiresAt == nil || !again.ExpiresAt.Equal(newExp) {
+		t.Errorf("mutation through FindClaim pointer not reflected in state: %+v", again)
+	}
+}
+
+func TestClaimsForAgent(t *testing.T) {
+	s := claimTestState()
+
+	claims := s.ClaimsForAgent("coder-1")
+	if len(claims) != 2 {
+		t.Fatalf("ClaimsForAgent(coder-1) returned %d claims, want 2", len(claims))
+	}
+	for _, c := range claims {
+		if c.AgentID != "coder-1" {
+			t.Errorf("claim %+v has wrong agent", c)
+		}
+	}
+
+	if got := s.ClaimsForAgent("nobody"); len(got) != 0 {
+		t.Errorf("ClaimsForAgent(nobody) = %+v, want empty", got)
+	}
+}
+
+func TestGrantClaimAppendsNewClaim(t *testing.T) {
+	s := &State{}
+	s.GrantClaim(Claim{TaskID: "task-1", AgentID: "coder-1", Kind: ClaimKindDoer, GrantedAt: time.Now().UTC()})
+
+	if len(s.Claims) != 1 {
+		t.Fatalf("len(Claims) = %d, want 1", len(s.Claims))
+	}
+	if c := s.FindClaim("task-1", ClaimKindDoer); c == nil || c.AgentID != "coder-1" {
+		t.Errorf("FindClaim after grant = %+v, want coder-1", c)
+	}
+}
+
+func TestGrantClaimReplacesSameTaskAndKind(t *testing.T) {
+	s := claimTestState()
+
+	granted := time.Date(2026, 6, 12, 13, 0, 0, 0, time.UTC)
+	s.GrantClaim(Claim{TaskID: "task-1", AgentID: "coder-2", Kind: ClaimKindDoer, GrantedAt: granted})
+
+	if len(s.Claims) != 3 {
+		t.Fatalf("len(Claims) = %d, want 3 (replace, not append)", len(s.Claims))
+	}
+	c := s.FindClaim("task-1", ClaimKindDoer)
+	if c == nil || c.AgentID != "coder-2" {
+		t.Fatalf("FindClaim after re-grant = %+v, want coder-2", c)
+	}
+	if !c.GrantedAt.Equal(granted) {
+		t.Errorf("GrantedAt = %v, want %v", c.GrantedAt, granted)
+	}
+	if c.ExpiresAt != nil {
+		t.Errorf("ExpiresAt = %v, want nil (fully replaced)", c.ExpiresAt)
+	}
+	// The reviewer claim on the same task must be untouched.
+	if r := s.FindClaim("task-1", ClaimKindReviewer); r == nil || r.AgentID != "reviewer-1" {
+		t.Errorf("reviewer claim disturbed by doer re-grant: %+v", r)
+	}
+}
+
+func TestReleaseClaimRecord(t *testing.T) {
+	s := claimTestState()
+
+	if !s.ReleaseClaimRecord("task-1", ClaimKindDoer) {
+		t.Error("ReleaseClaimRecord(task-1, doer) = false, want true")
+	}
+	if len(s.Claims) != 2 {
+		t.Fatalf("len(Claims) = %d, want 2", len(s.Claims))
+	}
+	if s.FindClaim("task-1", ClaimKindDoer) != nil {
+		t.Error("doer claim still present after release")
+	}
+	if s.FindClaim("task-1", ClaimKindReviewer) == nil {
+		t.Error("reviewer claim removed by doer release")
+	}
+
+	// Releasing an absent claim is a no-op returning false.
+	if s.ReleaseClaimRecord("task-1", ClaimKindDoer) {
+		t.Error("second ReleaseClaimRecord = true, want false")
+	}
+	if s.ReleaseClaimRecord("missing-task", ClaimKindReviewer) {
+		t.Error("ReleaseClaimRecord(missing-task) = true, want false")
+	}
+}

--- a/internal/models/state.go
+++ b/internal/models/state.go
@@ -16,6 +16,7 @@ type State struct {
 	HumanNotes      []HumanNote            `yaml:"human_notes"`
 	SpecChanges     []SpecChange           `yaml:"spec_changes"`
 	Anomalies       []Anomaly              `yaml:"anomalies"`
+	Claims          []Claim                `yaml:"claims,omitempty"`
 	Sprint          Sprint                 `yaml:"sprint"`
 	SprintHistory   []SprintSummary        `yaml:"sprint_history,omitempty"`
 	CircuitBreaker  CircuitBreaker         `yaml:"circuit_breaker"`

--- a/internal/ops/add_tasks.go
+++ b/internal/ops/add_tasks.go
@@ -149,7 +149,7 @@ func AddTask(statePath, logPath string, input *AddTaskInput, orchestratorID stri
 	}
 
 	var postValidationErr error
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("add_task", func(state *models.State) error {
 		if state.FindTask(input.ID) != nil {
 			return &PreconditionError{Reason: fmt.Sprintf("task '%s' already exists", input.ID)}
 		}

--- a/internal/ops/advance_sprint.go
+++ b/internal/ops/advance_sprint.go
@@ -51,7 +51,7 @@ func AdvanceSprint(projectRoot string) (*AdvanceSprintResult, error) {
 
 	var result AdvanceSprintResult
 
-	err := blackboard.Modify(func(s *models.State) error {
+	err := blackboard.ModifyOp("advance_sprint", func(s *models.State) error {
 		plan, err := planSprintAdvance(s, time.Now().UTC(), projectRoot)
 		if err != nil {
 			return err

--- a/internal/ops/agent_health.go
+++ b/internal/ops/agent_health.go
@@ -56,7 +56,7 @@ func MarkAgentDegraded(input MarkAgentDegradedInput) error {
 
 	bb := db.For(paths.New(input.ProjectRoot).StatePath())
 	now := time.Now().UTC()
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("mark_agent_degraded", func(state *models.State) error {
 		agent, hasAgent := state.Agents[input.AgentID]
 		if state.AgentHealth == nil {
 			state.AgentHealth = make(map[string]models.AgentHealth)
@@ -117,7 +117,7 @@ func ClearAgentDegraded(projectRoot, agentID string) error {
 		return &PreconditionError{Reason: "agent ID is required"}
 	}
 	bb := db.For(paths.New(projectRoot).StatePath())
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("clear_agent_degraded", func(state *models.State) error {
 		if state.AgentHealth == nil {
 			return nil
 		}

--- a/internal/ops/analyze.go
+++ b/internal/ops/analyze.go
@@ -39,7 +39,7 @@ func Analyze(projectRoot string) (*AnalyzeResult, error) {
 	result, consideredAnomalies, suppressedCount := analysis.DetectUnacknowledgedPatterns(state)
 
 	if !result.Triggered {
-		err := blackboard.Modify(func(s *models.State) error {
+		err := blackboard.ModifyOp("analyze", func(s *models.State) error {
 			s.CircuitBreaker.LastCheck = timestamp
 			s.CircuitBreaker.Status = "OK"
 			s.CircuitBreaker.CurrentTrigger = nil
@@ -76,7 +76,7 @@ func Analyze(projectRoot string) (*AnalyzeResult, error) {
 		return nil, fmt.Errorf("failed to write report: %w", err)
 	}
 
-	err = blackboard.Modify(func(s *models.State) error {
+	err = blackboard.ModifyOp("analyze", func(s *models.State) error {
 		s.CircuitBreaker.LastCheck = timestamp
 		s.CircuitBreaker.Status = "TRIGGERED"
 		s.CircuitBreaker.CurrentTrigger = &models.CircuitBreakerTrigger{

--- a/internal/ops/assess_blocked.go
+++ b/internal/ops/assess_blocked.go
@@ -47,7 +47,7 @@ func AssessBlocked(projectRoot, taskID, note, agentID string) (*AssessBlockedRes
 	bb := db.For(lp.StatePath())
 	now := time.Now().UTC()
 
-	err := bb.Modify(func(state *models.State) error {
+	err := bb.ModifyOp("assess_blocked", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/assess_hypothesis_exhausted.go
+++ b/internal/ops/assess_hypothesis_exhausted.go
@@ -42,7 +42,7 @@ func AssessHypothesisExhausted(projectRoot, taskID, note, agentID string) (*Asse
 	}
 	pipelineTransitions := BuildPipelineTransitions(resolver)
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("assess_hypothesis_exhausted", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/await_resubmission.go
+++ b/internal/ops/await_resubmission.go
@@ -234,7 +234,7 @@ func checkLastRejectingReviewer(task *models.Task, agentID string) error {
 // the task, and sets the agent's status to WAITING with CurrentTask.
 func acquireReviewOwnership(bb *db.Blackboard, agentID, taskID string, timeout time.Duration) error {
 	leaseExpiry := time.Now().Add(timeout + reviewOwnershipLeaseMargin)
-	return bb.Modify(func(s *models.State) error {
+	return bb.ModifyOp("acquire_review_ownership", func(s *models.State) error {
 		agent, ok := s.Agents[agentID]
 		if !ok {
 			return &errors.NotFoundError{Entity: "agent", ID: agentID}
@@ -246,6 +246,7 @@ func acquireReviewOwnership(bb *db.Blackboard, agentID, taskID string, timeout t
 
 		task.ReviewingBy = &agentID
 		task.ReviewLeaseExpires = &leaseExpiry
+		recordReviewerClaim(s, taskID, agentID, leaseExpiry)
 		agent.Status = models.AgentStatusWaiting
 		agent.CurrentTask = &taskID
 		s.Agents[agentID] = agent
@@ -257,7 +258,7 @@ func acquireReviewOwnership(bb *db.Blackboard, agentID, taskID string, timeout t
 // and the agent. Agent status is intentionally left unchanged — the
 // supervisor's resetAgentAfterExit handles status transitions.
 func releaseReviewOwnership(bb *db.Blackboard, agentID, taskID string) error {
-	return bb.Modify(func(s *models.State) error {
+	return bb.ModifyOp("release_review_ownership", func(s *models.State) error {
 		if agent, ok := s.Agents[agentID]; ok {
 			agent.CurrentTask = nil
 			s.Agents[agentID] = agent
@@ -266,6 +267,7 @@ func releaseReviewOwnership(bb *db.Blackboard, agentID, taskID string) error {
 		if task != nil {
 			task.ReviewingBy = nil
 			task.ReviewLeaseExpires = nil
+			releaseReviewerClaimRecord(s, taskID)
 		}
 		return nil
 	})
@@ -336,7 +338,7 @@ func reclaimForReview(projectRoot string, bb *db.Blackboard, taskID, agentID str
 	var reviewCycle int
 	var reviewBoundaryErr error
 
-	modErr := bb.Modify(func(s *models.State) error {
+	modErr := bb.ModifyOp("reclaim_for_review", func(s *models.State) error {
 		task := s.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -357,6 +359,7 @@ func reclaimForReview(projectRoot string, bb *db.Blackboard, taskID, agentID str
 
 		task.ReviewLeaseExpires = &freshLease
 		// ReviewingBy stays set from acquireReviewOwnership.
+		recordReviewerClaim(s, taskID, agentID, freshLease)
 
 		if task.ReviewCommit != nil {
 			reviewCommit = *task.ReviewCommit

--- a/internal/ops/await_verdict.go
+++ b/internal/ops/await_verdict.go
@@ -292,7 +292,7 @@ func checkLastSubmitter(task *models.Task, agentID string) error {
 // CurrentTask to taskID. This prevents other supervisors from claiming the
 // task if it gets rejected while we're waiting.
 func acquireAwaitOwnership(bb *db.Blackboard, agentID, taskID string) error {
-	return bb.Modify(func(s *models.State) error {
+	return bb.ModifyOp("acquire_await_ownership", func(s *models.State) error {
 		agent, ok := s.Agents[agentID]
 		if !ok {
 			return &errors.NotFoundError{Entity: "agent", ID: agentID}
@@ -308,7 +308,7 @@ func acquireAwaitOwnership(bb *db.Blackboard, agentID, taskID string) error {
 // of the task. Status is left unchanged — the supervisor's resetAgentAfterExit
 // handles status transitions when the CLI session ends.
 func releaseOwnership(bb *db.Blackboard, agentID string) error {
-	return bb.Modify(func(s *models.State) error {
+	return bb.ModifyOp("release_await_ownership", func(s *models.State) error {
 		if agent, ok := s.Agents[agentID]; ok {
 			agent.CurrentTask = nil
 			s.Agents[agentID] = agent

--- a/internal/ops/cancel_task.go
+++ b/internal/ops/cancel_task.go
@@ -49,7 +49,7 @@ func CancelTask(projectRoot, taskID, reason, agentID string) (*CancelResult, err
 	originalStatus := task.Status
 
 	// Atomic State Update
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("cancel_task", func(state *models.State) error {
 		currentTask := state.FindTask(taskID)
 		if currentTask == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -68,6 +68,8 @@ func CancelTask(projectRoot, taskID, reason, agentID string) (*CancelResult, err
 		currentTask.LeaseExpires = nil
 		currentTask.ReviewingBy = nil
 		currentTask.ReviewLeaseExpires = nil
+		releaseDoerClaimRecord(state, taskID)
+		releaseReviewerClaimRecord(state, taskID)
 		currentTask.Worktree = nil
 		clearAttemptState(currentTask, attemptStateRetire)
 

--- a/internal/ops/claim_records.go
+++ b/internal/ops/claim_records.go
@@ -1,0 +1,67 @@
+package ops
+
+import (
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// Claim records (strangler phase 1: dual-write).
+//
+// These helpers mirror legacy ownership fields (task.AssignedTo/LeaseExpires,
+// task.ReviewingBy/ReviewLeaseExpires) into state.Claims. They mutate ONLY
+// state.Claims — the legacy task/agent fields stay maintained by the existing
+// mutation code surrounding each call. Claims do not yet drive any behavior.
+
+// recordDoerClaim dual-writes the doer ownership of taskID into state.Claims.
+func recordDoerClaim(state *models.State, taskID, agentID string, leaseExpires time.Time) {
+	recordClaim(state, taskID, agentID, models.ClaimKindDoer, leaseExpires)
+}
+
+// recordReviewerClaim dual-writes the reviewer ownership of taskID into state.Claims.
+func recordReviewerClaim(state *models.State, taskID, agentID string, leaseExpires time.Time) {
+	recordClaim(state, taskID, agentID, models.ClaimKindReviewer, leaseExpires)
+}
+
+// recordClaim grants or renews a claim. A renewal (same task, kind, and agent)
+// updates ExpiresAt in place and preserves GrantedAt; anything else replaces
+// the claim for (taskID, kind) with a fresh grant.
+func recordClaim(state *models.State, taskID, agentID, kind string, leaseExpires time.Time) {
+	exp := leaseExpires
+	if existing := state.FindClaim(taskID, kind); existing != nil && existing.AgentID == agentID {
+		existing.ExpiresAt = &exp
+		return
+	}
+	state.GrantClaim(models.Claim{
+		TaskID:    taskID,
+		AgentID:   agentID,
+		Kind:      kind,
+		GrantedAt: time.Now().UTC(),
+		ExpiresAt: &exp,
+	})
+}
+
+// releaseDoerClaimRecord removes the doer claim record for taskID, if any.
+func releaseDoerClaimRecord(state *models.State, taskID string) {
+	state.ReleaseClaimRecord(taskID, models.ClaimKindDoer)
+}
+
+// releaseReviewerClaimRecord removes the reviewer claim record for taskID, if any.
+func releaseReviewerClaimRecord(state *models.State, taskID string) {
+	state.ReleaseClaimRecord(taskID, models.ClaimKindReviewer)
+}
+
+// SweepExpiredClaims returns the claims whose lease expired more than the
+// lease-expiry grace period before now. It does not mutate state — it is the
+// read-only primitive for the future lease-sweep scheduler and is not wired
+// into any command yet.
+func SweepExpiredClaims(state *models.State, now time.Time) []models.Claim {
+	cutoff := now.Add(-models.LeaseExpiryGracePeriod)
+	var expired []models.Claim
+	for _, c := range state.Claims {
+		if c.ExpiresAt != nil && c.ExpiresAt.Before(cutoff) {
+			expired = append(expired, c)
+		}
+	}
+	return expired
+}

--- a/internal/ops/claim_records_test.go
+++ b/internal/ops/claim_records_test.go
@@ -1,0 +1,109 @@
+package ops
+
+import (
+	"testing"
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/roles"
+	"github.com/liza-mas/liza/internal/testhelpers"
+)
+
+// TestClaimReleaseCycle_KeepsClaimRecordsInSyncWithLegacyFields drives a full
+// doer claim -> release cycle through the real ClaimTask/ReleaseClaim ops and
+// asserts the first-class claim records (state.Claims) stay consistent with
+// the legacy AssignedTo/LeaseExpires fields at every step (dual-write).
+func TestClaimReleaseCycle_KeepsClaimRecordsInSyncWithLegacyFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	testhelpers.SetupTestGitRepo(t, tmpDir)
+	stateFile, _ := testhelpers.SetupLizaDir(t, tmpDir)
+
+	now := time.Now().UTC()
+	state := testhelpers.CreateValidState()
+	registerClaimTaskTestAgents(state)
+	state.Tasks = []models.Task{
+		testhelpers.BuildTaskByStatus("task-1", models.TaskStatusReady, now),
+	}
+	testhelpers.WriteInitialState(t, stateFile, state)
+
+	// Claim: a doer claim record must mirror the legacy fields.
+	if _, err := ClaimTask(tmpDir, "task-1", "coder-1"); err != nil {
+		t.Fatalf("ClaimTask() error: %v", err)
+	}
+
+	claimed := readClaimStateForTest(t, stateFile)
+	task := claimed.FindTask("task-1")
+	if task == nil {
+		t.Fatal("task not found after claim")
+	}
+	if task.AssignedTo == nil || *task.AssignedTo != "coder-1" {
+		t.Fatal("legacy AssignedTo not set — test precondition broken")
+	}
+	claim := claimed.FindClaim("task-1", models.ClaimKindDoer)
+	if claim == nil {
+		t.Fatal("doer claim record missing after ClaimTask")
+	}
+	if claim.AgentID != *task.AssignedTo {
+		t.Errorf("claim AgentID = %q, want legacy AssignedTo %q", claim.AgentID, *task.AssignedTo)
+	}
+	if task.LeaseExpires == nil {
+		t.Fatal("legacy LeaseExpires not set after claim")
+	}
+	if claim.ExpiresAt == nil || !claim.ExpiresAt.Equal(*task.LeaseExpires) {
+		t.Errorf("claim ExpiresAt = %v, want legacy LeaseExpires %v", claim.ExpiresAt, task.LeaseExpires)
+	}
+	if claim.GrantedAt.IsZero() {
+		t.Error("claim GrantedAt is zero")
+	}
+	if got := claimed.ClaimsForAgent("coder-1"); len(got) != 1 {
+		t.Errorf("ClaimsForAgent(coder-1) = %d claims, want 1", len(got))
+	}
+
+	// Release: the claim record must be removed alongside the legacy fields.
+	result, err := ReleaseClaim(tmpDir, "task-1", roles.ClaimDoer, true, "test cycle", "human")
+	if err != nil {
+		t.Fatalf("ReleaseClaim() error: %v", err)
+	}
+	if !result.ReleasedDoer {
+		t.Fatal("ReleaseClaim did not release doer claim")
+	}
+
+	released := readClaimStateForTest(t, stateFile)
+	task = released.FindTask("task-1")
+	if task.AssignedTo != nil || task.LeaseExpires != nil {
+		t.Fatalf("legacy fields not cleared: AssignedTo=%v LeaseExpires=%v", task.AssignedTo, task.LeaseExpires)
+	}
+	if c := released.FindClaim("task-1", models.ClaimKindDoer); c != nil {
+		t.Errorf("doer claim record still present after release: %+v", c)
+	}
+	if got := released.ClaimsForAgent("coder-1"); len(got) != 0 {
+		t.Errorf("ClaimsForAgent(coder-1) after release = %+v, want none", got)
+	}
+}
+
+func TestSweepExpiredClaims(t *testing.T) {
+	now := time.Now().UTC()
+	longExpired := now.Add(-models.LeaseExpiryGracePeriod - time.Minute)
+	withinGrace := now.Add(-models.LeaseExpiryGracePeriod + time.Minute)
+	live := now.Add(time.Hour)
+
+	state := &models.State{
+		Claims: []models.Claim{
+			{TaskID: "task-1", AgentID: "coder-1", Kind: models.ClaimKindDoer, ExpiresAt: &longExpired},
+			{TaskID: "task-2", AgentID: "coder-2", Kind: models.ClaimKindDoer, ExpiresAt: &withinGrace},
+			{TaskID: "task-3", AgentID: "reviewer-1", Kind: models.ClaimKindReviewer, ExpiresAt: &live},
+			{TaskID: "task-4", AgentID: "coder-3", Kind: models.ClaimKindDoer}, // no lease — never swept
+		},
+	}
+
+	expired := SweepExpiredClaims(state, now)
+	if len(expired) != 1 {
+		t.Fatalf("SweepExpiredClaims() = %d claims, want 1: %+v", len(expired), expired)
+	}
+	if expired[0].TaskID != "task-1" {
+		t.Errorf("swept TaskID = %q, want task-1", expired[0].TaskID)
+	}
+	if len(state.Claims) != 4 {
+		t.Errorf("SweepExpiredClaims must not mutate state, len(Claims) = %d", len(state.Claims))
+	}
+}

--- a/internal/ops/claim_reviewer_task.go
+++ b/internal/ops/claim_reviewer_task.go
@@ -80,7 +80,7 @@ func ClaimReviewerTask(input ClaimReviewerTaskInput) (*ClaimReviewerTaskResult, 
 	}
 	pr := pb.pr
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("claim_reviewer_task", func(state *models.State) error {
 		claimingAgent, err := requireRegisteredClaimAgent(state, input.AgentID, role)
 		if err != nil {
 			return err
@@ -158,6 +158,7 @@ func ClaimReviewerTask(input ClaimReviewerTaskInput) (*ClaimReviewerTaskResult, 
 			}
 			task.ReviewingBy = &input.AgentID
 			task.ReviewLeaseExpires = &leaseExpires
+			recordReviewerClaim(state, task.ID, input.AgentID, leaseExpires)
 
 			agent := claimingAgent
 			agent.Status = models.AgentStatusReviewing

--- a/internal/ops/claim_task.go
+++ b/internal/ops/claim_task.go
@@ -297,6 +297,7 @@ func completeClaimTaskAfterValidation(
 	}
 	worktreeCreated := worktreePhase.created
 	worktreeDeleted := worktreePhase.deleted
+	claimCtx.worktreeRecreated = worktreePhase.created
 
 	var envFileWarnings []string
 	if copyWorktreeEnvFiles {
@@ -340,7 +341,7 @@ func completeClaimTaskAfterValidation(
 		testClaimTaskHooks.beforePhase3Modify()
 	}
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("claim_task", func(state *models.State) error {
 		// Re-check task exists and status hasn't changed
 		task := state.FindTask(taskID)
 		if task == nil {
@@ -383,6 +384,7 @@ func completeClaimTaskAfterValidation(
 		}
 		task.AssignedTo = &agentID
 		task.LeaseExpires = &leaseExpires
+		recordDoerClaim(state, taskID, agentID, leaseExpires)
 
 		// Increment iteration (0 -> 1 on first claim, then 2, 3, etc.)
 		task.Iteration++
@@ -673,7 +675,7 @@ func enforceBlockedEscalation(
 ) error {
 	now := time.Now().UTC()
 
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("blocked_escalation", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -713,6 +715,7 @@ func enforceBlockedEscalation(
 			}
 		}
 		task.AssignedTo = nil
+		releaseDoerClaimRecord(state, task.ID)
 
 		agentPtr := &agentID
 		reasonPtr := &blockedReason

--- a/internal/ops/claim_task_strategy.go
+++ b/internal/ops/claim_task_strategy.go
@@ -21,6 +21,10 @@ type claimContext struct {
 	previousAssignee  string
 	baseCommit        string
 	leaseExpires      time.Time
+	// worktreeRecreated is set after the worktree phase when the strategy
+	// rebuilt the worktree from the current integration HEAD (rather than
+	// preserving an existing one).
+	worktreeRecreated bool
 }
 
 type claimStrategy interface {
@@ -219,7 +223,18 @@ func (rejectedClaimStrategy) shouldRunPostWorktreeCmd(claimWorktreePhaseResult) 
 	return true
 }
 
-func (rejectedClaimStrategy) mutateTask(_ *models.Task, _ *claimContext) {}
+func (rejectedClaimStrategy) mutateTask(task *models.Task, ctx *claimContext) {
+	// Preserved worktree (same-coder reclaim): the original worktree and
+	// base_commit still describe the work — leave them untouched. Recreated
+	// worktree (reassignment or missing/orphaned state): the new worktree
+	// branches from the current integration HEAD, so the task metadata must
+	// follow or reviewers would diff against a stale base.
+	if !ctx.worktreeRecreated {
+		return
+	}
+	task.Worktree = &ctx.worktreeRel
+	task.BaseCommit = &ctx.baseCommit
+}
 
 func (rejectedClaimStrategy) historyEntry(now time.Time, ctx *claimContext) models.TaskHistoryEntry {
 	agentPtr := &ctx.agentID

--- a/internal/ops/clear_stale_review_claims.go
+++ b/internal/ops/clear_stale_review_claims.go
@@ -31,7 +31,7 @@ func ClearStaleReviewClaims(projectRoot string) (int, error) {
 	cleared := 0
 	now := time.Now().UTC()
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("clear_stale_review_claims", func(state *models.State) error {
 		for i := range state.Tasks {
 			task := &state.Tasks[i]
 
@@ -52,6 +52,7 @@ func ClearStaleReviewClaims(projectRoot string) (int, error) {
 					staleReviewer := *task.ReviewingBy
 					task.ReviewingBy = nil
 					task.ReviewLeaseExpires = nil
+					releaseReviewerClaimRecord(state, task.ID)
 
 					if a, ok := state.Agents[staleReviewer]; ok {
 						if a.CurrentTask != nil && *a.CurrentTask == task.ID {
@@ -94,6 +95,7 @@ func ClearStaleReviewClaims(projectRoot string) (int, error) {
 			}
 			task.ReviewingBy = nil
 			task.ReviewLeaseExpires = nil
+			releaseReviewerClaimRecord(state, task.ID)
 
 			if a, ok := state.Agents[staleReviewer]; ok {
 				if a.CurrentTask != nil && *a.CurrentTask == task.ID {

--- a/internal/ops/delete_agent.go
+++ b/internal/ops/delete_agent.go
@@ -261,7 +261,7 @@ func DeleteAgent(projectRoot, agentID string, force, allowRunningPID bool, reaso
 		}
 	}
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("delete_agent", func(state *models.State) error {
 		agent, exists := state.Agents[agentID]
 		if !exists {
 			return &errors.NotFoundError{Entity: "agent", ID: agentID}

--- a/internal/ops/delete_task.go
+++ b/internal/ops/delete_task.go
@@ -163,7 +163,7 @@ func DeleteTask(projectRoot, taskID string, force, deleteWorktree bool, reason s
 	}
 
 	// Atomic state update
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("delete_task", func(state *models.State) error {
 		taskIndex := state.FindTaskIndex(taskID)
 		if taskIndex == -1 {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -194,6 +194,10 @@ func DeleteTask(projectRoot, taskID string, force, deleteWorktree bool, reason s
 
 		// Remove task from state.Tasks slice
 		state.Tasks = append(state.Tasks[:taskIndex], state.Tasks[taskIndex+1:]...)
+
+		// Remove claim records — claims must not reference a deleted task.
+		releaseDoerClaimRecord(state, taskID)
+		releaseReviewerClaimRecord(state, taskID)
 
 		// Remove task from sprint scope
 		state.Sprint.Scope.Planned = slices.DeleteFunc(state.Sprint.Scope.Planned, func(id string) bool { return id == taskID })

--- a/internal/ops/handoff.go
+++ b/internal/ops/handoff.go
@@ -78,7 +78,7 @@ func Handoff(input *HandoffInput) (*HandoffResult, error) {
 		succeeded = []string{input.Summary}
 	}
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("handoff", func(state *models.State) error {
 		task := state.FindTask(input.TaskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: input.TaskID}

--- a/internal/ops/hypothesis_exhaustion.go
+++ b/internal/ops/hypothesis_exhaustion.go
@@ -32,6 +32,8 @@ func blockTaskForHypothesisExhaustion(state *models.State, task *models.Task, ag
 	task.LeaseExpires = nil
 	task.ReviewingBy = nil
 	task.ReviewLeaseExpires = nil
+	releaseDoerClaimRecord(state, task.ID)
+	releaseReviewerClaimRecord(state, task.ID)
 
 	note := fmt.Sprintf("failed_by: %s", strings.Join(task.FailedBy, ", "))
 	task.History = append(task.History, models.TaskHistoryEntry{

--- a/internal/ops/lease.go
+++ b/internal/ops/lease.go
@@ -7,6 +7,7 @@ import (
 )
 
 // renewLease sets a fresh lease expiry on task based on the configured duration.
+// The matching doer claim record, if present, is renewed in lockstep (dual-write).
 func renewLease(s *models.State, t *models.Task) {
 	dur := s.Config.LeaseDuration
 	if dur <= 0 {
@@ -14,4 +15,7 @@ func renewLease(s *models.State, t *models.Task) {
 	}
 	exp := time.Now().UTC().Add(time.Duration(dur) * time.Second)
 	t.LeaseExpires = &exp
+	if t.AssignedTo != nil {
+		recordClaim(s, t.ID, *t.AssignedTo, models.ClaimKindDoer, exp)
+	}
 }

--- a/internal/ops/mark_blocked.go
+++ b/internal/ops/mark_blocked.go
@@ -86,7 +86,7 @@ func MarkBlockedWithOptions(projectRoot, taskID, reason string, questions []stri
 	}
 	pipelineTransitions := BuildPipelineTransitions(resolver)
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("mark_blocked", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -116,6 +116,7 @@ func MarkBlockedWithOptions(projectRoot, taskID, reason string, questions []stri
 		releaseAgentsForTask(state, taskID)
 		task.AssignedTo = nil
 		task.LeaseExpires = nil
+		releaseDoerClaimRecord(state, taskID)
 
 		task.History = append(task.History, models.TaskHistoryEntry{
 			Time:   now,

--- a/internal/ops/mode_change.go
+++ b/internal/ops/mode_change.go
@@ -43,7 +43,7 @@ func changeMode(projectRoot, reason, changedBy string, target models.SystemMode)
 	timestamp := time.Now()
 	var previousMode models.SystemMode
 
-	err := blackboard.Modify(func(s *models.State) error {
+	err := blackboard.ModifyOp("mode_change", func(s *models.State) error {
 		previousMode = s.Config.Mode
 		if previousMode == "" {
 			previousMode = models.SystemModeRunning
@@ -182,7 +182,7 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 	var advanceResult *AdvanceSprintResult
 	runTransitionsAfterResume := false
 
-	err := blackboard.Modify(func(s *models.State) error {
+	err := blackboard.ModifyOp("resume", func(s *models.State) error {
 		currentMode := s.Config.Mode
 		if currentMode == "" {
 			currentMode = models.SystemModeRunning
@@ -259,7 +259,7 @@ func Resume(projectRoot, changedBy string) (*ResumeResult, error) {
 func clearTransitionCheckpointTrigger(projectRoot string) error {
 	statePath := paths.New(projectRoot).StatePath()
 	blackboard := db.For(statePath)
-	return blackboard.Modify(func(s *models.State) error {
+	return blackboard.ModifyOp("clear_transition_checkpoint", func(s *models.State) error {
 		if models.IsTransitionCheckpointTrigger(s.Sprint.CheckpointTrigger) {
 			s.Sprint.CheckpointTrigger = ""
 		}

--- a/internal/ops/proceed.go
+++ b/internal/ops/proceed.go
@@ -178,7 +178,7 @@ func Proceed(projectRoot, taskID, transitionName string) (*ProceedResult, error)
 		TransitionName: transitionName,
 	}
 
-	err = blackboard.Modify(func(s *models.State) error {
+	err = blackboard.ModifyOp("proceed", func(s *models.State) error {
 		// Validate sprint is COMPLETED
 		if s.Sprint.Status != models.SprintStatusCompleted {
 			return fmt.Errorf("sprint must be COMPLETED before proceeding (current: %s)", s.Sprint.Status)
@@ -1009,7 +1009,7 @@ func ExecuteAvailableTransitions(projectRoot string, triggerFilter string) ([]Pr
 	now := time.Now().UTC()
 	var results []ProceedResult
 
-	err = blackboard.Modify(func(s *models.State) error {
+	err = blackboard.ModifyOp("execute_transitions", func(s *models.State) error {
 		var pending []pendingTx
 		origIdx := 0
 

--- a/internal/ops/reconcile_merged.go
+++ b/internal/ops/reconcile_merged.go
@@ -61,7 +61,7 @@ func ReconcileMerged(projectRoot, taskID, mergeCommit, prURL, reason, agentID st
 	}
 
 	now := time.Now().UTC()
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("reconcile_merged", func(state *models.State) error {
 		currentTask := state.FindTask(taskID)
 		if currentTask == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -79,6 +79,8 @@ func ReconcileMerged(projectRoot, taskID, mergeCommit, prURL, reason, agentID st
 		currentTask.LeaseExpires = nil
 		currentTask.ReviewingBy = nil
 		currentTask.ReviewLeaseExpires = nil
+		releaseDoerClaimRecord(state, taskID)
+		releaseReviewerClaimRecord(state, taskID)
 		currentTask.MergeCommit = &resolvedCommit
 		currentTask.IntegrationFailure = nil
 

--- a/internal/ops/recover_agent.go
+++ b/internal/ops/recover_agent.go
@@ -101,7 +101,7 @@ func RecoverAgent(projectRoot, agentID string, force bool, reason string) (*Reco
 
 	// Phase 3: State modify (atomic)
 	now := time.Now().UTC()
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("recover_agent", func(state *models.State) error {
 		currentDoerTaskIDs, currentReviewerTaskIDs := TaskClaimsForAgent(state, agentID)
 		agentStillExists := false
 		if _, ok := state.Agents[agentID]; ok {

--- a/internal/ops/recover_task.go
+++ b/internal/ops/recover_task.go
@@ -176,7 +176,7 @@ func RecoverTaskWithOptions(projectRoot, taskID string, reason string, opts Reco
 	}
 
 	now := time.Now().UTC()
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("recover_task", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return nil
@@ -203,6 +203,7 @@ func RecoverTaskWithOptions(projectRoot, taskID string, reason string, opts Reco
 			task.Status = statuses.Initial
 			task.ReviewingBy = nil
 			task.ReviewLeaseExpires = nil
+			releaseReviewerClaimRecord(state, taskID)
 			clearAttemptState(task, attemptStateInitialReset)
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("reset %s to %s: missing review_commit", taskID, statuses.Initial))
@@ -465,7 +466,7 @@ func recoverTaskFreshReset(bb *db.Blackboard, gitWrapper *git.Git, taskID, reaso
 	baseCommit := ""
 	var freshCreateErr error
 	now := time.Now().UTC()
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("recover_task", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return fmt.Errorf("task %s not found in state", taskID)
@@ -501,6 +502,8 @@ func recoverTaskFreshReset(bb *db.Blackboard, gitWrapper *git.Git, taskID, reaso
 		task.LeaseExpires = nil
 		task.ReviewingBy = nil
 		task.ReviewLeaseExpires = nil
+		releaseDoerClaimRecord(state, task.ID)
+		releaseReviewerClaimRecord(state, task.ID)
 		task.RejectionReason = nil
 		if outcome.ClearBlocked {
 			task.BlockedReason = nil
@@ -560,6 +563,8 @@ func recoverTaskMarkFreshCreationFailure(state *models.State, task *models.Task,
 	task.LeaseExpires = nil
 	task.ReviewingBy = nil
 	task.ReviewLeaseExpires = nil
+	releaseDoerClaimRecord(state, task.ID)
+	releaseReviewerClaimRecord(state, task.ID)
 	task.RejectionReason = nil
 	task.RepairRequest = nil
 	task.Worktree = nil
@@ -672,6 +677,7 @@ func releaseRecoverTaskAgent(state *models.State, task *models.Task, agentID str
 	}
 	task.AssignedTo = nil
 	task.LeaseExpires = nil
+	releaseDoerClaimRecord(state, task.ID)
 }
 
 func releaseRecoverTaskReviewerAgent(state *models.State, task *models.Task, agentID string) {
@@ -682,6 +688,7 @@ func releaseRecoverTaskReviewerAgent(state *models.State, task *models.Task, age
 	}
 	task.ReviewingBy = nil
 	task.ReviewLeaseExpires = nil
+	releaseReviewerClaimRecord(state, task.ID)
 }
 
 func recoverTaskNeedsReviewCommitReset(task *models.Task, statuses recoverTaskStatusSet) bool {

--- a/internal/ops/release_claim.go
+++ b/internal/ops/release_claim.go
@@ -23,13 +23,19 @@ type ReleaseClaimResult struct {
 
 // claimRelease describes the field access pattern for one role's claim on a task.
 type claimRelease struct {
-	hasClaimFn      func(*models.Task) bool
-	agentFieldFn    func(*models.Task) *string
-	leaseFieldFn    func(*models.Task) *time.Time
-	activeStatus    models.TaskStatus
-	releasedStatus  models.TaskStatus
-	eventName       string
-	clearFn         func(*models.Task)
+	hasClaimFn     func(*models.Task) bool
+	agentFieldFn   func(*models.Task) *string
+	leaseFieldFn   func(*models.Task) *time.Time
+	activeStatus   models.TaskStatus
+	releasedStatus models.TaskStatus
+	eventName      string
+	// claimKind selects which first-class claim record (state.Claims) is
+	// released alongside the legacy fields (strangler dual-write).
+	claimKind string
+	// clearFn clears the role's claim fields. transitioned reports whether
+	// this release moved the task from activeStatus back to releasedStatus —
+	// attempt-scoped state may only be wiped in that case.
+	clearFn         func(task *models.Task, transitioned bool)
 	missingLeaseMsg string
 	activeLeaseMsg  string
 }
@@ -41,7 +47,8 @@ var reviewerRelease = claimRelease{
 	activeStatus:    models.TaskStatusReviewing,
 	releasedStatus:  models.TaskStatusReadyForReview,
 	eventName:       "review_claim_released",
-	clearFn:         func(t *models.Task) { t.ReviewingBy = nil; t.ReviewLeaseExpires = nil },
+	claimKind:       models.ClaimKindReviewer,
+	clearFn:         func(t *models.Task, _ bool) { t.ReviewingBy = nil; t.ReviewLeaseExpires = nil },
 	missingLeaseMsg: "review lease expires missing for task %s, use --force to clear",
 	activeLeaseMsg:  "review lease still valid until %s, use --force to clear",
 }
@@ -53,9 +60,18 @@ var doerRelease = claimRelease{
 	activeStatus:   models.TaskStatusImplementing,
 	releasedStatus: models.TaskStatusReady,
 	eventName:      "doer_claim_released",
-	clearFn: func(t *models.Task) {
+	claimKind:      models.ClaimKindDoer,
+	clearFn: func(t *models.Task, transitioned bool) {
 		t.AssignedTo = nil
 		t.LeaseExpires = nil
+		if !transitioned {
+			// The task stays in a submitted/reviewing-family status: the
+			// submission (worktree, base_commit, review_commit, output) is
+			// still the artifact under review and must survive the release.
+			// Wiping it here used to strand tasks as submitted-with-nothing-
+			// to-review zombies.
+			return
+		}
 		t.Worktree = nil
 		t.BaseCommit = nil
 		t.Iteration = 0
@@ -177,10 +193,12 @@ func releaseOneClaim(state *models.State, task *models.Task, cfg claimRelease, p
 		}
 	}
 
+	transitioned := false
 	if task.Status == cfg.activeStatus && pipelineTransitions != nil {
 		if err := task.TransitionWith(cfg.releasedStatus, pipelineTransitions); err != nil {
 			return false, err
 		}
+		transitioned = true
 	}
 
 	if agent != nil {
@@ -191,7 +209,10 @@ func releaseOneClaim(state *models.State, task *models.Task, cfg claimRelease, p
 		}
 	}
 
-	cfg.clearFn(task)
+	cfg.clearFn(task, transitioned)
+	if cfg.claimKind != "" {
+		state.ReleaseClaimRecord(task.ID, cfg.claimKind)
+	}
 
 	task.History = append(task.History, models.TaskHistoryEntry{
 		Time:   now,
@@ -237,7 +258,7 @@ func ReleaseClaim(projectRoot, taskID, role string, force bool, reason, agentID 
 	}
 	pipelineTransitions := BuildPipelineTransitions(resolver)
 
-	err := bb.Modify(func(state *models.State) error {
+	err := bb.ModifyOp("release_claim", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/repair_doer_ownership.go
+++ b/internal/ops/repair_doer_ownership.go
@@ -31,7 +31,7 @@ func RepairInvalidDoerOwnership(statePath, projectRoot, logPath, reason string) 
 	var refusals []string
 	now := time.Now().UTC()
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("repair_doer_ownership", func(state *models.State) error {
 		for i := range state.Tasks {
 			task := &state.Tasks[i]
 
@@ -72,7 +72,7 @@ func RepairInvalidDoerOwnership(statePath, projectRoot, logPath, reason string) 
 			if err := task.TransitionWith(revertStatus, pb.transitions); err != nil {
 				return err
 			}
-			clearDoerClaimFields(task)
+			clearDoerClaimFields(state, task)
 
 			if doerID != "" {
 				if agent, ok := state.Agents[doerID]; ok {
@@ -164,9 +164,10 @@ func invalidActiveDoerOwnershipReason(state *models.State, task *models.Task, pr
 	return models.ActiveDoerOwnershipReason(state, task, doerID, pr)
 }
 
-func clearDoerClaimFields(task *models.Task) {
+func clearDoerClaimFields(state *models.State, task *models.Task) {
 	task.AssignedTo = nil
 	task.LeaseExpires = nil
+	releaseDoerClaimRecord(state, task.ID)
 	task.Worktree = nil
 	task.BaseCommit = nil
 	task.Iteration = 0

--- a/internal/ops/repair_review_ownership.go
+++ b/internal/ops/repair_review_ownership.go
@@ -28,7 +28,7 @@ func RepairInvalidReviewOwnership(statePath, projectRoot, logPath, reason string
 	repaired := 0
 	now := time.Now().UTC()
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("repair_review_ownership", func(state *models.State) error {
 		for i := range state.Tasks {
 			task := &state.Tasks[i]
 
@@ -55,6 +55,7 @@ func RepairInvalidReviewOwnership(statePath, projectRoot, logPath, reason string
 			}
 			task.ReviewingBy = nil
 			task.ReviewLeaseExpires = nil
+			releaseReviewerClaimRecord(state, task.ID)
 
 			if reviewerID != "" {
 				if agent, ok := state.Agents[reviewerID]; ok {

--- a/internal/ops/replan.go
+++ b/internal/ops/replan.go
@@ -54,7 +54,7 @@ func Replan(projectRoot string, input *ReplanInput) (*ReplanResult, error) {
 
 	var result ReplanResult
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("replan", func(state *models.State) error {
 		// Resolve target task
 		task, resolveErr := resolveReplanTarget(state, input.TaskID, planningPairs)
 		if resolveErr != nil {

--- a/internal/ops/resume_handoff.go
+++ b/internal/ops/resume_handoff.go
@@ -70,7 +70,7 @@ func resumeHandoffWithState(bb *db.Blackboard, state *models.State, agentID stri
 		id := task.ID
 		wt := *task.Worktree
 
-		err := bb.Modify(func(s *models.State) error {
+		err := bb.ModifyOp("resume_handoff", func(s *models.State) error {
 			t := s.FindTask(id)
 			if t == nil {
 				return &lizaerrors.NotFoundError{Entity: "task", ID: id}

--- a/internal/ops/resume_owned_task.go
+++ b/internal/ops/resume_owned_task.go
@@ -114,7 +114,7 @@ func resumeOwnedCandidate(bb *db.Blackboard, taskID, agentID string, pr models.P
 	now := time.Now().UTC()
 	var worktree string
 
-	err := bb.Modify(func(state *models.State) error {
+	err := bb.ModifyOp("resume_owned_task", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &lizaerrors.NotFoundError{Entity: "task", ID: taskID}
@@ -167,7 +167,7 @@ func blockOwnedResumeCandidate(
 	blocked := false
 	questions := []string{"Repair or recreate the task worktree, then unblock the task."}
 
-	err := bb.Modify(func(state *models.State) error {
+	err := bb.ModifyOp("block_owned_resume_candidate", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &lizaerrors.NotFoundError{Entity: "task", ID: taskID}
@@ -183,6 +183,7 @@ func blockOwnedResumeCandidate(
 		task.BlockedQuestions = questions
 		task.AssignedTo = nil
 		task.LeaseExpires = nil
+		releaseDoerClaimRecord(state, taskID)
 		releaseAgentsForTask(state, taskID)
 		task.History = append(task.History, models.TaskHistoryEntry{
 			Time:   now,

--- a/internal/ops/retarget_dependency.go
+++ b/internal/ops/retarget_dependency.go
@@ -67,7 +67,7 @@ func RetargetDependency(projectRoot, taskID, oldDependency string, newDependenci
 	var result RetargetDependencyResult
 	now := time.Now().UTC()
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("retarget_dependency", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/review_boundary.go
+++ b/internal/ops/review_boundary.go
@@ -145,6 +145,8 @@ func markReviewBoundaryIntegrationFailed(state *models.State, task *models.Task,
 	task.LeaseExpires = nil
 	task.ReviewingBy = nil
 	task.ReviewLeaseExpires = nil
+	releaseDoerClaimRecord(state, task.ID)
+	releaseReviewerClaimRecord(state, task.ID)
 
 	diagnostic := map[string]any{
 		"operation":     reviewBoundaryOperationAssignment,

--- a/internal/ops/set_auto_resume.go
+++ b/internal/ops/set_auto_resume.go
@@ -10,7 +10,7 @@ import (
 func SetAutoResume(projectRoot string, enabled bool) error {
 	lp := paths.New(projectRoot)
 	bb := db.For(lp.StatePath())
-	return bb.Modify(func(s *models.State) error {
+	return bb.ModifyOp("set_auto_resume", func(s *models.State) error {
 		s.Config.AutoResume = enabled
 		return nil
 	})

--- a/internal/ops/set_discovery_disposition.go
+++ b/internal/ops/set_discovery_disposition.go
@@ -34,7 +34,7 @@ func SetDiscoveryDisposition(projectRoot, discoveryID, disposition string) error
 
 	isTaskRef := !validDispositionSentinels[disposition]
 
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("set_discovery_disposition", func(state *models.State) error {
 		// Verify referenced task exists when disposition is a task ID.
 		if isTaskRef && state.FindTask(disposition) == nil {
 			return &PreconditionError{Reason: fmt.Sprintf("disposition references task %q which does not exist", disposition)}

--- a/internal/ops/set_task_output.go
+++ b/internal/ops/set_task_output.go
@@ -80,7 +80,7 @@ func SetTaskOutput(projectRoot string, input *SetTaskOutputInput) error {
 		}
 	}
 
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("set_task_output", func(state *models.State) error {
 		task := state.FindTask(input.TaskID)
 		if task == nil {
 			return fmt.Errorf("task %s not found", input.TaskID)

--- a/internal/ops/sprint_checkpoint.go
+++ b/internal/ops/sprint_checkpoint.go
@@ -72,7 +72,7 @@ func SprintCheckpoint(projectRoot string, trigger string) (*SprintCheckpointResu
 		return nil, fmt.Errorf("failed to write sprint summary: %w", err)
 	}
 
-	err = blackboard.Modify(func(s *models.State) error {
+	err = blackboard.ModifyOp("sprint_checkpoint", func(s *models.State) error {
 		s.Sprint.Status = models.SprintStatusCheckpoint
 		s.Sprint.Timeline.CheckpointAt = &timestamp
 		s.Sprint.CheckpointTrigger = trigger

--- a/internal/ops/submit_review.go
+++ b/internal/ops/submit_review.go
@@ -277,7 +277,7 @@ func SubmitForReview(projectRoot, taskID, commitRef, agentID string) (*SubmitFor
 	// Phase 3: Atomic update with new commit SHA
 	now := time.Now().UTC()
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("submit_for_review", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -435,7 +435,7 @@ func truncateForDiagnostics(s string, limit int) string {
 // They differ in pre-conditions (approved vs implementing) and post-actions (agent release).
 func markSubmitRebaseConflict(bb *db.Blackboard, taskID, agentID string, pipelineTransitions map[models.TaskStatus][]models.TaskStatus) error {
 	reason := IntegrationReasonMergeConflict
-	return bb.Modify(func(s *models.State) error {
+	return bb.ModifyOp("submit_rebase_conflict", func(s *models.State) error {
 		t := s.FindTask(taskID)
 		if t == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -447,6 +447,7 @@ func markSubmitRebaseConflict(bb *db.Blackboard, taskID, agentID string, pipelin
 		t.IntegrationFix = false
 		t.AssignedTo = nil
 		t.LeaseExpires = nil
+		releaseDoerClaimRecord(s, t.ID)
 
 		now := time.Now().UTC()
 		diagnostic := map[string]any{

--- a/internal/ops/submit_verdict.go
+++ b/internal/ops/submit_verdict.go
@@ -213,7 +213,7 @@ func SubmitVerdict(projectRoot, taskID, verdict, reason, agentID, impact string)
 		testSubmitVerdictHooks.beforeModify()
 	}
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("submit_verdict", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -345,6 +345,7 @@ func SubmitVerdict(projectRoot, taskID, verdict, reason, agentID, impact string)
 						}
 					}
 					task.AssignedTo = nil
+					releaseDoerClaimRecord(state, taskID)
 
 					task.History = append(task.History, models.TaskHistoryEntry{
 						Time:   now,
@@ -362,6 +363,7 @@ func SubmitVerdict(projectRoot, taskID, verdict, reason, agentID, impact string)
 
 		task.ReviewingBy = nil
 		task.ReviewLeaseExpires = nil
+		releaseReviewerClaimRecord(state, taskID)
 		state.ReleaseAgent(agentID)
 
 		return nil
@@ -423,7 +425,7 @@ func recordSubmitVerdictFailureAnomaly(bb *db.Blackboard, taskID, agentID, verdi
 		return nil
 	}
 
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("submit_verdict_failure_anomaly", func(state *models.State) error {
 		state.Anomalies = append(state.Anomalies, models.Anomaly{
 			Timestamp: time.Now().UTC(),
 			Task:      taskID,
@@ -483,7 +485,7 @@ func isReviewingStatus(status, expectedReviewingStatus, expectedReviewing2Status
 
 func recordStaleVerdictAnomaly(bb *db.Blackboard, taskID, agentID, verdict, reason, impact string, expectedReviewingStatus, expectedReviewing2Status models.TaskStatus) error {
 	now := time.Now().UTC()
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("stale_verdict_anomaly", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/supersede_task.go
+++ b/internal/ops/supersede_task.go
@@ -114,7 +114,7 @@ func SupersedeTaskWithOptions(projectRoot, taskID string, replacementIDs []strin
 
 	// Phase 2: Atomic State Update
 	hadWorktree := task.Worktree != nil
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("supersede_task", func(state *models.State) error {
 		currentTask := state.FindTask(taskID)
 		if currentTask == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -139,6 +139,8 @@ func SupersedeTaskWithOptions(projectRoot, taskID string, replacementIDs []strin
 		currentTask.LeaseExpires = nil
 		currentTask.ReviewingBy = nil
 		currentTask.ReviewLeaseExpires = nil
+		releaseDoerClaimRecord(state, taskID)
+		releaseReviewerClaimRecord(state, taskID)
 		currentTask.Worktree = nil
 		clearAttemptState(currentTask, attemptStateRetire)
 

--- a/internal/ops/transition_attempt.go
+++ b/internal/ops/transition_attempt.go
@@ -61,7 +61,7 @@ func TransitionToNewAttempt(projectRoot, taskID, reason string) (*TransitionAtte
 	)
 
 	// Phase 1: mark attempt boundary, block claims via sentinel.
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("transition_attempt", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -104,6 +104,8 @@ func TransitionToNewAttempt(projectRoot, taskID, reason string) (*TransitionAtte
 
 		sentinel := transitioning
 		task.AssignedTo = &sentinel
+		// The sentinel is not an agent — the previous doer's claim ends here.
+		releaseDoerClaimRecord(state, task.ID)
 
 		now := time.Now().UTC()
 		task.History = append(task.History, models.TaskHistoryEntry{
@@ -146,7 +148,7 @@ func TransitionToNewAttempt(projectRoot, taskID, reason string) (*TransitionAtte
 	pb.transitions[originalStatus] = append(pb.transitions[originalStatus], initialStatus)
 
 	// Phase 3: release sentinel, make task claimable.
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("transition_attempt", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -172,6 +174,8 @@ func TransitionToNewAttempt(projectRoot, taskID, reason string) (*TransitionAtte
 		task.BaseCommit = nil
 		task.ReviewingBy = nil
 		task.ReviewLeaseExpires = nil
+		releaseDoerClaimRecord(state, task.ID)
+		releaseReviewerClaimRecord(state, task.ID)
 		clearAttemptState(task, attemptStateInitialReset)
 
 		return task.TransitionWith(initialStatus, pb.transitions)

--- a/internal/ops/unblock_task.go
+++ b/internal/ops/unblock_task.go
@@ -135,7 +135,7 @@ func UnblockTaskWithOptions(projectRoot, taskID, reason, agentID string, opts Un
 	}
 
 	var result UnblockTaskResult
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("unblock_task", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -217,6 +217,7 @@ func UnblockTaskWithOptions(projectRoot, taskID, reason, agentID string, opts Un
 			historyExtra["assigned_to"] = opts.AssignTo
 			task.AssignedTo = &opts.AssignTo
 			task.LeaseExpires = &leaseExpires
+			recordDoerClaim(state, taskID, opts.AssignTo, leaseExpires)
 			agent.Status = models.AgentStatusWorking
 			agent.CurrentTask = &taskID
 			agent.LeaseExpires = &leaseExpires
@@ -241,6 +242,7 @@ func UnblockTaskWithOptions(projectRoot, taskID, reason, agentID string, opts Un
 			task.Status = targetStatus
 			task.AssignedTo = nil
 			task.LeaseExpires = nil
+			releaseDoerClaimRecord(state, taskID)
 		}
 		task.BlockedReason = nil
 		task.BlockedQuestions = nil
@@ -444,7 +446,7 @@ func markUnblockRebaseConflict(bb *db.Blackboard, taskID, agentID string, snapsh
 		"stdout_stderr_excerpt": excerpt,
 		"recovery_hint":         "resolve the unblock-time rebase conflict in the task worktree, then retry unblock-task",
 	}
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("unblock_rebase_conflict", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/unblock_task_test.go
+++ b/internal/ops/unblock_task_test.go
@@ -25,6 +25,7 @@ func TestUnblockTask_RestoresExecutingStateAndAssignment(t *testing.T) {
 	task := testhelpers.BuildTaskByStatus("task-1", models.TaskStatusBlocked, now)
 	task.RolePair = "code-planning-pair"
 	task.Worktree = testhelpers.StringPtr(".worktrees/task-1")
+	task.BaseCommit = testhelpers.StringPtr("abc1234")
 	task.RepairRequest = &models.RepairRequest{
 		Operation:  "restore_git_write_access",
 		Target:     ".git/worktrees/task-1",
@@ -108,6 +109,7 @@ func TestUnblockTask_AllowsAssignToWithoutLiveProcess(t *testing.T) {
 	task := testhelpers.BuildTaskByStatus("task-1", models.TaskStatusBlocked, now)
 	task.RolePair = "code-planning-pair"
 	task.Worktree = testhelpers.StringPtr(".worktrees/task-1")
+	task.BaseCommit = testhelpers.StringPtr("abc1234")
 	state.Tasks = []models.Task{task}
 	testhelpers.WriteInitialState(t, stateFile, state)
 
@@ -509,6 +511,7 @@ func TestUnblockTask_RejectsUnmetDependencies(t *testing.T) {
 	task := testhelpers.BuildTaskByStatus("task-1", models.TaskStatusBlocked, now)
 	task.RolePair = "code-planning-pair"
 	task.Worktree = testhelpers.StringPtr(".worktrees/task-1")
+	task.BaseCommit = testhelpers.StringPtr("abc1234")
 	task.DependsOn = []string{"dep-1"}
 	dep := testhelpers.BuildTaskByStatus("dep-1", models.TaskStatusImplementing, now)
 	state.Tasks = []models.Task{task, dep}
@@ -538,6 +541,7 @@ func TestUnblockTask_AllowsMergedDependency(t *testing.T) {
 	task := testhelpers.BuildTaskByStatus("task-1", models.TaskStatusBlocked, now)
 	task.RolePair = "code-planning-pair"
 	task.Worktree = testhelpers.StringPtr(".worktrees/task-1")
+	task.BaseCommit = testhelpers.StringPtr("abc1234")
 	task.DependsOn = []string{"dep-1"}
 	dep := testhelpers.BuildTaskByStatus("dep-1", models.TaskStatusMerged, now)
 	state.Tasks = []models.Task{task, dep}
@@ -564,6 +568,7 @@ func TestUnblockTask_RejectsUnknownAssignTo(t *testing.T) {
 	task := testhelpers.BuildTaskByStatus("task-1", models.TaskStatusBlocked, now)
 	task.RolePair = "code-planning-pair"
 	task.Worktree = testhelpers.StringPtr(".worktrees/task-1")
+	task.BaseCommit = testhelpers.StringPtr("abc1234")
 	state.Tasks = []models.Task{task}
 	testhelpers.WriteInitialState(t, stateFile, state)
 
@@ -587,6 +592,7 @@ func TestUnblockTask_RejectsWrongDoerRole(t *testing.T) {
 	task := testhelpers.BuildTaskByStatus("task-1", models.TaskStatusBlocked, now)
 	task.RolePair = "code-planning-pair"
 	task.Worktree = testhelpers.StringPtr(".worktrees/task-1")
+	task.BaseCommit = testhelpers.StringPtr("abc1234")
 	state.Tasks = []models.Task{task}
 	testhelpers.WriteInitialState(t, stateFile, state)
 

--- a/internal/ops/update_review_commit.go
+++ b/internal/ops/update_review_commit.go
@@ -110,7 +110,7 @@ func UpdateReviewCommit(projectRoot, taskID, changedBy string) (*UpdateReviewCom
 	now := time.Now().UTC()
 	reviewerReleased := false
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("update_review_commit", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}
@@ -139,6 +139,7 @@ func UpdateReviewCommit(projectRoot, taskID, changedBy string) (*UpdateReviewCom
 			}
 			task.ReviewingBy = nil
 			task.ReviewLeaseExpires = nil
+			releaseReviewerClaimRecord(state, taskID)
 			reviewerReleased = true
 
 			if err := task.TransitionWith(submittedStatus, pipelineTransitions); err != nil {

--- a/internal/ops/update_sprint_metrics.go
+++ b/internal/ops/update_sprint_metrics.go
@@ -27,7 +27,7 @@ func UpdateSprintMetrics(projectRoot string) (models.SprintMetrics, error) {
 	}
 	metrics := state.ComputeSprintMetricsWithTerminalStates(terminalStates)
 
-	err = blackboard.Modify(func(s *models.State) error {
+	err = blackboard.ModifyOp("update_sprint_metrics", func(s *models.State) error {
 		s.Sprint.Metrics = metrics
 		return nil
 	})

--- a/internal/ops/write_checkpoint.go
+++ b/internal/ops/write_checkpoint.go
@@ -67,7 +67,7 @@ func WriteCheckpoint(projectRoot string, input *WriteCheckpointInput) error {
 
 	now := time.Now().UTC()
 
-	return bb.Modify(func(state *models.State) error {
+	return bb.ModifyOp("write_checkpoint", func(state *models.State) error {
 		task := state.FindTask(input.TaskID)
 		if task == nil {
 			return fmt.Errorf("task %s not found", input.TaskID)

--- a/internal/ops/wt_create.go
+++ b/internal/ops/wt_create.go
@@ -105,7 +105,7 @@ func CreateWorktree(projectRoot, taskID string, fresh bool) (*CreateWorktreeResu
 		return nil, fmt.Errorf("failed to create worktree: %w", err)
 	}
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("wt_create", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/wt_delete.go
+++ b/internal/ops/wt_delete.go
@@ -70,7 +70,7 @@ func DeleteWorktree(projectRoot, taskID string) (*DeleteWorktreeResult, error) {
 		}
 	}
 
-	err = bb.Modify(func(state *models.State) error {
+	err = bb.ModifyOp("wt_delete", func(state *models.State) error {
 		task := state.FindTask(taskID)
 		if task == nil {
 			return &errors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/ops/wt_merge.go
+++ b/internal/ops/wt_merge.go
@@ -140,7 +140,7 @@ func markIntegrationFailedWithDiagnostic(
 	if pb != nil {
 		pr = pb.pr
 	}
-	return bb.Modify(func(s *models.State) error {
+	return bb.ModifyOp("integration_failed", func(s *models.State) error {
 		t := s.FindTask(taskID)
 		if t == nil {
 			return &lizaerrors.NotFoundError{Entity: "task", ID: taskID}
@@ -704,7 +704,7 @@ func MergeWorktree(projectRoot, taskID, agentID string, mergeExtra ...map[string
 	// worktree still exists for investigation; reverse order would lose the worktree
 	// while state still says APPROVED)
 	var autoConfiguredPostWorktreeCmd bool
-	err = bb.Modify(func(s *models.State) error {
+	err = bb.ModifyOp("wt_merge", func(s *models.State) error {
 		t := s.FindTask(taskID)
 		if t == nil {
 			return &lizaerrors.NotFoundError{Entity: "task", ID: taskID}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,180 @@
+// Package scheduler computes, from a single immutable state snapshot, the set
+// of runnable work in the system: which tasks need a doer, which need a
+// reviewer, which approved tasks need merging, and which claims have expired
+// and should be reclaimed.
+//
+// Today this readiness logic is scattered across per-role supervisor wait
+// loops (internal/agent/strategy_*.go) and model helpers. Consolidating it
+// into one pure, deterministic function is the first step toward a single
+// central scheduler: the same Plan that powers the read-only `liza schedule`
+// diagnostic is what a future scheduler loop will dispatch from.
+//
+// Scope note: orchestrator wake detection (internal/agent/workdetection.go)
+// is intentionally NOT folded in here yet — it is referenced across the
+// agent, commands, and prompts packages, so relocating it is a separate
+// step. Plan therefore covers doer/review/merge/reclaim work; orchestrator
+// readiness remains computed by the orchestrator strategy.
+package scheduler
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/ops"
+	"github.com/liza-mas/liza/internal/pipeline"
+)
+
+// WorkKind classifies a unit of runnable work.
+type WorkKind string
+
+const (
+	// WorkDoer: a task is claimable by a doer role and needs implementation.
+	WorkDoer WorkKind = "doer"
+	// WorkReview: a submitted task is claimable by a reviewer role.
+	WorkReview WorkKind = "review"
+	// WorkMerge: an approved task is awaiting merge to the integration branch.
+	WorkMerge WorkKind = "merge"
+	// WorkReclaim: a lease has expired past the grace period; the claim
+	// should be released so the task becomes claimable again.
+	WorkReclaim WorkKind = "reclaim"
+)
+
+// WorkItem is one runnable unit of work.
+type WorkItem struct {
+	Kind WorkKind `json:"kind"`
+	// TaskID is the task the work concerns.
+	TaskID string `json:"task_id"`
+	// Role is the agent role that should handle WorkDoer/WorkReview items;
+	// empty for WorkMerge and WorkReclaim.
+	Role string `json:"role,omitempty"`
+	// AgentID is the holder of an expired claim (WorkReclaim only).
+	AgentID string `json:"agent_id,omitempty"`
+	// Detail is a short human-readable explanation for diagnostics.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Plan is the complete set of runnable work derived from a state snapshot.
+// It is deterministic: identical input states yield identical Plans (items
+// are sorted by kind then task ID).
+type Plan struct {
+	Items []WorkItem
+}
+
+// Counts returns the number of items of each kind.
+func (p Plan) Counts() map[WorkKind]int {
+	counts := map[WorkKind]int{}
+	for _, item := range p.Items {
+		counts[item.Kind]++
+	}
+	return counts
+}
+
+// ByKind returns the items of a single kind, preserving Plan order.
+func (p Plan) ByKind(kind WorkKind) []WorkItem {
+	var out []WorkItem
+	for _, item := range p.Items {
+		if item.Kind == kind {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// Compute derives the runnable-work Plan from a state snapshot.
+//
+// Per task (in priority order, at most one item per task):
+//   - status == the role-pair's approved status        → WorkMerge
+//   - claimable by the role-pair's reviewer role        → WorkReview
+//   - claimable by the role-pair's doer role            → WorkDoer
+//
+// Then, independently, every claim whose lease expired beyond the grace
+// period yields a WorkReclaim item (a task may simultaneously have an expired
+// claim and, once reclaimed, become doer/review-claimable — both surface).
+//
+// Claimability already excludes tasks with a live (unexpired) claim, so a
+// task actively being worked never appears as doer/review work.
+func Compute(state *models.State, resolver *pipeline.Resolver, now time.Time) Plan {
+	var items []WorkItem
+	if state == nil || resolver == nil {
+		return Plan{}
+	}
+
+	for i := range state.Tasks {
+		task := &state.Tasks[i]
+		if task.RolePair == "" {
+			continue
+		}
+		if item, ok := classifyTask(task, state.Tasks, resolver); ok {
+			items = append(items, item)
+		}
+	}
+
+	for _, claim := range ops.SweepExpiredClaims(state, now) {
+		items = append(items, WorkItem{
+			Kind:    WorkReclaim,
+			TaskID:  claim.TaskID,
+			AgentID: claim.AgentID,
+			Detail:  fmt.Sprintf("%s claim by %s expired", claim.Kind, claim.AgentID),
+		})
+	}
+
+	sortItems(items)
+	return Plan{Items: items}
+}
+
+// classifyTask returns the single highest-priority work item a task needs, if
+// any. Merge takes priority over review over doer work because an approved
+// task is further along the lifecycle than a submitted or ready one.
+func classifyTask(task *models.Task, allTasks []models.Task, resolver *pipeline.Resolver) (WorkItem, bool) {
+	if approved, err := resolver.ApprovedStatus(task.RolePair); err == nil && task.Status == approved {
+		return WorkItem{
+			Kind:   WorkMerge,
+			TaskID: task.ID,
+			Detail: fmt.Sprintf("approved (%s), awaiting merge", task.Status),
+		}, true
+	}
+
+	if reviewerRole, err := resolver.ReviewerRole(task.RolePair); err == nil {
+		if task.IsClaimable(reviewerRole, allTasks, resolver) {
+			return WorkItem{
+				Kind:   WorkReview,
+				TaskID: task.ID,
+				Role:   reviewerRole,
+				Detail: fmt.Sprintf("%s, claimable for review", task.Status),
+			}, true
+		}
+	}
+
+	if doerRole, err := resolver.DoerRole(task.RolePair); err == nil {
+		if task.IsClaimable(doerRole, allTasks, resolver) {
+			return WorkItem{
+				Kind:   WorkDoer,
+				TaskID: task.ID,
+				Role:   doerRole,
+				Detail: fmt.Sprintf("%s, claimable by doer", task.Status),
+			}, true
+		}
+	}
+
+	return WorkItem{}, false
+}
+
+// kindOrder gives a stable sort priority to work kinds (merge first, matching
+// lifecycle progress).
+var kindOrder = map[WorkKind]int{
+	WorkMerge:   0,
+	WorkReview:  1,
+	WorkDoer:    2,
+	WorkReclaim: 3,
+}
+
+func sortItems(items []WorkItem) {
+	sort.SliceStable(items, func(a, b int) bool {
+		if kindOrder[items[a].Kind] != kindOrder[items[b].Kind] {
+			return kindOrder[items[a].Kind] < kindOrder[items[b].Kind]
+		}
+		return items[a].TaskID < items[b].TaskID
+	})
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,199 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/pipeline"
+)
+
+// embeddedResolver loads the production pipeline config so tests exercise the
+// real role-pair/status wiring rather than a hand-rolled fixture.
+func embeddedResolver(t *testing.T) *pipeline.Resolver {
+	t.Helper()
+	cfg, err := pipeline.LoadEmbeddedReference()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedReference: %v", err)
+	}
+	return pipeline.NewResolver(cfg)
+}
+
+// status helpers resolve canonical coding-pair statuses from the config so the
+// test stays correct if the embedded status names change.
+func codingStatus(t *testing.T, r *pipeline.Resolver, which string) models.TaskStatus {
+	t.Helper()
+	var (
+		s   models.TaskStatus
+		err error
+	)
+	switch which {
+	case "initial":
+		s, err = r.InitialStatus("coding-pair")
+	case "submitted":
+		s, err = r.SubmittedStatus("coding-pair")
+	case "approved":
+		s, err = r.ApprovedStatus("coding-pair")
+	default:
+		t.Fatalf("unknown status key %q", which)
+	}
+	if err != nil {
+		t.Fatalf("resolve %s status: %v", which, err)
+	}
+	return s
+}
+
+func TestCompute_ClassifiesDoerReviewMerge(t *testing.T) {
+	r := embeddedResolver(t)
+	now := time.Now().UTC()
+
+	reviewCommit := "rev123"
+	state := &models.State{
+		Tasks: []models.Task{
+			{ID: "t-doer", RolePair: "coding-pair", Status: codingStatus(t, r, "initial")},
+			{ID: "t-review", RolePair: "coding-pair", Status: codingStatus(t, r, "submitted"), ReviewCommit: &reviewCommit},
+			{ID: "t-merge", RolePair: "coding-pair", Status: codingStatus(t, r, "approved"), ReviewCommit: &reviewCommit},
+		},
+		Agents: map[string]models.Agent{},
+	}
+
+	plan := Compute(state, r, now)
+	counts := plan.Counts()
+	if counts[WorkDoer] != 1 || counts[WorkReview] != 1 || counts[WorkMerge] != 1 {
+		t.Fatalf("unexpected counts: %+v (items=%+v)", counts, plan.Items)
+	}
+
+	byTask := map[string]WorkItem{}
+	for _, it := range plan.Items {
+		byTask[it.TaskID] = it
+	}
+	if byTask["t-doer"].Kind != WorkDoer {
+		t.Errorf("t-doer = %s, want doer", byTask["t-doer"].Kind)
+	}
+	if byTask["t-review"].Kind != WorkReview {
+		t.Errorf("t-review = %s, want review", byTask["t-review"].Kind)
+	}
+	if byTask["t-merge"].Kind != WorkMerge {
+		t.Errorf("t-merge = %s, want merge", byTask["t-merge"].Kind)
+	}
+
+	// Roles are populated for doer/review, empty for merge.
+	if byTask["t-doer"].Role == "" || byTask["t-review"].Role == "" {
+		t.Errorf("expected roles on doer/review items: %+v", plan.Items)
+	}
+	if byTask["t-merge"].Role != "" {
+		t.Errorf("merge item should carry no role, got %q", byTask["t-merge"].Role)
+	}
+
+	// Deterministic ordering: merge before review before doer.
+	if plan.Items[0].Kind != WorkMerge || plan.Items[len(plan.Items)-1].Kind != WorkDoer {
+		t.Errorf("items not ordered merge→review→doer: %+v", plan.Items)
+	}
+}
+
+func TestCompute_ActivelyClaimedTaskIsNotRunnable(t *testing.T) {
+	r := embeddedResolver(t)
+	now := time.Now().UTC()
+
+	// A task being implemented (assigned, live lease) must not surface as work.
+	agent := "coder-1"
+	worktree := ".worktrees/t1"
+	base := "abc"
+	future := now.Add(30 * time.Minute)
+	executing, err := r.ExecutingStatus("coding-pair")
+	if err != nil {
+		t.Fatalf("executing status: %v", err)
+	}
+	state := &models.State{
+		Tasks: []models.Task{{
+			ID: "t1", RolePair: "coding-pair", Status: executing,
+			AssignedTo: &agent, Worktree: &worktree, BaseCommit: &base, LeaseExpires: &future,
+		}},
+		Agents: map[string]models.Agent{},
+	}
+
+	plan := Compute(state, r, now)
+	if len(plan.Items) != 0 {
+		t.Fatalf("actively-claimed task produced work items: %+v", plan.Items)
+	}
+}
+
+func TestCompute_ExpiredClaimSurfacesReclaim(t *testing.T) {
+	r := embeddedResolver(t)
+	now := time.Now().UTC()
+	expired := now.Add(-models.LeaseExpiryGracePeriod - time.Minute)
+
+	state := &models.State{
+		Tasks: []models.Task{{ID: "t1", RolePair: "coding-pair", Status: codingStatus(t, r, "initial")}},
+		Claims: []models.Claim{
+			{TaskID: "t1", AgentID: "coder-9", Kind: models.ClaimKindDoer, ExpiresAt: &expired},
+		},
+		Agents: map[string]models.Agent{},
+	}
+
+	reclaims := Compute(state, r, now).ByKind(WorkReclaim)
+	if len(reclaims) != 1 || reclaims[0].AgentID != "coder-9" || reclaims[0].TaskID != "t1" {
+		t.Fatalf("expected one reclaim for coder-9 on t1, got %+v", reclaims)
+	}
+}
+
+func TestCompute_FreshClaimDoesNotReclaim(t *testing.T) {
+	r := embeddedResolver(t)
+	now := time.Now().UTC()
+	future := now.Add(30 * time.Minute)
+
+	state := &models.State{
+		Tasks:  []models.Task{{ID: "t1", RolePair: "coding-pair", Status: codingStatus(t, r, "initial")}},
+		Claims: []models.Claim{{TaskID: "t1", AgentID: "coder-9", Kind: models.ClaimKindDoer, ExpiresAt: &future}},
+		Agents: map[string]models.Agent{},
+	}
+	if got := Compute(state, r, now).ByKind(WorkReclaim); len(got) != 0 {
+		t.Fatalf("fresh claim produced reclaim: %+v", got)
+	}
+}
+
+func TestCompute_NilInputsAndNoRolePair(t *testing.T) {
+	r := embeddedResolver(t)
+	now := time.Now().UTC()
+
+	if got := Compute(nil, r, now); len(got.Items) != 0 {
+		t.Errorf("nil state should yield empty plan, got %+v", got)
+	}
+	if got := Compute(&models.State{}, nil, now); len(got.Items) != 0 {
+		t.Errorf("nil resolver should yield empty plan, got %+v", got)
+	}
+	// Legacy task without role_pair is skipped (not classifiable).
+	state := &models.State{Tasks: []models.Task{{ID: "legacy", Status: "READY"}}, Agents: map[string]models.Agent{}}
+	if got := Compute(state, r, now); len(got.Items) != 0 {
+		t.Errorf("role-pair-less task should be skipped, got %+v", got)
+	}
+}
+
+func TestCompute_Deterministic(t *testing.T) {
+	r := embeddedResolver(t)
+	now := time.Now().UTC()
+	reviewCommit := "rev"
+	state := &models.State{
+		Tasks: []models.Task{
+			{ID: "b", RolePair: "coding-pair", Status: codingStatus(t, r, "initial")},
+			{ID: "a", RolePair: "coding-pair", Status: codingStatus(t, r, "initial")},
+			{ID: "m", RolePair: "coding-pair", Status: codingStatus(t, r, "approved"), ReviewCommit: &reviewCommit},
+		},
+		Agents: map[string]models.Agent{},
+	}
+	first := Compute(state, r, now)
+	second := Compute(state, r, now)
+	if len(first.Items) != len(second.Items) {
+		t.Fatalf("non-deterministic length")
+	}
+	for i := range first.Items {
+		if first.Items[i] != second.Items[i] {
+			t.Fatalf("non-deterministic at %d: %+v vs %+v", i, first.Items[i], second.Items[i])
+		}
+	}
+	// Within doer kind, task IDs sorted ascending: a before b.
+	doers := first.ByKind(WorkDoer)
+	if len(doers) != 2 || doers[0].TaskID != "a" || doers[1].TaskID != "b" {
+		t.Fatalf("doer items not sorted by task id: %+v", doers)
+	}
+}

--- a/internal/statevalidate/validate.go
+++ b/internal/statevalidate/validate.go
@@ -212,6 +212,9 @@ func ValidateState(state *models.State, projectRoot string, skipSpecFileCheck bo
 		validateAnomalies,
 		validateHandoffEvents,
 		validateSprint,
+		func(state *models.State, projectRoot string, skipSpecFileCheck bool) error {
+			return validateClaims(state, warnWriter)
+		},
 	}
 
 	for _, validator := range validators {

--- a/internal/statevalidate/validate_claims.go
+++ b/internal/statevalidate/validate_claims.go
@@ -1,0 +1,48 @@
+package statevalidate
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+// validateClaims checks first-class claim records (strangler phase 1).
+//
+// Errors: a claim must reference an existing task.
+//
+// Warnings (warnWriter): a claim that contradicts the legacy ownership fields
+// it dual-writes (AssignedTo for doer claims, ReviewingBy for reviewer
+// claims). Claims are new and old state files have none, so the absence of a
+// claim for an owned task is expected and never warns — only contradiction
+// does.
+func validateClaims(state *models.State, warnWriter io.Writer) error {
+	for _, c := range state.Claims {
+		task := state.FindTask(c.TaskID)
+		if task == nil {
+			return fmt.Errorf("claim (kind: %s, agent: %s) references non-existent task %s", c.Kind, c.AgentID, c.TaskID)
+		}
+
+		switch c.Kind {
+		case models.ClaimKindDoer:
+			warnClaimLegacyMismatch(warnWriter, c, "assigned_to", task.AssignedTo)
+		case models.ClaimKindReviewer:
+			warnClaimLegacyMismatch(warnWriter, c, "reviewing_by", task.ReviewingBy)
+		default:
+			fmt.Fprintf(warnWriter, "WARNING: claim for task %s has unknown kind %q\n", c.TaskID, c.Kind)
+		}
+	}
+	return nil
+}
+
+func warnClaimLegacyMismatch(warnWriter io.Writer, c models.Claim, legacyField string, legacyAgent *string) {
+	if legacyAgent == nil {
+		fmt.Fprintf(warnWriter, "WARNING: %s claim for task %s held by %s but legacy %s is unset\n",
+			c.Kind, c.TaskID, c.AgentID, legacyField)
+		return
+	}
+	if *legacyAgent != c.AgentID {
+		fmt.Fprintf(warnWriter, "WARNING: %s claim for task %s held by %s but legacy %s is %s\n",
+			c.Kind, c.TaskID, c.AgentID, legacyField, *legacyAgent)
+	}
+}

--- a/internal/statevalidate/validate_claims_test.go
+++ b/internal/statevalidate/validate_claims_test.go
@@ -1,0 +1,113 @@
+package statevalidate
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/liza-mas/liza/internal/models"
+)
+
+func claimsTestState() *models.State {
+	coder := "coder-1"
+	reviewer := "reviewer-1"
+	return &models.State{
+		Tasks: []models.Task{
+			{ID: "task-1", Status: "IMPLEMENTING_CODE", AssignedTo: &coder},
+			{ID: "task-2", Status: "REVIEWING_CODE", ReviewingBy: &reviewer},
+			{ID: "task-3", Status: "READY"},
+		},
+		Agents: map[string]models.Agent{},
+	}
+}
+
+func TestValidateClaims_AgreementProducesNoWarning(t *testing.T) {
+	state := claimsTestState()
+	state.Claims = []models.Claim{
+		{TaskID: "task-1", AgentID: "coder-1", Kind: models.ClaimKindDoer, GrantedAt: time.Now().UTC()},
+		{TaskID: "task-2", AgentID: "reviewer-1", Kind: models.ClaimKindReviewer, GrantedAt: time.Now().UTC()},
+	}
+
+	var warnings bytes.Buffer
+	if err := validateClaims(state, &warnings); err != nil {
+		t.Fatalf("validateClaims() error: %v", err)
+	}
+	if warnings.Len() != 0 {
+		t.Errorf("expected no warnings, got %q", warnings.String())
+	}
+}
+
+func TestValidateClaims_AbsentClaimForOwnedTaskIsSilent(t *testing.T) {
+	// Old state files have no claims; ownership without a claim must neither
+	// error nor warn.
+	state := claimsTestState()
+
+	var warnings bytes.Buffer
+	if err := validateClaims(state, &warnings); err != nil {
+		t.Fatalf("validateClaims() error: %v", err)
+	}
+	if warnings.Len() != 0 {
+		t.Errorf("expected no warnings, got %q", warnings.String())
+	}
+}
+
+func TestValidateClaims_ContradictionWarns(t *testing.T) {
+	tests := []struct {
+		name         string
+		claim        models.Claim
+		wantContains string
+	}{
+		{
+			name:         "doer claim disagrees with assigned_to",
+			claim:        models.Claim{TaskID: "task-1", AgentID: "coder-9", Kind: models.ClaimKindDoer},
+			wantContains: "doer claim for task task-1 held by coder-9 but legacy assigned_to is coder-1",
+		},
+		{
+			name:         "doer claim on unassigned task",
+			claim:        models.Claim{TaskID: "task-3", AgentID: "coder-1", Kind: models.ClaimKindDoer},
+			wantContains: "doer claim for task task-3 held by coder-1 but legacy assigned_to is unset",
+		},
+		{
+			name:         "reviewer claim disagrees with reviewing_by",
+			claim:        models.Claim{TaskID: "task-2", AgentID: "reviewer-9", Kind: models.ClaimKindReviewer},
+			wantContains: "reviewer claim for task task-2 held by reviewer-9 but legacy reviewing_by is reviewer-1",
+		},
+		{
+			name:         "reviewer claim on task without reviewer",
+			claim:        models.Claim{TaskID: "task-1", AgentID: "reviewer-1", Kind: models.ClaimKindReviewer},
+			wantContains: "reviewer claim for task task-1 held by reviewer-1 but legacy reviewing_by is unset",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := claimsTestState()
+			state.Claims = []models.Claim{tt.claim}
+
+			var warnings bytes.Buffer
+			if err := validateClaims(state, &warnings); err != nil {
+				t.Fatalf("validateClaims() error: %v (contradictions must warn, not error)", err)
+			}
+			if !strings.Contains(warnings.String(), tt.wantContains) {
+				t.Errorf("warnings = %q, want to contain %q", warnings.String(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestValidateClaims_MissingTaskIsError(t *testing.T) {
+	state := claimsTestState()
+	state.Claims = []models.Claim{
+		{TaskID: "ghost-task", AgentID: "coder-1", Kind: models.ClaimKindDoer},
+	}
+
+	var warnings bytes.Buffer
+	err := validateClaims(state, &warnings)
+	if err == nil {
+		t.Fatal("expected error for claim referencing non-existent task, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost-task") {
+		t.Errorf("error = %q, want to mention ghost-task", err.Error())
+	}
+}

--- a/internal/statevalidate/validate_task.go
+++ b/internal/statevalidate/validate_task.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/liza-mas/liza/internal/models"
 	"github.com/liza-mas/liza/internal/pipeline"
+	"github.com/liza-mas/liza/internal/taskinvariants"
 )
 
 // validateRequiredFields checks that the top-level state structure contains all
@@ -81,90 +82,15 @@ func validateTaskStates(state *models.State, projectRoot string, skipSpecFileChe
 // statusClassifier resolves whether a TaskStatus belongs to a given lifecycle
 // phase using pipeline-declared statuses. Built once and shared by
 // validateTaskInvariants and validateDependencies.
-type statusClassifier struct {
-	executing []models.TaskStatus
-	initial   []models.TaskStatus
-	submitted []models.TaskStatus
-	reviewing []models.TaskStatus
-	approved  []models.TaskStatus
-	partial   []models.TaskStatus
-	rejected  []models.TaskStatus
-}
+// statusClassifier is the structural classifier shared with the write funnel.
+// The rules themselves live in internal/taskinvariants — one source of truth
+// for both at-rest validation (here) and fail-closed write enforcement (db).
+type statusClassifier = taskinvariants.StatusClassifier
 
 // newStatusClassifier constructs a statusClassifier from a pipeline resolver
 // and configuration. Returns an empty classifier when resolver or config is nil.
 func newStatusClassifier(resolver *pipeline.Resolver, cfg *pipeline.PipelineConfig) statusClassifier {
-	sc := statusClassifier{}
-	if resolver == nil || cfg == nil {
-		return sc
-	}
-	for rpName := range cfg.Pipeline.RolePairs {
-		if s, err := resolver.ExecutingStatus(rpName); err == nil {
-			sc.executing = append(sc.executing, s)
-		}
-		if s, err := resolver.InitialStatus(rpName); err == nil {
-			sc.initial = append(sc.initial, s)
-		}
-		if s, err := resolver.SubmittedStatus(rpName); err == nil {
-			sc.submitted = append(sc.submitted, s)
-		}
-		if s, err := resolver.ReviewingStatus(rpName); err == nil {
-			sc.reviewing = append(sc.reviewing, s)
-		}
-		// reviewing-2 reuses the review lease mechanism — classify as reviewing.
-		if s, err := resolver.Reviewing2Status(rpName); err == nil {
-			sc.reviewing = append(sc.reviewing, s)
-		}
-		if s, err := resolver.ApprovedStatus(rpName); err == nil {
-			sc.approved = append(sc.approved, s)
-		}
-		if s, err := resolver.PartiallyApprovedStatus(rpName); err == nil {
-			sc.partial = append(sc.partial, s)
-		}
-		if s, err := resolver.RejectedStatus(rpName); err == nil {
-			sc.rejected = append(sc.rejected, s)
-		}
-	}
-	return sc
-}
-
-// containsStatus returns true if the given status appears in the list.
-// Used by statusClassifier methods to check pipeline-declared statuses.
-func containsStatus(list []models.TaskStatus, s models.TaskStatus) bool {
-	for _, v := range list {
-		if s == v {
-			return true
-		}
-	}
-	return false
-}
-
-func (sc *statusClassifier) IsExecuting(s models.TaskStatus) bool {
-	return containsStatus(sc.executing, s)
-}
-
-func (sc *statusClassifier) IsInitial(s models.TaskStatus) bool {
-	return containsStatus(sc.initial, s)
-}
-
-func (sc *statusClassifier) IsSubmitted(s models.TaskStatus) bool {
-	return containsStatus(sc.submitted, s)
-}
-
-func (sc *statusClassifier) IsReviewing(s models.TaskStatus) bool {
-	return containsStatus(sc.reviewing, s)
-}
-
-func (sc *statusClassifier) IsApproved(s models.TaskStatus) bool {
-	return containsStatus(sc.approved, s)
-}
-
-func (sc *statusClassifier) IsPartiallyApproved(s models.TaskStatus) bool {
-	return containsStatus(sc.partial, s)
-}
-
-func (sc *statusClassifier) IsRejected(s models.TaskStatus) bool {
-	return s == models.TaskStatusRejected || s == models.TaskStatusCodingPlanRejected || containsStatus(sc.rejected, s)
+	return taskinvariants.NewStatusClassifier(resolver, cfg)
 }
 
 // validateTaskInvariants enforces structural invariants across all tasks:
@@ -312,105 +238,7 @@ func validateTaskInvariants(state *models.State, projectRoot string, skipSpecFil
 // review_lease_expires). Prevents tasks from entering states without the
 // metadata needed for agents to operate on them.
 func validateStatusFields(task *models.Task, sc *statusClassifier) error {
-	if sc.IsInitial(task.Status) && task.AssignedTo != nil {
-		return fmt.Errorf("%s task with assigned_to: %s", task.Status, task.ID)
-	}
-
-	if sc.IsExecuting(task.Status) {
-		if task.AssignedTo == nil {
-			return fmt.Errorf("%s task without assigned_to: %s", task.Status, task.ID)
-		}
-		if task.Worktree == nil {
-			return fmt.Errorf("%s task without worktree: %s", task.Status, task.ID)
-		}
-		if !task.IntegrationFix && task.BaseCommit == nil {
-			return fmt.Errorf("%s task without base_commit: %s", task.Status, task.ID)
-		}
-		if task.LeaseExpires == nil {
-			return fmt.Errorf("%s task without lease_expires: %s", task.Status, task.ID)
-		}
-	}
-
-	if sc.IsSubmitted(task.Status) && task.ReviewCommit == nil {
-		return fmt.Errorf("%s task without review_commit: %s", task.Status, task.ID)
-	}
-
-	if sc.IsReviewing(task.Status) {
-		if task.ReviewingBy == nil {
-			return fmt.Errorf("%s task without reviewing_by: %s", task.Status, task.ID)
-		}
-		if task.ReviewLeaseExpires == nil {
-			return fmt.Errorf("%s task without review_lease_expires: %s", task.Status, task.ID)
-		}
-		if task.ReviewCommit == nil {
-			return fmt.Errorf("%s task without review_commit: %s", task.Status, task.ID)
-		}
-	}
-
-	if sc.IsApproved(task.Status) && task.ReviewCommit == nil {
-		return fmt.Errorf("%s task without review_commit: %s", task.Status, task.ID)
-	}
-	if task.IntegrationFailure != nil && disallowsIntegrationFailure(task.Status, sc) {
-		return fmt.Errorf("%s task has stale integration_failure outside integration recovery: %s", task.Status, task.ID)
-	}
-
-	if task.Status == models.TaskStatusMerged && task.Worktree != nil {
-		return fmt.Errorf("MERGED task still has worktree: %s", task.ID)
-	}
-
-	if task.Status == models.TaskStatusBlocked {
-		if task.BlockedReason == nil {
-			return fmt.Errorf("BLOCKED task without blocked_reason: %s", task.ID)
-		}
-		if len(task.BlockedQuestions) == 0 {
-			return fmt.Errorf("BLOCKED task without blocked_questions: %s", task.ID)
-		}
-		if task.RepairRequest != nil && strings.TrimSpace(task.RepairRequest.Operation) == "" {
-			return fmt.Errorf("BLOCKED task repair_request without operation: %s", task.ID)
-		}
-		if task.RepairRequest != nil && strings.TrimSpace(task.RepairRequest.Target) == "" {
-			return fmt.Errorf("BLOCKED task repair_request without target: %s", task.ID)
-		}
-		if task.RepairRequest != nil && strings.TrimSpace(task.RepairRequest.Command) == "" {
-			return fmt.Errorf("BLOCKED task repair_request without command: %s", task.ID)
-		}
-		if task.RepairRequest != nil && len(nonEmptyStrings(task.RepairRequest.Evidence)) == 0 {
-			return fmt.Errorf("BLOCKED task repair_request without evidence: %s", task.ID)
-		}
-		if task.RepairRequest != nil && len(nonEmptyStrings(task.RepairRequest.Validation)) == 0 {
-			return fmt.Errorf("BLOCKED task repair_request without validation: %s", task.ID)
-		}
-	}
-
-	if sc.IsRejected(task.Status) && task.RejectionReason == nil {
-		return fmt.Errorf("%s task without rejection_reason: %s", task.Status, task.ID)
-	}
-
-	if task.Status == models.TaskStatusSuperseded {
-		if task.RescopeReason == nil {
-			return fmt.Errorf("SUPERSEDED task without rescope_reason: %s", task.ID)
-		}
-	}
-
-	return nil
-}
-
-func disallowsIntegrationFailure(status models.TaskStatus, sc *statusClassifier) bool {
-	// Belt-and-suspenders: explicit legacy/built-in statuses remain protected
-	// even if no active pipeline resolver declares the matching lifecycle state.
-	switch status {
-	case models.TaskStatusReadyForReview,
-		models.TaskStatusLegacyReadyForReview,
-		models.TaskStatusReviewing,
-		models.TaskStatusPartiallyApproved,
-		models.TaskStatusReviewingCode2,
-		models.TaskStatusApproved,
-		models.TaskStatusCodingPlanToReview,
-		models.TaskStatusReviewingCodingPlan,
-		models.TaskStatusCodingPlanApproved:
-		return true
-	}
-	return sc.IsSubmitted(status) || sc.IsReviewing(status) || sc.IsPartiallyApproved(status) || sc.IsApproved(status)
+	return taskinvariants.ValidateStatusFields(task, sc)
 }
 
 func nonEmptyStrings(values []string) []string {

--- a/internal/taskinvariants/taskinvariants.go
+++ b/internal/taskinvariants/taskinvariants.go
@@ -1,0 +1,219 @@
+// Package taskinvariants holds the structural per-task invariants: the fields
+// every task status requires (or forbids). It is a leaf package — importing
+// only models and pipeline — so both the at-rest validator (statevalidate)
+// and the write funnel (db) can enforce the SAME rules from one source.
+//
+// At-rest validation reports violations after the fact; funnel enforcement
+// rejects the write that would introduce them. As writers migrate to named
+// operations the at-rest checks become a backstop instead of the gate.
+package taskinvariants
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/liza-mas/liza/internal/models"
+	"github.com/liza-mas/liza/internal/pipeline"
+)
+
+// StatusClassifier classifies pipeline-declared task statuses by lifecycle
+// phase (initial, executing, submitted, reviewing, approved, rejected).
+type StatusClassifier struct {
+	executing []models.TaskStatus
+	initial   []models.TaskStatus
+	submitted []models.TaskStatus
+	reviewing []models.TaskStatus
+	approved  []models.TaskStatus
+	partial   []models.TaskStatus
+	rejected  []models.TaskStatus
+}
+
+// NewStatusClassifier constructs a StatusClassifier from a pipeline resolver
+// and configuration. Returns an empty classifier when resolver or config is nil.
+func NewStatusClassifier(resolver *pipeline.Resolver, cfg *pipeline.PipelineConfig) StatusClassifier {
+	sc := StatusClassifier{}
+	if resolver == nil || cfg == nil {
+		return sc
+	}
+	for rpName := range cfg.Pipeline.RolePairs {
+		if s, err := resolver.ExecutingStatus(rpName); err == nil {
+			sc.executing = append(sc.executing, s)
+		}
+		if s, err := resolver.InitialStatus(rpName); err == nil {
+			sc.initial = append(sc.initial, s)
+		}
+		if s, err := resolver.SubmittedStatus(rpName); err == nil {
+			sc.submitted = append(sc.submitted, s)
+		}
+		if s, err := resolver.ReviewingStatus(rpName); err == nil {
+			sc.reviewing = append(sc.reviewing, s)
+		}
+		// reviewing-2 reuses the review lease mechanism — classify as reviewing.
+		if s, err := resolver.Reviewing2Status(rpName); err == nil {
+			sc.reviewing = append(sc.reviewing, s)
+		}
+		if s, err := resolver.ApprovedStatus(rpName); err == nil {
+			sc.approved = append(sc.approved, s)
+		}
+		if s, err := resolver.PartiallyApprovedStatus(rpName); err == nil {
+			sc.partial = append(sc.partial, s)
+		}
+		if s, err := resolver.RejectedStatus(rpName); err == nil {
+			sc.rejected = append(sc.rejected, s)
+		}
+	}
+	return sc
+}
+
+func containsStatus(list []models.TaskStatus, s models.TaskStatus) bool {
+	for _, v := range list {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+func (sc *StatusClassifier) IsExecuting(s models.TaskStatus) bool {
+	return containsStatus(sc.executing, s)
+}
+
+func (sc *StatusClassifier) IsInitial(s models.TaskStatus) bool {
+	return containsStatus(sc.initial, s)
+}
+
+func (sc *StatusClassifier) IsSubmitted(s models.TaskStatus) bool {
+	return containsStatus(sc.submitted, s)
+}
+
+func (sc *StatusClassifier) IsReviewing(s models.TaskStatus) bool {
+	return containsStatus(sc.reviewing, s)
+}
+
+func (sc *StatusClassifier) IsApproved(s models.TaskStatus) bool {
+	return containsStatus(sc.approved, s)
+}
+
+func (sc *StatusClassifier) IsPartiallyApproved(s models.TaskStatus) bool {
+	return containsStatus(sc.partial, s)
+}
+
+func (sc *StatusClassifier) IsRejected(s models.TaskStatus) bool {
+	return s == models.TaskStatusRejected || s == models.TaskStatusCodingPlanRejected || containsStatus(sc.rejected, s)
+}
+
+// ValidateStatusFields checks that a task carries the fields its status
+// requires (and none its status forbids). These are the structural invariants
+// behind "REVIEWING task must have reviewing_by", "MERGED task must not have
+// worktree", etc.
+func ValidateStatusFields(task *models.Task, sc *StatusClassifier) error {
+	if sc.IsInitial(task.Status) && task.AssignedTo != nil {
+		return fmt.Errorf("%s task with assigned_to: %s", task.Status, task.ID)
+	}
+
+	if sc.IsExecuting(task.Status) {
+		if task.AssignedTo == nil {
+			return fmt.Errorf("%s task without assigned_to: %s", task.Status, task.ID)
+		}
+		if task.Worktree == nil {
+			return fmt.Errorf("%s task without worktree: %s", task.Status, task.ID)
+		}
+		if !task.IntegrationFix && task.BaseCommit == nil {
+			return fmt.Errorf("%s task without base_commit: %s", task.Status, task.ID)
+		}
+		if task.LeaseExpires == nil {
+			return fmt.Errorf("%s task without lease_expires: %s", task.Status, task.ID)
+		}
+	}
+
+	if sc.IsSubmitted(task.Status) && task.ReviewCommit == nil {
+		return fmt.Errorf("%s task without review_commit: %s", task.Status, task.ID)
+	}
+
+	if sc.IsReviewing(task.Status) {
+		if task.ReviewingBy == nil {
+			return fmt.Errorf("%s task without reviewing_by: %s", task.Status, task.ID)
+		}
+		if task.ReviewLeaseExpires == nil {
+			return fmt.Errorf("%s task without review_lease_expires: %s", task.Status, task.ID)
+		}
+		if task.ReviewCommit == nil {
+			return fmt.Errorf("%s task without review_commit: %s", task.Status, task.ID)
+		}
+	}
+
+	if sc.IsApproved(task.Status) && task.ReviewCommit == nil {
+		return fmt.Errorf("%s task without review_commit: %s", task.Status, task.ID)
+	}
+	if task.IntegrationFailure != nil && disallowsIntegrationFailure(task.Status, sc) {
+		return fmt.Errorf("%s task has stale integration_failure outside integration recovery: %s", task.Status, task.ID)
+	}
+
+	if task.Status == models.TaskStatusMerged && task.Worktree != nil {
+		return fmt.Errorf("MERGED task still has worktree: %s", task.ID)
+	}
+
+	if task.Status == models.TaskStatusBlocked {
+		if task.BlockedReason == nil {
+			return fmt.Errorf("BLOCKED task without blocked_reason: %s", task.ID)
+		}
+		if len(task.BlockedQuestions) == 0 {
+			return fmt.Errorf("BLOCKED task without blocked_questions: %s", task.ID)
+		}
+		if task.RepairRequest != nil && strings.TrimSpace(task.RepairRequest.Operation) == "" {
+			return fmt.Errorf("BLOCKED task repair_request without operation: %s", task.ID)
+		}
+		if task.RepairRequest != nil && strings.TrimSpace(task.RepairRequest.Target) == "" {
+			return fmt.Errorf("BLOCKED task repair_request without target: %s", task.ID)
+		}
+		if task.RepairRequest != nil && strings.TrimSpace(task.RepairRequest.Command) == "" {
+			return fmt.Errorf("BLOCKED task repair_request without command: %s", task.ID)
+		}
+		if task.RepairRequest != nil && len(nonEmptyStrings(task.RepairRequest.Evidence)) == 0 {
+			return fmt.Errorf("BLOCKED task repair_request without evidence: %s", task.ID)
+		}
+		if task.RepairRequest != nil && len(nonEmptyStrings(task.RepairRequest.Validation)) == 0 {
+			return fmt.Errorf("BLOCKED task repair_request without validation: %s", task.ID)
+		}
+	}
+
+	if sc.IsRejected(task.Status) && task.RejectionReason == nil {
+		return fmt.Errorf("%s task without rejection_reason: %s", task.Status, task.ID)
+	}
+
+	if task.Status == models.TaskStatusSuperseded {
+		if task.RescopeReason == nil {
+			return fmt.Errorf("SUPERSEDED task without rescope_reason: %s", task.ID)
+		}
+	}
+
+	return nil
+}
+
+func disallowsIntegrationFailure(status models.TaskStatus, sc *StatusClassifier) bool {
+	// Belt-and-suspenders: explicit legacy/built-in statuses remain protected
+	// even if no active pipeline resolver declares the matching lifecycle state.
+	switch status {
+	case models.TaskStatusReadyForReview,
+		models.TaskStatusLegacyReadyForReview,
+		models.TaskStatusReviewing,
+		models.TaskStatusPartiallyApproved,
+		models.TaskStatusReviewingCode2,
+		models.TaskStatusApproved,
+		models.TaskStatusCodingPlanToReview,
+		models.TaskStatusReviewingCodingPlan,
+		models.TaskStatusCodingPlanApproved:
+		return true
+	}
+	return sc.IsSubmitted(status) || sc.IsReviewing(status) || sc.IsPartiallyApproved(status) || sc.IsApproved(status)
+}
+
+func nonEmptyStrings(values []string) []string {
+	var nonEmpty []string
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			nonEmpty = append(nonEmpty, value)
+		}
+	}
+	return nonEmpty
+}

--- a/internal/testhelpers/fixtures.go
+++ b/internal/testhelpers/fixtures.go
@@ -249,6 +249,11 @@ func BuildTaskByStatus(taskID string, status models.TaskStatus, now time.Time) m
 		reviewCommit := "review123"
 		task.ReviewCommit = &reviewCommit
 		task.Iteration = 1
+		// Rejection never clears base_commit in production: the task has
+		// carried it since the original claim, and same-coder reclaim with a
+		// preserved worktree relies on it for the review boundary.
+		baseCommit := "abc1234"
+		task.BaseCommit = &baseCommit
 		worktree := ".worktrees/" + taskID
 		task.Worktree = &worktree
 

--- a/internal/testhelpers/setup.go
+++ b/internal/testhelpers/setup.go
@@ -58,6 +58,7 @@ var (
 func SetupTestGitRepo(t *testing.T, tmpDir string) {
 	t.Helper()
 
+	isolateGitConfigEnv(t)
 	if err := prepareGitFixtureDir(tmpDir); err != nil {
 		t.Fatalf("Failed to prepare test git repo directory: %v", err)
 	}
@@ -74,6 +75,7 @@ func SetupTestGitRepo(t *testing.T, tmpDir string) {
 func SetupBasicTestGitRepo(t *testing.T, tmpDir string) {
 	t.Helper()
 
+	isolateGitConfigEnv(t)
 	if err := prepareGitFixtureDir(tmpDir); err != nil {
 		t.Fatalf("Failed to prepare basic test git repo directory: %v", err)
 	}
@@ -82,6 +84,26 @@ func SetupBasicTestGitRepo(t *testing.T, tmpDir string) {
 		t.Fatalf("Failed to copy basic test git repo template: %v", err)
 	}
 	configureTestGitRepo(t, tmpDir)
+}
+
+// isolateGitConfigEnv points global and system git config at os.DevNull so
+// host-level configuration (e.g. core.excludesFile in ~/.gitconfig) cannot leak
+// into test repositories or into subprocesses spawned by the code under test
+// (which inherit the test process environment via gitenv.Env / exec.Command).
+//
+// Values already present in the environment are preserved: tests that
+// intentionally exercise global-config behavior set GIT_CONFIG_GLOBAL via
+// t.Setenv before calling the setup helpers, and that override must win.
+// t.Setenv also guards against misuse from parallel tests.
+func isolateGitConfigEnv(t *testing.T) {
+	t.Helper()
+
+	if _, ok := os.LookupEnv("GIT_CONFIG_GLOBAL"); !ok {
+		t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	}
+	if _, ok := os.LookupEnv("GIT_CONFIG_SYSTEM"); !ok {
+		t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	}
 }
 
 func gitRepoTemplateDir(t *testing.T, template *preparedGitRepoTemplate, includeIntegrationBranch bool) string {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -251,7 +251,7 @@ func checkpointCmd(projectRoot string) tea.Cmd {
 func toggleAutoResumeCmd(bb *db.Blackboard) tea.Cmd {
 	return func() tea.Msg {
 		var newVal bool
-		err := bb.Modify(func(s *models.State) error {
+		err := bb.ModifyOp("toggle_auto_resume", func(s *models.State) error {
 			s.Config.AutoResume = !s.Config.AutoResume
 			newVal = s.Config.AutoResume
 			return nil

--- a/internal/worktreeexclude/worktreeexclude_test.go
+++ b/internal/worktreeexclude/worktreeexclude_test.go
@@ -137,6 +137,12 @@ type gitRepoFixture struct {
 func newGitRepoWithWorktrees(t *testing.T, names ...string) gitRepoFixture {
 	t.Helper()
 
+	// Isolate from host-level git config: a user's global core.excludesFile
+	// (e.g. ~/.gitignore_global) would otherwise surface as an unexpected
+	// "effective core.excludesFile already configured" conflict.
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
 	parent := t.TempDir()
 	repo := filepath.Join(parent, "repo")
 	if err := os.MkdirAll(repo, 0o755); err != nil {


### PR DESCRIPTION
## What this is

A **strangler migration** toward an event-journal orchestration architecture. Everything is **additive and reversible**: `state.yaml` remains the source of truth, and all of `INVARIANTS.md` is preserved. This is the first multi-phase landing, not a finished system.

Full status, concerns, and remaining roadmap: [`docs/event-journal-migration.md`](docs/event-journal-migration.md).

## Why

Liza's orchestration complexity is largely compensation for a mutable, denormalized `state.yaml` that ~55 commands mutate in place. Because that model *permits* invalid states, the system grew an immune system to repair them after the fact (a 2k-line `statevalidate`, transcript-scrubbing `statehygiene`, ~10 repair commands, five overlapping supervisor progress trackers, duplicated ownership/lease fields). This migration inverts the foundation.

## What landed

| Area | Notes |
|------|-------|
| **Append-only journal** (`internal/journal`) | Plain JSONL (`.liza/journal.jsonl`), **no SQLite** per code-owner constraint. fsync, field caps, torn-tail tolerance, rotation with projection-equivalent snapshots. |
| **Shadow derivation** (`internal/db`) | Every `Modify`/`Write` derives typed events by diffing before/after, inside the state lock. Zero call-site changes. |
| **Op provenance + fail-closed funnel** | `ModifyOp(op, fn)` names ~70 write sites; structural per-task invariants (`internal/taskinvariants`) enforced *before* writing, no-worse-than-before semantics. |
| **Unified progress policy** (`internal/agent/progress.go`) | Five overlapping trackers (exit42/crash/spin/runtime-failure/success-no-progress) → one ledger + one threshold table. |
| **Claims as entities** (`internal/models/claim.go`, `internal/ops/claim_records.go`) | First-class claim records dual-written with legacy ownership fields; `SweepExpiredClaims` primitive; contradiction warnings. |
| **Scheduler core** (`internal/scheduler`) | Pure `Compute(state, resolver, now) → Plan` for doer/review/merge/reclaim; surfaced read-only via `liza schedule`. **Not yet wired into the live loop.** |
| **Verification** | `liza journal --verify` + broadened `liza validate`: warns on journal/state divergence across statuses, claim holders, and system singletons. |

## Bugs found *by* the fail-closed funnel (and fixed)

- Rejected-task reclaim kept a stale/missing `base_commit` when the worktree was recreated → corrupted reviewer diff scope.
- `release-claim` wiped `review_commit` while leaving a submitted status → unreviewable zombie tasks.

## Key reviewer concerns (detail in the doc)

1. **Journal events are lossy diffs, not snapshots** — full `state.yaml` reconstruction is impossible today; the lossless event vocabulary *is* the bulk of the eventual source-of-truth flip, not a precursor.
2. **Scheduler core is proven but not live** — hot-path rewiring needs real multi-agent runs, not just unit tests.
3. **Dual-write can drift** — claims + legacy fields; `liza validate` divergence check is the backstop.
4. Orchestrator wake detection not yet consolidated into the scheduler (cross-package move, deferred).
5. Write-funnel enforcement intentionally permissive for now (generic ops, no-config projects, no-worse-than-before).

## Verification

- `make test` → 42 packages ok, 0 FAIL
- `make test-e2e` (full sprint sequence) → pass
- `make lint` → clean
- Also fixes pre-existing `wt_create`/`worktreeexclude` test failures on hosts with a global `core.excludesFile` (test git-env isolation).
- Live: `liza schedule` lists runnable work from real state; `liza validate` clean on coherent state, correctly flags an injected claim divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)