### PR TITLE
fix(updater): consolidate update flag parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,28 @@ Mode-specific guides:
 - **Multi-Agent (Liza)**: [Multi-Agent Usage](support-docs/USAGE_MULTI_AGENTS.md), then try the [Demo](docs/DEMO.md)
 - **Reference**: [Configuration](support-docs/CONFIGURATION.md) · [Recipes](docs/RECIPES.md) · [Troubleshooting](support-docs/TROUBLESHOOTING.md)
 
+### Update Settings
+
+Update flags persist to `~/.liza/update.json`, so you only need to set them
+once:
+
+```bash
+liza --check-update --update-channel=main
+```
+
+That writes:
+
+```json
+{
+  "check_update": true,
+  "channel": "main"
+}
+```
+
+Future interactive `liza` runs use the saved settings. `--check-update=false`
+disables saved checks, and `--update-channel=stable` switches back to release
+updates.
+
 ### Recommended Tools
 
 Liza optimizes cost-to-quality, not cost-to-lets-cross-fingers. These tools reduce token usage without sacrificing output quality:

--- a/cmd/liza/main.go
+++ b/cmd/liza/main.go
@@ -283,6 +283,10 @@ func main() {
 		// If we get here with a non-fatal error, it's a reexec error or similar - log and continue
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 	}
+	if updater.UpdateSettingsOnly(os.Args) {
+		fmt.Fprint(os.Stdout, updater.SavedUpdateSettingsSummary())
+		return
+	}
 	if err := rootCmd.Execute(); err != nil {
 		if !errors.Is(err, jsonout.ErrAlreadyWritten) {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
+	golang.org/x/mod v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -40,7 +41,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -493,8 +493,8 @@ func installBinaryFromTarGz(r io.Reader, target string) error {
 		switch header.Typeflag {
 		case tar.TypeReg:
 			// Regular file is allowed
-		case tar.TypeRegA:
-			// Regular file (extended) is allowed
+		case '\x00':
+			// Legacy regular file marker is allowed
 		default:
 			// Reject symlinks, hardlinks, directories, devices, etc.
 			return fmt.Errorf("reject dangerous tar entry type %d for %s", header.Typeflag, header.Name)
@@ -775,32 +775,12 @@ func shouldSkip(cfg Config) bool {
 }
 
 func checkUpdateFlag(args []string) (bool, bool) {
-	// Stop parsing at --
-	preDashArgs := args
-	for i, arg := range args {
-		if arg == "--" {
-			preDashArgs = args[:i]
-			break
-		}
+	flags, err := parseUpdateFlags(args)
+	if err != nil {
+		return false, false
 	}
-
-	var enabled *bool
-	for i := 1; i < len(preDashArgs); i++ {
-		arg := preDashArgs[i]
-		if strings.HasPrefix(arg, "--check-update=") {
-			value := strings.TrimPrefix(arg, "--check-update=")
-			if value == "true" {
-				enabled = &[]bool{true}[0]
-			} else if value == "false" {
-				enabled = &[]bool{false}[0]
-			}
-		} else if arg == "--check-update" {
-			// --check-update without = is treated as true
-			enabled = &[]bool{true}[0]
-		}
-	}
-	if enabled != nil {
-		return *enabled, true
+	if flags.checkUpdate != nil {
+		return *flags.checkUpdate, true
 	}
 	return false, false
 }
@@ -834,6 +814,12 @@ func proposeDisableCheck(stdin *bufio.Reader, stdout io.Writer, disable func() e
 type preferences struct {
 	CheckUpdate *bool  `json:"check_update,omitempty"`
 	Channel     string `json:"channel,omitempty"`
+}
+
+type parsedUpdateFlags struct {
+	checkUpdate  *bool
+	channel      string
+	settingsOnly bool
 }
 
 func updatePrefsPath() (string, error) {
@@ -898,77 +884,61 @@ func persistExplicitUpdatePreferences(cfg Config) error {
 }
 
 func validateExplicitUpdateFlags(args []string) error {
-	preDashArgs := args
-	for i, arg := range args {
-		if arg == "--" {
-			preDashArgs = args[:i]
-			break
-		}
-	}
-
-	for i := 1; i < len(preDashArgs); i++ {
-		arg := preDashArgs[i]
-		switch {
-		case strings.HasPrefix(arg, "--check-update="):
-			value := strings.TrimPrefix(arg, "--check-update=")
-			if value != "true" && value != "false" {
-				return &FatalError{fmt.Errorf("invalid --check-update value %q (valid values: true, false)", value)}
-			}
-		case arg == "--update-channel":
-			if i+1 >= len(preDashArgs) {
-				return &FatalError{fmt.Errorf("--update-channel requires a value (valid values: stable, main)")}
-			}
-			channel := strings.ToLower(strings.TrimSpace(preDashArgs[i+1]))
-			if err := validateChannel(channel); err != nil {
-				return err
-			}
-			i++
-		case strings.HasPrefix(arg, "--update-channel="):
-			channel := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(arg, "--update-channel=")))
-			if err := validateChannel(channel); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	_, err := parseUpdateFlags(args)
+	return err
 }
 
 func UpdateSettingsOnly(args []string) bool {
+	flags, err := parseUpdateFlags(args)
+	return err == nil && flags.settingsOnly
+}
+
+func parseUpdateFlags(args []string) (parsedUpdateFlags, error) {
+	var flags parsedUpdateFlags
 	changed := false
+	settingsOnly := true
 	for i := 1; i < len(args); i++ {
 		arg := args[i]
 		switch {
 		case arg == "--":
-			return changed && i == len(args)-1
+			flags.settingsOnly = changed && settingsOnly && i == len(args)-1
+			return flags, nil
 		case arg == "--check-update":
-			changed = true
+			flags.checkUpdate = boolPtr(true)
 		case strings.HasPrefix(arg, "--check-update="):
 			value := strings.TrimPrefix(arg, "--check-update=")
 			if value != "true" && value != "false" {
-				return false
+				return flags, &FatalError{fmt.Errorf("invalid --check-update value %q (valid values: true, false)", value)}
 			}
-			changed = true
+			flags.checkUpdate = boolPtr(value == "true")
 		case arg == "--update-channel":
-			if i+1 >= len(args) {
-				return false
+			if i+1 >= len(args) || args[i+1] == "--" {
+				return flags, &FatalError{fmt.Errorf("--update-channel requires a value (valid values: stable, main)")}
 			}
 			channel := strings.ToLower(strings.TrimSpace(args[i+1]))
-			if channel == "" || strings.HasPrefix(channel, "-") || validateChannel(channel) != nil {
-				return false
+			flags.channel = channel
+			if err := validateChannel(channel); err != nil {
+				return flags, err
 			}
-			changed = true
 			i++
 		case strings.HasPrefix(arg, "--update-channel="):
 			channel := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(arg, "--update-channel=")))
-			if channel == "" || validateChannel(channel) != nil {
-				return false
+			flags.channel = channel
+			if err := validateChannel(channel); err != nil {
+				return flags, err
 			}
-			changed = true
 		default:
-			return false
+			settingsOnly = false
+			continue
 		}
+		changed = true
 	}
-	return changed
+	flags.settingsOnly = changed && settingsOnly
+	return flags, nil
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func SavedUpdateSettingsSummary() string {
@@ -1029,26 +999,12 @@ func updateChannel(cfg Config) string {
 }
 
 func updateChannelFlag(args []string) (string, bool) {
-	// Stop parsing at --
-	preDashArgs := args
-	for i, arg := range args {
-		if arg == "--" {
-			preDashArgs = args[:i]
-			break
-		}
+	flags, err := parseUpdateFlags(args)
+	if err != nil {
+		return "", false
 	}
-
-	var channel string
-	for i := 1; i < len(preDashArgs); i++ {
-		arg := preDashArgs[i]
-		if strings.HasPrefix(arg, "--update-channel=") {
-			channel = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(arg, "--update-channel=")))
-		} else if arg == "--update-channel" && i+1 < len(preDashArgs) {
-			channel = strings.ToLower(strings.TrimSpace(preDashArgs[i+1]))
-		}
-	}
-	if channel != "" {
-		return channel, true
+	if flags.channel != "" {
+		return flags.channel, true
 	}
 	return "", false
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -106,6 +106,9 @@ type candidate struct {
 
 func MaybeUpdateAndReexec(ctx context.Context, cfg Config) error {
 	cfg = withDefaults(cfg)
+	if err := validateExplicitUpdateFlags(cfg.Args); err != nil {
+		return err
+	}
 	if err := persistExplicitUpdatePreferences(cfg); err != nil {
 		return err
 	}
@@ -894,6 +897,42 @@ func persistExplicitUpdatePreferences(cfg Config) error {
 	return nil
 }
 
+func validateExplicitUpdateFlags(args []string) error {
+	preDashArgs := args
+	for i, arg := range args {
+		if arg == "--" {
+			preDashArgs = args[:i]
+			break
+		}
+	}
+
+	for i := 1; i < len(preDashArgs); i++ {
+		arg := preDashArgs[i]
+		switch {
+		case strings.HasPrefix(arg, "--check-update="):
+			value := strings.TrimPrefix(arg, "--check-update=")
+			if value != "true" && value != "false" {
+				return &FatalError{fmt.Errorf("invalid --check-update value %q (valid values: true, false)", value)}
+			}
+		case arg == "--update-channel":
+			if i+1 >= len(preDashArgs) {
+				return &FatalError{fmt.Errorf("--update-channel requires a value (valid values: stable, main)")}
+			}
+			channel := strings.ToLower(strings.TrimSpace(preDashArgs[i+1]))
+			if err := validateChannel(channel); err != nil {
+				return err
+			}
+			i++
+		case strings.HasPrefix(arg, "--update-channel="):
+			channel := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(arg, "--update-channel=")))
+			if err := validateChannel(channel); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func UpdateSettingsOnly(args []string) bool {
 	changed := false
 	for i := 1; i < len(args); i++ {
@@ -901,12 +940,29 @@ func UpdateSettingsOnly(args []string) bool {
 		switch {
 		case arg == "--":
 			return changed && i == len(args)-1
-		case arg == "--check-update" || strings.HasPrefix(arg, "--check-update="):
+		case arg == "--check-update":
+			changed = true
+		case strings.HasPrefix(arg, "--check-update="):
+			value := strings.TrimPrefix(arg, "--check-update=")
+			if value != "true" && value != "false" {
+				return false
+			}
 			changed = true
 		case arg == "--update-channel":
+			if i+1 >= len(args) {
+				return false
+			}
+			channel := strings.ToLower(strings.TrimSpace(args[i+1]))
+			if channel == "" || strings.HasPrefix(channel, "-") || validateChannel(channel) != nil {
+				return false
+			}
 			changed = true
 			i++
 		case strings.HasPrefix(arg, "--update-channel="):
+			channel := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(arg, "--update-channel=")))
+			if channel == "" || validateChannel(channel) != nil {
+				return false
+			}
 			changed = true
 		default:
 			return false

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -100,6 +100,12 @@ type candidate struct {
 
 func MaybeUpdateAndReexec(ctx context.Context, cfg Config) error {
 	cfg = withDefaults(cfg)
+	if err := persistExplicitUpdatePreferences(cfg); err != nil {
+		return err
+	}
+	if UpdateSettingsOnly(cfg.Args) {
+		return nil
+	}
 	if shouldSkip(cfg) {
 		return nil
 	}
@@ -702,6 +708,9 @@ func shouldSkip(cfg Config) bool {
 	if cfg.CheckDisabled != nil && cfg.CheckDisabled() {
 		return true
 	}
+	if prefs := readUpdatePreferences(); prefs.CheckUpdate != nil {
+		return !*prefs.CheckUpdate || !cfg.IsInteractive()
+	}
 	if !checkUpdateEnvEnabled(cfg) {
 		return true
 	}
@@ -769,7 +778,8 @@ func proposeDisableCheck(stdin *bufio.Reader, stdout io.Writer, disable func() e
 }
 
 type preferences struct {
-	CheckUpdate *bool `json:"check_update,omitempty"`
+	CheckUpdate *bool  `json:"check_update,omitempty"`
+	Channel     string `json:"channel,omitempty"`
 }
 
 func updatePrefsPath() (string, error) {
@@ -781,22 +791,93 @@ func updatePrefsPath() (string, error) {
 }
 
 func UpdateChecksDisabled() bool {
-	path, err := updatePrefsPath()
-	if err != nil {
-		return false
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false
-	}
-	var prefs preferences
-	if err := json.Unmarshal(data, &prefs); err != nil {
-		return false
-	}
+	prefs := readUpdatePreferences()
 	return prefs.CheckUpdate != nil && !*prefs.CheckUpdate
 }
 
+func readUpdatePreferences() preferences {
+	path, err := updatePrefsPath()
+	if err != nil {
+		return preferences{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return preferences{}
+	}
+	var prefs preferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		return preferences{}
+	}
+	prefs.Channel = strings.ToLower(strings.TrimSpace(prefs.Channel))
+	return prefs
+}
+
 func DisableUpdateChecks() error {
+	prefs := readUpdatePreferences()
+	disabled := false
+	prefs.CheckUpdate = &disabled
+	return writeUpdatePreferences(prefs)
+}
+
+func persistExplicitUpdatePreferences(cfg Config) error {
+	var changed bool
+	prefs := readUpdatePreferences()
+
+	if enabled, ok := checkUpdateFlag(cfg.Args); ok {
+		prefs.CheckUpdate = &enabled
+		changed = true
+	}
+	if channel, ok := updateChannelFlag(cfg.Args); ok {
+		if err := validateChannel(channel); err != nil {
+			return err
+		}
+		prefs.Channel = channel
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	if err := writeUpdatePreferences(prefs); err != nil {
+		return &FatalError{fmt.Errorf("write update preferences: %w", err)}
+	}
+	return nil
+}
+
+func UpdateSettingsOnly(args []string) bool {
+	changed := false
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--":
+			return changed && i == len(args)-1
+		case arg == "--check-update" || strings.HasPrefix(arg, "--check-update="):
+			changed = true
+		case arg == "--update-channel":
+			changed = true
+			i++
+		case strings.HasPrefix(arg, "--update-channel="):
+			changed = true
+		default:
+			return false
+		}
+	}
+	return changed
+}
+
+func SavedUpdateSettingsSummary() string {
+	prefs := readUpdatePreferences()
+	checkUpdate := "unset"
+	if prefs.CheckUpdate != nil {
+		checkUpdate = fmt.Sprintf("%t", *prefs.CheckUpdate)
+	}
+	channel := prefs.Channel
+	if channel == "" {
+		channel = channelStable
+	}
+	return fmt.Sprintf("Update settings saved: check_update=%s, channel=%s\n", checkUpdate, channel)
+}
+
+func writeUpdatePreferences(prefs preferences) error {
 	path, err := updatePrefsPath()
 	if err != nil {
 		return err
@@ -804,8 +885,8 @@ func DisableUpdateChecks() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create global liza config dir: %w", err)
 	}
-	disabled := false
-	data, err := json.MarshalIndent(preferences{CheckUpdate: &disabled}, "", "  ")
+	prefs.Channel = strings.ToLower(strings.TrimSpace(prefs.Channel))
+	data, err := json.MarshalIndent(prefs, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode update preferences: %w", err)
 	}
@@ -825,11 +906,27 @@ func validateChannel(channel string) error {
 }
 
 func updateChannel(cfg Config) string {
+	if channel, ok := updateChannelFlag(cfg.Args); ok {
+		return channel
+	}
+	if cfg.Channel != "" {
+		return strings.ToLower(strings.TrimSpace(cfg.Channel))
+	}
+	if envChannel := envValue(cfg.Env, channelEnvName); envChannel != "" {
+		return strings.ToLower(strings.TrimSpace(envChannel))
+	}
+	if prefs := readUpdatePreferences(); prefs.Channel != "" {
+		return prefs.Channel
+	}
+	return channelStable
+}
+
+func updateChannelFlag(args []string) (string, bool) {
 	// Stop parsing at --
-	preDashArgs := cfg.Args
-	for i, arg := range cfg.Args {
+	preDashArgs := args
+	for i, arg := range args {
 		if arg == "--" {
-			preDashArgs = cfg.Args[:i]
+			preDashArgs = args[:i]
 			break
 		}
 	}
@@ -844,15 +941,9 @@ func updateChannel(cfg Config) string {
 		}
 	}
 	if channel != "" {
-		return channel
+		return channel, true
 	}
-	if cfg.Channel != "" {
-		return strings.ToLower(strings.TrimSpace(cfg.Channel))
-	}
-	if envChannel := envValue(cfg.Env, channelEnvName); envChannel != "" {
-		return strings.ToLower(strings.TrimSpace(envChannel))
-	}
-	return channelStable
+	return "", false
 }
 
 func reexecArgs(args []string) []string {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -65,6 +65,7 @@ type Config struct {
 	InstallTimeout time.Duration
 	LookupLatest   func(context.Context) (string, error)
 	LookupMain     func(context.Context) (string, error)
+	IsMainAhead    func(context.Context, string, string) (bool, error)
 	Install        func(context.Context, candidate, string, io.Writer, io.Writer) error
 	InstallTarget  func() (string, error)
 	CheckDisabled  func() bool
@@ -89,6 +90,11 @@ type moduleInfo struct {
 
 type releaseInfo struct {
 	TagName string `json:"tag_name"`
+}
+
+type compareInfo struct {
+	AheadBy  int `json:"ahead_by"`
+	BehindBy int `json:"behind_by"`
 }
 
 type candidate struct {
@@ -218,6 +224,13 @@ func lookupCandidate(ctx context.Context, cfg Config) (candidate, error) {
 		if latest == "" || sameCommit(current, latest) {
 			return candidate{}, nil
 		}
+		ahead, err := cfg.IsMainAhead(ctx, current, latest)
+		if err != nil {
+			return candidate{}, err
+		}
+		if !ahead {
+			return candidate{}, nil
+		}
 		return candidate{
 			Channel: channelMain,
 			Current: shortCommit(current),
@@ -255,6 +268,44 @@ func MainCommit(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return parseMainCommit(out)
+}
+
+func MainCommitAhead(ctx context.Context, current, latest string) (bool, error) {
+	current = normalizeCommit(current)
+	latest = normalizeCommit(latest)
+	if current == "" || latest == "" || sameCommit(current, latest) {
+		return false, nil
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/liza-mas/liza/compare/%s...%s", current, latest)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("compare main commits: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("compare main commits: HTTP %s", resp.Status)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("read compare response: %w", err)
+	}
+	var info compareInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return false, fmt.Errorf("parse compare response: %w", err)
+	}
+	return mainCommitAheadFromCompare(info), nil
+}
+
+func mainCommitAheadFromCompare(info compareInfo) bool {
+	return info.AheadBy > 0 && info.BehindBy == 0
 }
 
 func Install(ctx context.Context, next candidate, target string, stdout, stderr io.Writer) error {
@@ -983,6 +1034,9 @@ func withDefaults(cfg Config) Config {
 	}
 	if cfg.LookupMain == nil {
 		cfg.LookupMain = MainCommit
+	}
+	if cfg.IsMainAhead == nil {
+		cfg.IsMainAhead = MainCommitAhead
 	}
 	if cfg.Install == nil {
 		// Use the configured ReleaseBaseURL for test injection, empty string uses canonical GitHub

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -24,6 +24,21 @@ import (
 	"time"
 )
 
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "liza-updater-home-*")
+	if err != nil {
+		panic(err)
+	}
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	_ = os.Setenv("HOME", oldHome)
+	_ = os.RemoveAll(home)
+	os.Exit(code)
+}
+
 func tempHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
@@ -393,6 +408,15 @@ func TestMaybeUpdateAndReexecMainChannelInstallsCommitRef(t *testing.T) {
 		LookupMain: func(context.Context) (string, error) {
 			return "222222222222abcdef", nil
 		},
+		IsMainAhead: func(_ context.Context, current, latest string) (bool, error) {
+			if current != "111111111111" {
+				t.Fatalf("current = %q, want 111111111111", current)
+			}
+			if latest != "222222222222abcdef" {
+				t.Fatalf("latest = %q, want 222222222222abcdef", latest)
+			}
+			return true, nil
+		},
 		Install: func(_ context.Context, next candidate, _ string, _ io.Writer, _ io.Writer) error {
 			installedRef = next.Ref
 			return nil
@@ -412,6 +436,68 @@ func TestMaybeUpdateAndReexecMainChannelInstallsCommitRef(t *testing.T) {
 	}
 	if installedRef != "222222222222abcdef" {
 		t.Fatalf("installed ref = %q, want main commit hash", installedRef)
+	}
+}
+
+func TestMaybeUpdateAndReexecMainChannelSkipsWhenMainNotAhead(t *testing.T) {
+	var stderr bytes.Buffer
+	installCalled := false
+	err := MaybeUpdateAndReexec(context.Background(), Config{
+		CurrentVersion: "v1.2.3",
+		CurrentCommit:  "10013d9e",
+		CheckUpdate:    true,
+		Channel:        "main",
+		Args:           []string{"/tmp/branch-liza", "version"},
+		Stdin:          strings.NewReader("y\n"),
+		Stdout:         io.Discard,
+		Stderr:         &stderr,
+		IsInteractive:  func() bool { return true },
+		LookupMain: func(context.Context) (string, error) {
+			return "e02d2cde2dee", nil
+		},
+		IsMainAhead: func(_ context.Context, current, latest string) (bool, error) {
+			if current != "10013d9e" {
+				t.Fatalf("current = %q, want 10013d9e", current)
+			}
+			if latest != "e02d2cde2dee" {
+				t.Fatalf("latest = %q, want e02d2cde2dee", latest)
+			}
+			return false, nil
+		},
+		Install: func(context.Context, candidate, string, io.Writer, io.Writer) error {
+			installCalled = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaybeUpdateAndReexec returned error: %v", err)
+	}
+	if installCalled {
+		t.Fatal("expected main channel skip not to install")
+	}
+	if strings.Contains(stderr.String(), "Liza main update is available") {
+		t.Fatalf("stderr should not contain update prompt, got:\n%s", stderr.String())
+	}
+}
+
+func TestMainCommitAheadFromCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		info compareInfo
+		want bool
+	}{
+		{name: "upstream main ahead", info: compareInfo{AheadBy: 1, BehindBy: 0}, want: true},
+		{name: "current branch ahead", info: compareInfo{AheadBy: 0, BehindBy: 1}, want: false},
+		{name: "diverged", info: compareInfo{AheadBy: 1, BehindBy: 1}, want: false},
+		{name: "identical", info: compareInfo{AheadBy: 0, BehindBy: 0}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mainCommitAheadFromCompare(tt.info); got != tt.want {
+				t.Fatalf("mainCommitAheadFromCompare(%+v) = %v, want %v", tt.info, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -553,12 +553,64 @@ func TestUpdateSettingsOnly(t *testing.T) {
 		{name: "subcommand", args: []string{"liza", "--check-update", "version"}, want: false},
 		{name: "double dash payload", args: []string{"liza", "--check-update", "--", "version"}, want: false},
 		{name: "no settings", args: []string{"liza"}, want: false},
+		{name: "invalid check value", args: []string{"liza", "--check-update=maybe"}, want: false},
+		{name: "empty check value", args: []string{"liza", "--check-update="}, want: false},
+		{name: "empty channel equals value", args: []string{"liza", "--update-channel="}, want: false},
+		{name: "missing channel value", args: []string{"liza", "--update-channel"}, want: false},
+		{name: "invalid channel value", args: []string{"liza", "--update-channel=nightly"}, want: false},
+		{name: "channel value is another flag", args: []string{"liza", "--update-channel", "--check-update"}, want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := UpdateSettingsOnly(tt.args); got != tt.want {
 				t.Fatalf("UpdateSettingsOnly(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaybeUpdateAndReexecMalformedUpdateFlagsFatal(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "invalid check value", args: []string{"liza", "--check-update=maybe"}, want: "invalid --check-update value"},
+		{name: "empty check value", args: []string{"liza", "--check-update="}, want: "invalid --check-update value"},
+		{name: "empty channel equals value", args: []string{"liza", "--update-channel="}, want: "invalid update channel"},
+		{name: "missing channel value", args: []string{"liza", "--update-channel"}, want: "--update-channel requires a value"},
+		{name: "invalid channel value", args: []string{"liza", "--update-channel=nightly"}, want: "invalid update channel"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := MaybeUpdateAndReexec(context.Background(), Config{
+				CurrentVersion: "v1.0.0",
+				CurrentCommit:  "111111111111",
+				Args:           tt.args,
+				Env:            []string{},
+				Stdout:         io.Discard,
+				Stderr:         io.Discard,
+				IsInteractive:  func() bool { return true },
+				LookupLatest: func(context.Context) (string, error) {
+					t.Fatal("malformed update flags should fail before lookup")
+					return "", nil
+				},
+				LookupMain: func(context.Context) (string, error) {
+					t.Fatal("malformed update flags should fail before lookup")
+					return "", nil
+				},
+			})
+			if err == nil {
+				t.Fatal("MaybeUpdateAndReexec returned nil, want fatal error")
+			}
+			var fatalErr *FatalError
+			if !errors.As(err, &fatalErr) {
+				t.Fatalf("error = %T, want FatalError", err)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want to contain %q", err.Error(), tt.want)
 			}
 		})
 	}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,42 @@ import (
 	"testing"
 	"time"
 )
+
+func tempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func writePrefsForTest(t *testing.T, home string, prefs preferences) {
+	t.Helper()
+	dir := filepath.Join(home, ".liza")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create temp .liza dir: %v", err)
+	}
+	data, err := json.MarshalIndent(prefs, "", "  ")
+	if err != nil {
+		t.Fatalf("encode prefs: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(dir, updatePrefs), data, 0o644); err != nil {
+		t.Fatalf("write prefs: %v", err)
+	}
+}
+
+func readPrefsForTest(t *testing.T, home string) preferences {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, ".liza", updatePrefs))
+	if err != nil {
+		t.Fatalf("read prefs: %v", err)
+	}
+	var prefs preferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		t.Fatalf("decode prefs: %v", err)
+	}
+	return prefs
+}
 
 func TestParseLatestVersion(t *testing.T) {
 	got, err := parseLatestVersion([]byte(`{"Path":"github.com/liza-mas/liza","Version":"v1.2.3"}`))
@@ -86,6 +123,7 @@ func TestMaybeUpdateAndReexecSkipsDevBuild(t *testing.T) {
 }
 
 func TestMaybeUpdateAndReexecSkipsWhenCheckUpdateOff(t *testing.T) {
+	tempHome(t)
 	called := false
 	err := MaybeUpdateAndReexec(context.Background(), Config{
 		CurrentVersion: "v1.0.0",
@@ -384,6 +422,133 @@ func TestUpdateChannelFlagOverridesEnv(t *testing.T) {
 	})
 	if got != "main" {
 		t.Fatalf("channel = %q, want main", got)
+	}
+}
+
+func TestMaybeUpdateAndReexecExplicitFlagsPersistUpdatePreferences(t *testing.T) {
+	home := tempHome(t)
+
+	err := MaybeUpdateAndReexec(context.Background(), Config{
+		CurrentVersion: "v1.0.0",
+		CurrentCommit:  "111111111111",
+		Args:           []string{"liza", "--check-update", "--update-channel=main"},
+		Env:            []string{},
+		Stdout:         io.Discard,
+		Stderr:         io.Discard,
+		IsInteractive:  func() bool { return true },
+		LookupMain: func(context.Context) (string, error) {
+			t.Fatal("settings-only invocation should not run update lookup")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaybeUpdateAndReexec returned error: %v", err)
+	}
+
+	prefs := readPrefsForTest(t, home)
+	if prefs.CheckUpdate == nil || !*prefs.CheckUpdate {
+		t.Fatalf("check_update = %v, want true", prefs.CheckUpdate)
+	}
+	if prefs.Channel != "main" {
+		t.Fatalf("channel = %q, want main", prefs.Channel)
+	}
+}
+
+func TestUpdateSettingsOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "check only", args: []string{"liza", "--check-update"}, want: true},
+		{name: "channel equals only", args: []string{"liza", "--update-channel=main"}, want: true},
+		{name: "channel space only", args: []string{"liza", "--update-channel", "main"}, want: true},
+		{name: "both only", args: []string{"liza", "--check-update=false", "--update-channel=stable"}, want: true},
+		{name: "subcommand", args: []string{"liza", "--check-update", "version"}, want: false},
+		{name: "double dash payload", args: []string{"liza", "--check-update", "--", "version"}, want: false},
+		{name: "no settings", args: []string{"liza"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UpdateSettingsOnly(tt.args); got != tt.want {
+				t.Fatalf("UpdateSettingsOnly(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSavedUpdateSettingsSummary(t *testing.T) {
+	home := tempHome(t)
+	enabled := true
+	writePrefsForTest(t, home, preferences{CheckUpdate: &enabled, Channel: "main"})
+
+	got := SavedUpdateSettingsSummary()
+	want := "Update settings saved: check_update=true, channel=main\n"
+	if got != want {
+		t.Fatalf("summary = %q, want %q", got, want)
+	}
+}
+
+func TestMaybeUpdateAndReexecSavedPreferencesEnableMainChannel(t *testing.T) {
+	home := tempHome(t)
+	enabled := true
+	writePrefsForTest(t, home, preferences{CheckUpdate: &enabled, Channel: "main"})
+
+	mainCalled := false
+	err := MaybeUpdateAndReexec(context.Background(), Config{
+		CurrentVersion: "v1.0.0",
+		CurrentCommit:  "111111111111",
+		Args:           []string{"liza", "version"},
+		Env:            []string{},
+		Stdout:         io.Discard,
+		Stderr:         io.Discard,
+		IsInteractive:  func() bool { return true },
+		LookupLatest: func(context.Context) (string, error) {
+			t.Fatal("stable lookup should not run for saved main channel")
+			return "", nil
+		},
+		LookupMain: func(context.Context) (string, error) {
+			mainCalled = true
+			return "111111111111", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaybeUpdateAndReexec returned error: %v", err)
+	}
+	if !mainCalled {
+		t.Fatal("expected saved check_update preference to run main channel lookup")
+	}
+}
+
+func TestUpdateChannelEnvOverridesSavedPreference(t *testing.T) {
+	home := tempHome(t)
+	writePrefsForTest(t, home, preferences{Channel: "main"})
+
+	got := updateChannel(Config{
+		Args: []string{"liza", "version"},
+		Env:  []string{"LIZA_UPDATE_CHANNEL=stable"},
+	})
+	if got != "stable" {
+		t.Fatalf("channel = %q, want stable", got)
+	}
+}
+
+func TestDisableUpdateChecksPreservesSavedChannel(t *testing.T) {
+	home := tempHome(t)
+	enabled := true
+	writePrefsForTest(t, home, preferences{CheckUpdate: &enabled, Channel: "main"})
+
+	if err := DisableUpdateChecks(); err != nil {
+		t.Fatalf("DisableUpdateChecks returned error: %v", err)
+	}
+
+	prefs := readPrefsForTest(t, home)
+	if prefs.CheckUpdate == nil || *prefs.CheckUpdate {
+		t.Fatalf("check_update = %v, want false", prefs.CheckUpdate)
+	}
+	if prefs.Channel != "main" {
+		t.Fatalf("channel = %q, want main", prefs.Channel)
 	}
 }
 
@@ -889,6 +1054,7 @@ func TestCheckUpdateFlagLastWins(t *testing.T) {
 }
 
 func TestUpdateChannelStopsAtDoubleDash(t *testing.T) {
+	tempHome(t)
 	tests := []struct {
 		name string
 		args []string

--- a/support-docs/CONFIGURATION.md
+++ b/support-docs/CONFIGURATION.md
@@ -34,6 +34,22 @@ Use `--force` to refresh existing global files after an upgrade. Use
 `--agent-tools <path>` to install a custom `AGENT_TOOLS.md` instead of the
 embedded default.
 
+## Update Preferences
+
+Interactive update preferences live in `~/.liza/update.json`. Explicit
+`--check-update` and `--update-channel` flags persist there so future
+interactive `liza` runs reuse the saved choice.
+
+| Key | Values | Purpose |
+|-----|--------|---------|
+| `check_update` | `true`, `false`, or unset | Enables or disables interactive update checks |
+| `channel` | `stable`, `main`, or unset | Selects release updates or main-branch updates |
+
+Command-line flags take precedence over saved preferences and update the file.
+`LIZA_UPDATE_CHANNEL` overrides the saved channel for that process. Saved
+`check_update` controls whether update checks run when no explicit flag is
+provided.
+
 ## Project Initialization (`liza init`)
 
 Run `liza init` in each project where Liza should activate the contract. The


### PR DESCRIPTION
## Summary
- persist explicit --check-update and --update-channel values to ~/.liza/update.json
- treat update-only flag invocations as settings writes, with a concise confirmation instead of the root help banner
- load saved check/channel preferences for future interactive update checks and document the settings file

## Verification
- go test ./internal/updater
- go test ./internal/updater ./cmd/liza
- make build
- HOME=$(mktemp -d) ./liza --check-update --update-channel=main, verified exit 0, no stderr, confirmation output, and ~/.liza/update.json contents
- make test failed with existing global git config core.excludesFile=/Users/livio/.gitignore_global leaking into worktree exclude tests
- GIT_CONFIG_GLOBAL=/dev/null make test passed
