### PR TITLE
feat(trovex): integrate Trovex MCP server for doc search

### DIFF
--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -18,16 +18,18 @@ import (
 	"github.com/liza-mas/liza/internal/scipsearch"
 	"github.com/liza-mas/liza/internal/semble"
 	"github.com/liza-mas/liza/internal/stacklit"
+	"github.com/liza-mas/liza/internal/trovex"
 )
 
 var (
 	buildSemblePromptMetadata = semble.BuildPromptMetadata
+	buildTrovexPromptMetadata = trovex.BuildPromptMetadata
 	scipAvailableIndexes      = scipsearch.AvailableIndexes
 	stacklitAvailableIndexes  = stacklit.AvailableIndexes
 )
 
 // baseConfigFrom constructs the BasePromptConfig shared by all roles.
-func baseConfigFrom(state *models.State, config SupervisorConfig, taskID string, scipIndexes []prompts.ScipSearchIndex, stacklitIndexes []prompts.StacklitIndex, sembleSearch prompts.SembleSearchMetadata) prompts.BasePromptConfig {
+func baseConfigFrom(state *models.State, config SupervisorConfig, taskID string, scipIndexes []prompts.ScipSearchIndex, stacklitIndexes []prompts.StacklitIndex, sembleSearch prompts.SembleSearchMetadata, trovexSearch prompts.TrovexSearchMetadata) prompts.BasePromptConfig {
 	return prompts.BasePromptConfig{
 		Role:              config.Role,
 		AgentID:           config.AgentID,
@@ -40,6 +42,7 @@ func baseConfigFrom(state *models.State, config SupervisorConfig, taskID string,
 		ScipSearchIndexes: scipIndexes,
 		StacklitIndexes:   stacklitIndexes,
 		SembleSearch:      sembleSearch,
+		TrovexSearch:      trovexSearch,
 	}
 }
 
@@ -63,6 +66,7 @@ func buildPromptWithContext(state *models.State, config SupervisorConfig, taskID
 		toBasePromptScipSearchIndexes(data.ScipIndexes),
 		toBasePromptStacklitIndexes(data.StacklitIndexes),
 		availablePromptSembleSearchMetadata(data.Worktree, semble.TargetKindTaskWorktree),
+		availablePromptTrovexSearchMetadata(data.Worktree),
 	))
 	if err != nil {
 		return "", fmt.Errorf("building base prompt: %w", err)
@@ -106,6 +110,7 @@ func buildOrchestratorPromptContext(state *models.State, config SupervisorConfig
 		toBasePromptScipSearchIndexes(data.ScipIndexes),
 		toBasePromptStacklitIndexes(data.StacklitIndexes),
 		availablePromptSembleSearchMetadata(config.ProjectRoot, semble.TargetKindProjectRoot),
+		availablePromptTrovexSearchMetadata(config.ProjectRoot),
 	))
 	if err != nil {
 		return "", fmt.Errorf("building base prompt: %w", err)
@@ -253,6 +258,22 @@ func availablePromptSembleSearchMetadata(targetRoot string, kind semble.TargetKi
 		return prompts.SembleSearchMetadata{}
 	}
 	return prompts.SembleSearchMetadata{
+		TargetRoot:      metadata.TargetRoot,
+		ShellTargetRoot: metadata.ShellTargetRoot,
+	}
+}
+
+func availablePromptTrovexSearchMetadata(targetRoot string) prompts.TrovexSearchMetadata {
+	if targetRoot == "" {
+		return prompts.TrovexSearchMetadata{}
+	}
+	metadata, ok := buildTrovexPromptMetadata(trovex.PromptMetadataOptions{
+		TargetRoot: targetRoot,
+	})
+	if !ok {
+		return prompts.TrovexSearchMetadata{}
+	}
+	return prompts.TrovexSearchMetadata{
 		TargetRoot:      metadata.TargetRoot,
 		ShellTargetRoot: metadata.ShellTargetRoot,
 	}

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/liza-mas/liza/internal/scipsearch"
 	"github.com/liza-mas/liza/internal/semble"
 	"github.com/liza-mas/liza/internal/stacklit"
+	"github.com/liza-mas/liza/internal/trovex"
 )
 
 var (
@@ -215,6 +216,16 @@ func InitPairingCommand(params InitPairingParams) error {
 	if projectRoot != "" {
 		if err := embedded.CleanStaleMCPEntry(projectRoot); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to clean stale .mcp.json entry: %v\n", err)
+		}
+	}
+
+	// Write trovex MCP server entry and default .trovexignore when trovex is enabled
+	if projectRoot != "" && trovex.RuntimeEnabled() {
+		if err := embedded.WriteTrovexMCPEntry(projectRoot, trovex.MCPEndpointURL(trovex.DefaultServePort)); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write trovex .mcp.json entry: %v\n", err)
+		}
+		if err := embedded.WriteTrovexIgnore(projectRoot); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write .trovexignore: %v\n", err)
 		}
 	}
 
@@ -824,6 +835,16 @@ func InitCommandWithConfig(params InitParams) error {
 	// Remove stale liza MCP server entry from .mcp.json (written by older Liza versions)
 	if err := embedded.CleanStaleMCPEntry(lizaPaths.ProjectRoot()); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to clean stale .mcp.json entry: %v\n", err)
+	}
+
+	// Write trovex MCP server entry and default .trovexignore when trovex is enabled
+	if trovex.RuntimeEnabled() {
+		if err := embedded.WriteTrovexMCPEntry(lizaPaths.ProjectRoot(), trovex.MCPEndpointURL(trovex.DefaultServePort)); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write trovex .mcp.json entry: %v\n", err)
+		}
+		if err := embedded.WriteTrovexIgnore(lizaPaths.ProjectRoot()); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write .trovexignore: %v\n", err)
+		}
 	}
 
 	// Create contract symlinks only for explicitly requested providers

--- a/internal/embedded/claude-settings.json
+++ b/internal/embedded/claude-settings.json
@@ -52,10 +52,30 @@
         ]
       },
       {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/trovex-md-read-guard.sh\"",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      },
+      {
         "matcher": "Write",
         "hooks": [
           {
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-path-guard.sh\"",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/trovex-md-guard.sh\"",
             "timeout": 5,
             "type": "command"
           }
@@ -72,10 +92,30 @@
         ]
       },
       {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/trovex-md-guard.sh\"",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      },
+      {
         "matcher": "MultiEdit",
         "hooks": [
           {
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-path-guard.sh\"",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/trovex-md-guard.sh\"",
             "timeout": 5,
             "type": "command"
           }
@@ -150,6 +190,12 @@
       "mcp__morph-mcp__codebase_search",
       "mcp__morph-mcp__edit_file",
       "mcp__perplexity__perplexity_ask",
+      "mcp__trovex__trovex",
+      "mcp__trovex__trovex_write",
+      "mcp__trovex__trovex_read",
+      "mcp__trovex__trovex_search",
+      "mcp__trovex__trovex_tag",
+      "mcp__trovex__trovex_delete",
 
       "Bash(liza:*)",
       "Bash(curl:*)",

--- a/internal/embedded/codex-hooks.json
+++ b/internal/embedded/codex-hooks.json
@@ -45,6 +45,28 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "matcher": "^apply_patch$|^mcp__filesystem__write_file$|^mcp__morph-mcp__edit_file$",
+        "hooks": [
+          {
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; hook=\"$root/.codex/hooks/trovex-md-guard.sh\"; [ -x \"$hook\" ] || exit 0; bash \"$hook\"",
+            "statusMessage": "Checking trovex doc routing",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__filesystem__read_file$|^mcp__filesystem__read_multiple_files$",
+        "hooks": [
+          {
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; hook=\"$root/.codex/hooks/trovex-md-read-guard.sh\"; [ -x \"$hook\" ] || exit 0; bash \"$hook\"",
+            "statusMessage": "Checking trovex doc routing",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
       }
     ]
   }

--- a/internal/embedded/embedded.go
+++ b/internal/embedded/embedded.go
@@ -65,6 +65,12 @@ var rtkGuardHookContent []byte
 //go:embed "hooks/worktree-path-guard.sh"
 var worktreePathGuardHookContent []byte
 
+//go:embed "hooks/trovex-md-guard.sh"
+var trovexMdGuardHookContent []byte
+
+//go:embed "hooks/trovex-md-read-guard.sh"
+var trovexMdReadGuardHookContent []byte
+
 // Git-level pre-commit hook for task worktrees. Deliberately NOT in hooks/
 // — that directory holds Claude Code PreToolUse hooks that get written to
 // .claude/hooks/ and referenced from claude-settings.json. This one is a
@@ -1088,6 +1094,77 @@ func CleanStaleMCPEntry(projectRoot string) error {
 	return os.WriteFile(mcpPath, append(output, '\n'), 0644)
 }
 
+// WriteTrovexMCPEntry writes or merges a trovex MCP server entry into
+// .mcp.json at the project root. The entry uses streamable-http transport
+// pointing at the given endpoint URL. Existing non-trovex entries are preserved.
+func WriteTrovexMCPEntry(projectRoot, endpointURL string) error {
+	mcpPath := filepath.Join(projectRoot, ".mcp.json")
+	var doc map[string]any
+
+	if data, err := os.ReadFile(mcpPath); err == nil {
+		if err := json.Unmarshal(data, &doc); err != nil {
+			doc = make(map[string]any)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("reading .mcp.json: %w", err)
+	} else {
+		doc = make(map[string]any)
+	}
+
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = make(map[string]any)
+	}
+	servers["trovex"] = map[string]any{
+		"url": endpointURL,
+	}
+	doc["mcpServers"] = servers
+
+	output, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling .mcp.json: %w", err)
+	}
+	return os.WriteFile(mcpPath, append(output, '\n'), 0644)
+}
+
+// defaultTrovexIgnorePatterns lists file patterns that should be read/written
+// directly on disk rather than routed through trovex MCP tools. These are
+// operational files that agents read at startup or that git tracks as config.
+var defaultTrovexIgnorePatterns = []string{
+	"CLAUDE.md",
+	"CLAUDE.local.md",
+	"AGENTS.md",
+	"GEMINI.md",
+	"GUARDRAILS.md",
+	"REPOSITORY.md",
+	"README.md",
+	"CONTRIBUTING.md",
+	"CHANGELOG.md",
+	"LICENSE.md",
+	".liza/*.md",
+	".liza/**/*.md",
+	"specs/**/*.md",
+	"docs/USAGE.md",
+}
+
+// WriteTrovexIgnore writes a default .trovexignore to the project root.
+// Only writes if the file doesn't already exist.
+func WriteTrovexIgnore(projectRoot string) error {
+	ignorePath := filepath.Join(projectRoot, ".trovexignore")
+	if _, err := os.Stat(ignorePath); err == nil {
+		return nil
+	}
+
+	var buf strings.Builder
+	buf.WriteString("# Files exempt from trovex MCP routing (read/written directly on disk).\n")
+	buf.WriteString("# Patterns use shell glob syntax against repo-relative paths.\n\n")
+	for _, pattern := range defaultTrovexIgnorePatterns {
+		buf.WriteString(pattern)
+		buf.WriteByte('\n')
+	}
+	return os.WriteFile(ignorePath, []byte(buf.String()), 0644)
+}
+
 // mergeSettings merges liza settings into existing settings.
 // Existing settings take precedence (user customizations preserved).
 // Special handling for permissions.allow (union) and hooks.PreToolUse (union).
@@ -1380,11 +1457,13 @@ func WriteHooks(projectRoot string) error {
 	}
 
 	for name, content := range map[string][]byte{
-		"enforce-init.sh":        enforceInitHookContent,
-		"session-context.sh":     sessionContextHookContent,
-		"git-guard.sh":           gitGuardHookContent,
-		"rtk-guard.sh":           rtkGuardHookContent,
-		"worktree-path-guard.sh": worktreePathGuardHookContent,
+		"enforce-init.sh":          enforceInitHookContent,
+		"session-context.sh":       sessionContextHookContent,
+		"git-guard.sh":             gitGuardHookContent,
+		"rtk-guard.sh":             rtkGuardHookContent,
+		"worktree-path-guard.sh":   worktreePathGuardHookContent,
+		"trovex-md-guard.sh":       trovexMdGuardHookContent,
+		"trovex-md-read-guard.sh":  trovexMdReadGuardHookContent,
 	} {
 		hookPath := filepath.Join(hooksDir, name)
 		if err := os.WriteFile(hookPath, content, 0755); err != nil {
@@ -1404,10 +1483,12 @@ func WriteCodexHooks(projectRoot string) error {
 	}
 
 	for name, content := range map[string][]byte{
-		"enforce-init.sh":        enforceInitHookContent,
-		"session-context.sh":     sessionContextHookContent,
-		"git-guard.sh":           gitGuardHookContent,
-		"worktree-path-guard.sh": worktreePathGuardHookContent,
+		"enforce-init.sh":          enforceInitHookContent,
+		"session-context.sh":       sessionContextHookContent,
+		"git-guard.sh":             gitGuardHookContent,
+		"worktree-path-guard.sh":   worktreePathGuardHookContent,
+		"trovex-md-guard.sh":       trovexMdGuardHookContent,
+		"trovex-md-read-guard.sh":  trovexMdReadGuardHookContent,
 	} {
 		hookPath := filepath.Join(hooksDir, name)
 		if err := os.WriteFile(hookPath, content, 0755); err != nil {

--- a/internal/embedded/embedded_test.go
+++ b/internal/embedded/embedded_test.go
@@ -2516,3 +2516,102 @@ func TestCleanStaleMCPEntry(t *testing.T) {
 		}
 	})
 }
+
+func TestWriteTrovexMCPEntry(t *testing.T) {
+	t.Run("creates new file", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := WriteTrovexMCPEntry(dir, "http://localhost:8765/mcp"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+		if err != nil {
+			t.Fatalf("file not created: %v", err)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		servers := doc["mcpServers"].(map[string]any)
+		entry := servers["trovex"].(map[string]any)
+		if entry["url"] != "http://localhost:8765/mcp" {
+			t.Errorf("url = %v, want http://localhost:8765/mcp", entry["url"])
+		}
+	})
+
+	t.Run("preserves existing entries", func(t *testing.T) {
+		dir := t.TempDir()
+		mcpPath := filepath.Join(dir, ".mcp.json")
+		os.WriteFile(mcpPath, []byte(`{"mcpServers": {"other": {"command": "x"}}}`), 0644)
+
+		if err := WriteTrovexMCPEntry(dir, "http://localhost:9000/mcp"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, _ := os.ReadFile(mcpPath)
+		var doc map[string]any
+		json.Unmarshal(data, &doc)
+		servers := doc["mcpServers"].(map[string]any)
+		if _, hasOther := servers["other"]; !hasOther {
+			t.Error("other entry should be preserved")
+		}
+		entry := servers["trovex"].(map[string]any)
+		if entry["url"] != "http://localhost:9000/mcp" {
+			t.Errorf("url = %v, want http://localhost:9000/mcp", entry["url"])
+		}
+	})
+
+	t.Run("updates existing trovex entry", func(t *testing.T) {
+		dir := t.TempDir()
+		mcpPath := filepath.Join(dir, ".mcp.json")
+		os.WriteFile(mcpPath, []byte(`{"mcpServers": {"trovex": {"url": "http://old:1234/mcp"}}}`), 0644)
+
+		if err := WriteTrovexMCPEntry(dir, "http://localhost:8765/mcp"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, _ := os.ReadFile(mcpPath)
+		var doc map[string]any
+		json.Unmarshal(data, &doc)
+		servers := doc["mcpServers"].(map[string]any)
+		entry := servers["trovex"].(map[string]any)
+		if entry["url"] != "http://localhost:8765/mcp" {
+			t.Errorf("url = %v, want http://localhost:8765/mcp", entry["url"])
+		}
+	})
+}
+
+func TestWriteTrovexIgnore(t *testing.T) {
+	t.Run("creates file with default patterns", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := WriteTrovexIgnore(dir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, ".trovexignore"))
+		if err != nil {
+			t.Fatalf("file not created: %v", err)
+		}
+		content := string(data)
+		for _, pattern := range []string{"CLAUDE.md", "GUARDRAILS.md", "README.md", ".liza/*.md", "specs/**/*.md"} {
+			if !strings.Contains(content, pattern) {
+				t.Errorf("missing pattern %q in .trovexignore", pattern)
+			}
+		}
+	})
+
+	t.Run("does not overwrite existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		ignorePath := filepath.Join(dir, ".trovexignore")
+		os.WriteFile(ignorePath, []byte("custom\n"), 0644)
+
+		if err := WriteTrovexIgnore(dir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, _ := os.ReadFile(ignorePath)
+		if string(data) != "custom\n" {
+			t.Errorf("existing file was overwritten: got %q", string(data))
+		}
+	})
+}

--- a/internal/embedded/hooks/session-context.sh
+++ b/internal/embedded/hooks/session-context.sh
@@ -209,6 +209,26 @@ if truthy_env "${LIZA_ENABLE_SEMBLE:-}" && root_sembleignore_safe && semble_offl
   shell_project_dir=$(quote_for_shell "$project_dir")
 fi
 
+trovex_enabled=false
+if truthy_env "${LIZA_ENABLE_TROVEX:-}" && ! command -v trovex >/dev/null 2>&1; then
+  echo "Warning: LIZA_ENABLE_TROVEX is set but trovex is not installed. Run 'liza toolchain install' or 'uvx install trovex' to enable Trovex doc routing." >&2
+fi
+if truthy_env "${LIZA_ENABLE_TROVEX:-}" && command -v trovex >/dev/null 2>&1; then
+  trovex_url="${TROVEX_URL:-http://localhost:8765}"
+  if ! curl -fsS -m 1 "$trovex_url/healthz" >/dev/null 2>&1; then
+    trovex_log="${TMPDIR:-/tmp}/trovex-serve.log"
+    if [ -z "${TROVEX_EMBED_MODEL:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+      TROVEX_EMBED_MODEL="BAAI/bge-small-en-v1.5" TROVEX_EMBED_DIM="384" \
+        nohup trovex serve --port 8765 >> "$trovex_log" 2>&1 &
+    else
+      nohup trovex serve --port 8765 >> "$trovex_log" 2>&1 &
+    fi
+  fi
+  if curl -fsS -m 2 "$trovex_url/healthz" >/dev/null 2>&1; then
+    trovex_enabled=true
+  fi
+fi
+
 functional_clusters_enabled=false
 functional_clusters_path="$project_dir/functional-clusters.json"
 if truthy_env "${LIZA_ENABLE_FUNCTIONAL_CLUSTERS:-}" && [[ -f "$functional_clusters_path" ]]; then
@@ -221,7 +241,7 @@ if [[ -d "$project_dir/specs/architecture/ADR" ]]; then
   adr_dir_available=true
 fi
 
-if [[ -z "${shell_stacklit_path:-}" && "${#scip_files[@]}" -eq 0 && "$semble_enabled" != "true" && "$functional_clusters_enabled" != "true" && "$adr_dir_available" != "true" ]]; then
+if [[ -z "${shell_stacklit_path:-}" && "${#scip_files[@]}" -eq 0 && "$semble_enabled" != "true" && "$trovex_enabled" != "true" && "$functional_clusters_enabled" != "true" && "$adr_dir_available" != "true" ]]; then
   printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$(json_escape "$context")"
   exit 0
 fi
@@ -301,6 +321,17 @@ if [[ "$functional_clusters_enabled" == "true" ]]; then
  // functional-clusters list --clusters $shell_functional_clusters_path
  // functional-clusters explain --clusters $shell_functional_clusters_path '<exact-member-symbol>'
  // Functional clusters are advisory and may be stale; verify against source files before editing."
+fi
+
+if [[ "$trovex_enabled" == "true" ]]; then
+  context+="
+ // Trovex MCP server is running. Use trovex MCP tools for .md documentation:
+ // trovex(q) — find canonical docs for a query (token-minimal routing)
+ // trovex_search(query, k) — semantic chunk search with reranking
+ // trovex_read(query, doc_id, section) — read specific doc or section
+ // trovex_write(content, kind, doc_id, tags) — write/update docs in the store
+ // Hooks redirect .md read/write through trovex automatically.
+ // Files in .trovexignore are exempt and read/written raw."
 fi
 
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$(json_escape "$context")"

--- a/internal/embedded/hooks/trovex-md-guard.sh
+++ b/internal/embedded/hooks/trovex-md-guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# trovex-md-guard — Claude Code PreToolUse hook (write side).
+#
+# Routes Markdown writes through trovex MCP tools instead of the local disk so
+# every agent shares one indexed source of truth. Blocks Write/Edit/MultiEdit to
+# a *.md file unless its path is listed in .trovexignore, and tells the agent to
+# use the trovex_write MCP tool instead.
+#
+# Degrades to ALLOW when the trovex server is unreachable or jq is missing — a
+# trovex outage must never brick the agent.
+set -euo pipefail
+
+TROVEX_URL="${TROVEX_URL:-http://localhost:8765}"
+
+allow() { exit 0; }
+
+command -v jq >/dev/null 2>&1 || allow
+
+input="$(cat)"
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+case "$tool" in Write | Edit | MultiEdit) ;; *) allow ;; esac
+
+file="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+[ -n "$file" ] || allow
+case "$file" in *.md | *.mdx | *.markdown) ;; *) allow ;; esac
+
+# .trovexignore — exempt paths stay as real files on disk.
+root="$(git -C "$(dirname "$file")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+ignore="$root/.trovexignore"
+if [ -f "$ignore" ]; then
+  rel="${file#"$root"/}"
+  while IFS= read -r pat || [ -n "$pat" ]; do
+    [ -z "$pat" ] && continue
+    case "$pat" in \#*) continue ;; esac
+    # shellcheck disable=SC2254
+    case "$rel" in $pat) allow ;; esac
+    # shellcheck disable=SC2254
+    case "$file" in $pat) allow ;; esac
+  done <"$ignore"
+fi
+
+# Graceful degradation: trovex down → don't block.
+curl -fsS -m 2 "$TROVEX_URL/healthz" >/dev/null 2>&1 || allow
+
+reason="trovex centralizes docs — use the trovex_write MCP tool instead of writing '$file' to disk. To keep this file on disk, add its path to .trovexignore."
+
+jq -cn --arg r "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
+  }
+}'
+exit 0

--- a/internal/embedded/hooks/trovex-md-read-guard.sh
+++ b/internal/embedded/hooks/trovex-md-read-guard.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# trovex-md-read-guard — Claude Code PreToolUse hook (read side).
+#
+# Nudges agents to retrieve docs via trovex MCP tools (trovex_search,
+# trovex_read) instead of reading .md files raw off disk — reading raw means
+# stale content and no chunk-level token savings.
+# .trovexignore exempts files that should be read raw (README, CLAUDE.md, etc.).
+# Degrades to ALLOW when the trovex server is unreachable or jq is missing.
+set -euo pipefail
+
+TROVEX_URL="${TROVEX_URL:-http://localhost:8765}"
+
+allow() { exit 0; }
+
+command -v jq >/dev/null 2>&1 || allow
+
+input="$(cat)"
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+case "$tool" in Read) ;; *) allow ;; esac
+
+file="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+[ -n "$file" ] || allow
+case "$file" in *.md | *.mdx | *.markdown) ;; *) allow ;; esac
+
+# .trovexignore — exempt paths are read raw off disk.
+root="$(git -C "$(dirname "$file")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+ignore="$root/.trovexignore"
+if [ -f "$ignore" ]; then
+  rel="${file#"$root"/}"
+  while IFS= read -r pat || [ -n "$pat" ]; do
+    [ -z "$pat" ] && continue
+    case "$pat" in \#*) continue ;; esac
+    # shellcheck disable=SC2254
+    case "$rel" in $pat) allow ;; esac
+    # shellcheck disable=SC2254
+    case "$file" in $pat) allow ;; esac
+  done <"$ignore"
+fi
+
+# Graceful degradation: trovex down → don't block reads.
+curl -fsS -m 2 "$TROVEX_URL/healthz" >/dev/null 2>&1 || allow
+
+reason="trovex centralizes docs — use trovex MCP tools (trovex_search or trovex_read) instead of reading '$file' raw. To read this file directly, add its path to .trovexignore."
+
+jq -cn --arg r "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
+  }
+}'
+exit 0

--- a/internal/pairingindex/hooks.go
+++ b/internal/pairingindex/hooks.go
@@ -40,11 +40,12 @@ type InstallHooksOptions struct {
 }
 
 // InstallActivationOptions configures the combined pairing index activation hook
-// setup for Stacklit and SCIP project-root refresh.
+// setup for Stacklit, SCIP, and Trovex project-root refresh.
 type InstallActivationOptions struct {
 	RepoRoot       string
 	Hooks          []string
 	EnableStacklit bool
+	EnableTrovex   bool
 	ScipPlans      []scipsearch.LanguageAggregatePlan
 }
 
@@ -147,6 +148,7 @@ func InstallActivation(opts InstallActivationOptions) (InstallActivationResult, 
 	content, err := renderIndexScript(renderIndexScriptOptions{
 		RepoRoot:       opts.RepoRoot,
 		EnableStacklit: opts.EnableStacklit,
+		EnableTrovex:   opts.EnableTrovex,
 		ScipPlans:      opts.ScipPlans,
 	})
 	if err != nil {
@@ -244,6 +246,7 @@ func RenderIndexScript(repoRoot string) (string, error) {
 type renderIndexScriptOptions struct {
 	RepoRoot       string
 	EnableStacklit bool
+	EnableTrovex   bool
 	ScipPlans      []scipsearch.LanguageAggregatePlan
 }
 
@@ -317,6 +320,29 @@ else
 	fi
 fi
 `, shellWord(stacklitPlan.Name), stacklitPlan.Name, shellWord(stacklitPlan.Name), stacklitGenerateCommand, shellWord(stacklitPlan.Name), shellWord(stacklitPlan.Name), stacklitGenerateCommand))
+	}
+	if opts.EnableTrovex {
+		body.WriteString(`if ! command -v trovex >/dev/null 2>&1; then
+	echo "liza-index.sh: trovex not found; skipping Trovex refresh" >&2
+else
+	needs_trovex=0
+	trovex_db="${HOME}/.trovex-data/trovex.db"
+	if [ ! -f "$trovex_db" ]; then
+		needs_trovex=1
+	elif find "$repo_root" -name '*.md' -not -path '*/.git/*' -not -path '*/.worktrees/*' -not -path '*/node_modules/*' -newer "$trovex_db" -print -quit | grep -q .; then
+		needs_trovex=1
+	fi
+	if [ "$needs_trovex" = "1" ]; then
+		echo "Trovex Indexing..."
+		if [ -z "${TROVEX_EMBED_MODEL:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+			export TROVEX_EMBED_MODEL="BAAI/bge-small-en-v1.5"
+			export TROVEX_EMBED_DIM="384"
+		fi
+		trovex index "$repo_root"
+		echo "Trovex index updated"
+	fi
+fi
+`)
 	}
 	return body.String(), nil
 }

--- a/internal/prompts/builder.go
+++ b/internal/prompts/builder.go
@@ -24,6 +24,7 @@ type BasePromptConfig struct {
 	ScipSearchIndexes []ScipSearchIndex
 	StacklitIndexes   []StacklitIndex
 	SembleSearch      SembleSearchMetadata
+	TrovexSearch      TrovexSearchMetadata
 }
 
 // ScipSearchIndex is prompt-safe metadata for one successful generated SCIP index.
@@ -43,11 +44,18 @@ type SembleSearchMetadata struct {
 	ShellTargetRoot string
 }
 
+// TrovexSearchMetadata is prompt-safe metadata for Trovex documentation search.
+type TrovexSearchMetadata struct {
+	TargetRoot      string
+	ShellTargetRoot string
+}
+
 type basePromptTemplateData struct {
 	BasePromptConfig
 	ScipSearchIndexes []scipSearchPromptIndex
 	StacklitIndexes   []stacklitPromptIndex
 	SembleSearch      *SembleSearchMetadata
+	TrovexSearch      *TrovexSearchMetadata
 }
 
 type scipSearchPromptIndex struct {
@@ -80,11 +88,20 @@ func BuildBasePrompt(config BasePromptConfig) (string, error) {
 		ScipSearchIndexes: buildScipSearchPromptIndexes(config.ScipSearchIndexes),
 		StacklitIndexes:   buildStacklitPromptIndexes(config.StacklitIndexes),
 		SembleSearch:      buildSembleSearchPromptMetadata(config.SembleSearch),
+		TrovexSearch:      buildTrovexSearchPromptMetadata(config.TrovexSearch),
 	}
 	return executeTemplate("base_prompt", data)
 }
 
 func buildSembleSearchPromptMetadata(metadata SembleSearchMetadata) *SembleSearchMetadata {
+	if metadata.TargetRoot == "" || metadata.ShellTargetRoot == "" {
+		return nil
+	}
+	copy := metadata
+	return &copy
+}
+
+func buildTrovexSearchPromptMetadata(metadata TrovexSearchMetadata) *TrovexSearchMetadata {
 	if metadata.TargetRoot == "" || metadata.ShellTargetRoot == "" {
 		return nil
 	}

--- a/internal/prompts/templates/base_prompt.tmpl
+++ b/internal/prompts/templates/base_prompt.tmpl
@@ -142,4 +142,21 @@ Semble is available for semantic repository search in this target root:
 
 Use `~/.liza/AGENT_TOOLS.md` for Semble command syntax, content modes, routing rules, and proof requirements.
 {{- end }}
+
+{{- if .TrovexSearch }}
+
+=== TROVEX DOC SEARCH ===
+Trovex MCP server is available for markdown documentation search in this project:
+{{ .TrovexSearch.ShellTargetRoot }}
+
+Use Trovex MCP tools instead of reading .md files directly:
+- `trovex(q)` — find canonical docs for a query (token-minimal routing)
+- `trovex_search(query, k)` — semantic chunk search with reranking
+- `trovex_read(query, doc_id, section)` — read specific doc or section
+- `trovex_write(content, kind, doc_id, tags)` — write/update docs in the store
+
+Prefer Trovex MCP tools over `cat`/`Read` for .md files — they return targeted passages
+with freshness markers and save 50-80% of doc tokens. Hooks will redirect .md
+read/write operations through Trovex when the server is reachable.
+{{- end }}
 {{- end -}}

--- a/internal/toolchain/catalog.go
+++ b/internal/toolchain/catalog.go
@@ -184,6 +184,13 @@ func Catalog() []Tool {
 			VersionArgs: []string{"--version"}, FullDefault: true,
 			ActivationEnv: []string{"LIZA_ENABLE_BASH_POLICY=1"},
 		},
+		{
+			ID: "trovex", Name: "Trovex", Binary: "trovex", Category: CategoryNavigation,
+			Purpose:     "Routes markdown documentation queries to minimal relevant sections.",
+			InstallKind: InstallUVTool, UVPackage: "trovex",
+			VersionArgs: []string{"--help"}, ActivationEnv: []string{"LIZA_ENABLE_TROVEX=1"},
+			BalancedDefault: true, FullDefault: true,
+		},
 		manualTool("filesystem-mcp", "filesystem MCP", "Batch local filesystem reads through provider MCP configuration."),
 		manualTool("context7", "context7 MCP", "Structured current library documentation lookup through MCP."),
 		manualTool("ref", "Ref MCP", "Broad documentation and guide lookup through MCP."),

--- a/internal/trovex/doc.go
+++ b/internal/trovex/doc.go
@@ -1,0 +1,12 @@
+// Package trovex owns Liza's optional Trovex documentation search activation
+// and command-planning contracts.
+//
+// Runtime lifecycle callers use RuntimeEnabled, RefreshIndex, and
+// BuildPromptMetadata to guard Trovex integration with LIZA_ENABLE_TROVEX,
+// refresh the markdown documentation index for a target root, and produce
+// prompt-safe metadata for agent guidance. Trovex stores its index in
+// ~/.trovex-data/trovex.db; no project-local artifacts are created. When the
+// operator has not configured an explicit embedding model or OpenAI API key,
+// command plans default to the local fastembed model (BAAI/bge-small-en-v1.5)
+// so indexing works offline without external API credentials.
+package trovex

--- a/internal/trovex/trovex.go
+++ b/internal/trovex/trovex.go
@@ -1,0 +1,257 @@
+package trovex
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const EnvEnableTrovex = "LIZA_ENABLE_TROVEX"
+
+const DefaultServePort = 8765
+
+const (
+	trovexExecutableName   = "trovex"
+	defaultLocalEmbedModel = "BAAI/bge-small-en-v1.5"
+	defaultLocalEmbedDim   = "384"
+)
+
+const maxFailureDiagnosticBytes = 1024
+
+// ExecutableLookup resolves an executable name to the path that would be run.
+type ExecutableLookup func(name string) (string, error)
+
+// RuntimeCommandPlan describes a fixed Trovex command without executing it.
+type RuntimeCommandPlan struct {
+	Name string
+	Args []string
+	Dir  string
+	Env  []EnvVar
+}
+
+// EnvVar is one environment override for a Trovex subprocess.
+type EnvVar struct {
+	Name  string
+	Value string
+}
+
+// RuntimeRunner executes one Trovex runtime command plan.
+type RuntimeRunner func(RuntimeCommandPlan) (string, error)
+
+// RefreshOptions configures one best-effort runtime Trovex index refresh.
+type RefreshOptions struct {
+	TargetRoot string
+	Runner     RuntimeRunner
+}
+
+// RefreshResult contains the refresh outcome and isolated failure diagnostics.
+type RefreshResult struct {
+	Refreshed bool
+	Failures  []RefreshFailure
+}
+
+// RefreshFailure contains bounded diagnostics for a failed Trovex indexing.
+type RefreshFailure struct {
+	Diagnostic string
+}
+
+// PromptMetadataOptions configures prompt-safe Trovex metadata construction.
+type PromptMetadataOptions struct {
+	TargetRoot string
+	LookPath   ExecutableLookup
+}
+
+// PromptMetadata is safe for prompt rendering; it intentionally excludes
+// diagnostics, command output, and executable paths.
+type PromptMetadata struct {
+	TargetRoot      string
+	ShellTargetRoot string
+}
+
+var (
+	runnerMu      sync.Mutex
+	defaultRunner RuntimeRunner = runRuntimeCommandPlan
+)
+
+// SetRuntimeRunnerForTest replaces the process runner until the returned
+// restore function is called.
+func SetRuntimeRunnerForTest(runner RuntimeRunner) func() {
+	runnerMu.Lock()
+	previous := defaultRunner
+	defaultRunner = runner
+	runnerMu.Unlock()
+
+	return func() {
+		runnerMu.Lock()
+		defaultRunner = previous
+		runnerMu.Unlock()
+	}
+}
+
+// ParseEnvGate reports whether a supplied Trovex activation value is enabled.
+func ParseEnvGate(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true":
+		return true
+	default:
+		return false
+	}
+}
+
+// RuntimeEnabled reports whether Trovex behavior is active for this process.
+func RuntimeEnabled() bool {
+	return ParseEnvGate(os.Getenv(EnvEnableTrovex))
+}
+
+// PlanIndexCommand returns the fixed Trovex index command for a target root
+// without executing it. When the operator has not configured an explicit
+// embedding model or OpenAI API key, local fastembed environment overrides are
+// included so indexing works offline.
+func PlanIndexCommand(targetRoot string) (RuntimeCommandPlan, error) {
+	targetRoot, err := filepath.Abs(targetRoot)
+	if err != nil {
+		return RuntimeCommandPlan{}, fmt.Errorf("resolve trovex target root: %w", err)
+	}
+	return RuntimeCommandPlan{
+		Name: trovexExecutableName,
+		Args: []string{"index", targetRoot},
+		Dir:  targetRoot,
+		Env:  localEmbeddingFallbackEnv(),
+	}, nil
+}
+
+// RefreshIndex runs trovex index for one target root. When disabled it returns
+// an empty result. On execution failure it captures bounded diagnostics without
+// propagating the error.
+func RefreshIndex(opts RefreshOptions) (RefreshResult, error) {
+	if !RuntimeEnabled() {
+		return RefreshResult{}, nil
+	}
+
+	plan, err := PlanIndexCommand(opts.TargetRoot)
+	if err != nil {
+		return RefreshResult{}, err
+	}
+
+	runner := opts.Runner
+	if runner == nil {
+		runner = getDefaultRunner()
+	}
+
+	output, err := runner(plan)
+	if err != nil {
+		return RefreshResult{
+			Failures: []RefreshFailure{{Diagnostic: boundedFailureDiagnostic(err, output)}},
+		}, nil
+	}
+	return RefreshResult{Refreshed: true}, nil
+}
+
+// BuildPromptMetadata returns prompt-safe Trovex context when activation and
+// CLI availability both pass.
+func BuildPromptMetadata(opts PromptMetadataOptions) (PromptMetadata, bool) {
+	if !RuntimeEnabled() {
+		return PromptMetadata{}, false
+	}
+
+	targetRoot, err := filepath.Abs(opts.TargetRoot)
+	if err != nil {
+		return PromptMetadata{}, false
+	}
+
+	lookup := opts.LookPath
+	if lookup == nil {
+		lookup = exec.LookPath
+	}
+	if _, err := lookup(trovexExecutableName); err != nil {
+		return PromptMetadata{}, false
+	}
+
+	return PromptMetadata{
+		TargetRoot:      targetRoot,
+		ShellTargetRoot: shellQuote(targetRoot),
+	}, true
+}
+
+// PlanServeCommand returns the fixed Trovex MCP server command for the given
+// port without executing it.
+func PlanServeCommand(port int) RuntimeCommandPlan {
+	if port <= 0 {
+		port = DefaultServePort
+	}
+	return RuntimeCommandPlan{
+		Name: trovexExecutableName,
+		Args: []string{"serve", "--port", fmt.Sprintf("%d", port)},
+	}
+}
+
+// MCPEndpointURL returns the MCP endpoint URL for a locally running Trovex
+// server at the given port.
+func MCPEndpointURL(port int) string {
+	if port <= 0 {
+		port = DefaultServePort
+	}
+	return fmt.Sprintf("http://localhost:%d/mcp", port)
+}
+
+// HealthCheckURL returns the health check URL for a locally running Trovex
+// server at the given port.
+func HealthCheckURL(port int) string {
+	if port <= 0 {
+		port = DefaultServePort
+	}
+	return fmt.Sprintf("http://localhost:%d/healthz", port)
+}
+
+func localEmbeddingFallbackEnv() []EnvVar {
+	if os.Getenv("TROVEX_EMBED_MODEL") != "" || os.Getenv("OPENAI_API_KEY") != "" {
+		return nil
+	}
+	return []EnvVar{
+		{Name: "TROVEX_EMBED_MODEL", Value: defaultLocalEmbedModel},
+		{Name: "TROVEX_EMBED_DIM", Value: defaultLocalEmbedDim},
+	}
+}
+
+func getDefaultRunner() RuntimeRunner {
+	runnerMu.Lock()
+	defer runnerMu.Unlock()
+	return defaultRunner
+}
+
+func runRuntimeCommandPlan(plan RuntimeCommandPlan) (string, error) {
+	cmd := exec.Command(plan.Name, plan.Args...)
+	cmd.Dir = plan.Dir
+	if len(plan.Env) > 0 {
+		cmd.Env = append(os.Environ(), envVars(plan.Env)...)
+	}
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func envVars(vars []EnvVar) []string {
+	values := make([]string, 0, len(vars))
+	for _, env := range vars {
+		values = append(values, env.Name+"="+env.Value)
+	}
+	return values
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func boundedFailureDiagnostic(err error, output string) string {
+	diagnostic := strings.TrimSpace(err.Error())
+	output = strings.TrimSpace(output)
+	if output != "" {
+		diagnostic += ": " + output
+	}
+	if len(diagnostic) <= maxFailureDiagnosticBytes {
+		return diagnostic
+	}
+	return diagnostic[:maxFailureDiagnosticBytes] + "...(truncated)"
+}

--- a/internal/trovex/trovex_test.go
+++ b/internal/trovex/trovex_test.go
@@ -1,0 +1,355 @@
+package trovex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseEnvGate(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{" true ", true},
+		{" 1 ", true},
+		{"0", false},
+		{"false", false},
+		{"", false},
+		{"yes", false},
+		{"on", false},
+	}
+	for _, tt := range tests {
+		if got := ParseEnvGate(tt.input); got != tt.want {
+			t.Errorf("ParseEnvGate(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestRuntimeEnabled(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		if !RuntimeEnabled() {
+			t.Error("RuntimeEnabled() = false, want true")
+		}
+	})
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "0")
+		if RuntimeEnabled() {
+			t.Error("RuntimeEnabled() = true, want false")
+		}
+	})
+	t.Run("unset", func(t *testing.T) {
+		if v, ok := os.LookupEnv(EnvEnableTrovex); ok {
+			t.Setenv(EnvEnableTrovex, v)
+			os.Unsetenv(EnvEnableTrovex)
+			defer os.Setenv(EnvEnableTrovex, v)
+		}
+		if RuntimeEnabled() {
+			t.Error("RuntimeEnabled() = true, want false when unset")
+		}
+	})
+}
+
+func TestPlanIndexCommand(t *testing.T) {
+	t.Run("valid_path", func(t *testing.T) {
+		dir := t.TempDir()
+		plan, err := PlanIndexCommand(dir)
+		if err != nil {
+			t.Fatalf("PlanIndexCommand(%q) error: %v", dir, err)
+		}
+		if plan.Name != trovexExecutableName {
+			t.Errorf("plan.Name = %q, want %q", plan.Name, trovexExecutableName)
+		}
+		if len(plan.Args) != 2 || plan.Args[0] != "index" {
+			t.Errorf("plan.Args = %v, want [index <abs-path>]", plan.Args)
+		}
+		if !filepath.IsAbs(plan.Args[1]) {
+			t.Errorf("plan.Args[1] = %q, want absolute path", plan.Args[1])
+		}
+		if !filepath.IsAbs(plan.Dir) {
+			t.Errorf("plan.Dir = %q, want absolute path", plan.Dir)
+		}
+	})
+
+	t.Run("local_embedding_fallback_no_config", func(t *testing.T) {
+		t.Setenv("TROVEX_EMBED_MODEL", "")
+		t.Setenv("OPENAI_API_KEY", "")
+		os.Unsetenv("TROVEX_EMBED_MODEL")
+		os.Unsetenv("OPENAI_API_KEY")
+
+		dir := t.TempDir()
+		plan, err := PlanIndexCommand(dir)
+		if err != nil {
+			t.Fatalf("PlanIndexCommand error: %v", err)
+		}
+		if len(plan.Env) != 2 {
+			t.Fatalf("plan.Env length = %d, want 2", len(plan.Env))
+		}
+		if plan.Env[0].Name != "TROVEX_EMBED_MODEL" || plan.Env[0].Value != defaultLocalEmbedModel {
+			t.Errorf("plan.Env[0] = %+v, want TROVEX_EMBED_MODEL=%s", plan.Env[0], defaultLocalEmbedModel)
+		}
+		if plan.Env[1].Name != "TROVEX_EMBED_DIM" || plan.Env[1].Value != defaultLocalEmbedDim {
+			t.Errorf("plan.Env[1] = %+v, want TROVEX_EMBED_DIM=%s", plan.Env[1], defaultLocalEmbedDim)
+		}
+	})
+
+	t.Run("local_embedding_fallback_with_openai_key", func(t *testing.T) {
+		t.Setenv("OPENAI_API_KEY", "sk-test")
+
+		dir := t.TempDir()
+		plan, err := PlanIndexCommand(dir)
+		if err != nil {
+			t.Fatalf("PlanIndexCommand error: %v", err)
+		}
+		if len(plan.Env) != 0 {
+			t.Errorf("plan.Env = %v, want empty when OPENAI_API_KEY is set", plan.Env)
+		}
+	})
+
+	t.Run("local_embedding_fallback_with_explicit_model", func(t *testing.T) {
+		t.Setenv("TROVEX_EMBED_MODEL", "text-embedding-3-small")
+
+		dir := t.TempDir()
+		plan, err := PlanIndexCommand(dir)
+		if err != nil {
+			t.Fatalf("PlanIndexCommand error: %v", err)
+		}
+		if len(plan.Env) != 0 {
+			t.Errorf("plan.Env = %v, want empty when TROVEX_EMBED_MODEL is set", plan.Env)
+		}
+	})
+}
+
+func TestRefreshIndex(t *testing.T) {
+	t.Run("disabled_noop", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "0")
+		result, err := RefreshIndex(RefreshOptions{TargetRoot: t.TempDir()})
+		if err != nil {
+			t.Fatalf("RefreshIndex error: %v", err)
+		}
+		if result.Refreshed {
+			t.Error("result.Refreshed = true, want false when disabled")
+		}
+		if len(result.Failures) != 0 {
+			t.Errorf("result.Failures = %v, want empty when disabled", result.Failures)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		dir := t.TempDir()
+
+		result, err := RefreshIndex(RefreshOptions{
+			TargetRoot: dir,
+			Runner:     func(_ RuntimeCommandPlan) (string, error) { return "indexed 5 docs", nil },
+		})
+		if err != nil {
+			t.Fatalf("RefreshIndex error: %v", err)
+		}
+		if !result.Refreshed {
+			t.Error("result.Refreshed = false, want true")
+		}
+		if len(result.Failures) != 0 {
+			t.Errorf("result.Failures = %v, want empty on success", result.Failures)
+		}
+	})
+
+	t.Run("failure_captured", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		dir := t.TempDir()
+
+		result, err := RefreshIndex(RefreshOptions{
+			TargetRoot: dir,
+			Runner: func(_ RuntimeCommandPlan) (string, error) {
+				return "database locked", errors.New("exit status 1")
+			},
+		})
+		if err != nil {
+			t.Fatalf("RefreshIndex returned hard error: %v", err)
+		}
+		if result.Refreshed {
+			t.Error("result.Refreshed = true, want false on failure")
+		}
+		if len(result.Failures) != 1 {
+			t.Fatalf("result.Failures length = %d, want 1", len(result.Failures))
+		}
+		if !strings.Contains(result.Failures[0].Diagnostic, "exit status 1") {
+			t.Errorf("diagnostic = %q, want to contain 'exit status 1'", result.Failures[0].Diagnostic)
+		}
+		if !strings.Contains(result.Failures[0].Diagnostic, "database locked") {
+			t.Errorf("diagnostic = %q, want to contain 'database locked'", result.Failures[0].Diagnostic)
+		}
+	})
+
+	t.Run("failure_diagnostic_bounded", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		dir := t.TempDir()
+		longOutput := strings.Repeat("x", maxFailureDiagnosticBytes+500)
+
+		result, err := RefreshIndex(RefreshOptions{
+			TargetRoot: dir,
+			Runner:     func(_ RuntimeCommandPlan) (string, error) { return longOutput, errors.New("fail") },
+		})
+		if err != nil {
+			t.Fatalf("RefreshIndex returned hard error: %v", err)
+		}
+		if len(result.Failures) != 1 {
+			t.Fatalf("result.Failures length = %d, want 1", len(result.Failures))
+		}
+		if len(result.Failures[0].Diagnostic) > maxFailureDiagnosticBytes+20 {
+			t.Errorf("diagnostic length = %d, want bounded near %d", len(result.Failures[0].Diagnostic), maxFailureDiagnosticBytes)
+		}
+	})
+
+	t.Run("runner_receives_plan", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		dir := t.TempDir()
+
+		var captured RuntimeCommandPlan
+		_, _ = RefreshIndex(RefreshOptions{
+			TargetRoot: dir,
+			Runner: func(plan RuntimeCommandPlan) (string, error) {
+				captured = plan
+				return "", nil
+			},
+		})
+		if captured.Name != trovexExecutableName {
+			t.Errorf("captured.Name = %q, want %q", captured.Name, trovexExecutableName)
+		}
+		if len(captured.Args) < 2 || captured.Args[0] != "index" {
+			t.Errorf("captured.Args = %v, want [index ...]", captured.Args)
+		}
+	})
+}
+
+func TestBuildPromptMetadata(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "0")
+		_, ok := BuildPromptMetadata(PromptMetadataOptions{TargetRoot: t.TempDir()})
+		if ok {
+			t.Error("BuildPromptMetadata returned ok=true when disabled")
+		}
+	})
+
+	t.Run("cli_not_found", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		_, ok := BuildPromptMetadata(PromptMetadataOptions{
+			TargetRoot: t.TempDir(),
+			LookPath:   func(string) (string, error) { return "", errors.New("not found") },
+		})
+		if ok {
+			t.Error("BuildPromptMetadata returned ok=true when CLI missing")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		dir := t.TempDir()
+		meta, ok := BuildPromptMetadata(PromptMetadataOptions{
+			TargetRoot: dir,
+			LookPath:   func(string) (string, error) { return "/usr/local/bin/trovex", nil },
+		})
+		if !ok {
+			t.Fatal("BuildPromptMetadata returned ok=false, want true")
+		}
+		if !filepath.IsAbs(meta.TargetRoot) {
+			t.Errorf("meta.TargetRoot = %q, want absolute path", meta.TargetRoot)
+		}
+		if !strings.HasPrefix(meta.ShellTargetRoot, "'") {
+			t.Errorf("meta.ShellTargetRoot = %q, want shell-quoted", meta.ShellTargetRoot)
+		}
+	})
+
+	t.Run("empty_target_root", func(t *testing.T) {
+		t.Setenv(EnvEnableTrovex, "1")
+		_, ok := BuildPromptMetadata(PromptMetadataOptions{
+			TargetRoot: "",
+			LookPath:   func(string) (string, error) { return "/usr/local/bin/trovex", nil },
+		})
+		// filepath.Abs("") returns cwd, which is valid — so this should succeed
+		if !ok {
+			t.Log("BuildPromptMetadata returned ok=false for empty root (cwd fallback)")
+		}
+	})
+}
+
+func TestPlanServeCommand(t *testing.T) {
+	t.Run("default_port", func(t *testing.T) {
+		plan := PlanServeCommand(0)
+		if plan.Name != trovexExecutableName {
+			t.Errorf("plan.Name = %q, want %q", plan.Name, trovexExecutableName)
+		}
+		if len(plan.Args) != 3 || plan.Args[0] != "serve" || plan.Args[1] != "--port" || plan.Args[2] != "8765" {
+			t.Errorf("plan.Args = %v, want [serve --port 8765]", plan.Args)
+		}
+	})
+
+	t.Run("custom_port", func(t *testing.T) {
+		plan := PlanServeCommand(9999)
+		if plan.Args[2] != "9999" {
+			t.Errorf("plan.Args[2] = %q, want %q", plan.Args[2], "9999")
+		}
+	})
+}
+
+func TestMCPEndpointURL(t *testing.T) {
+	tests := []struct {
+		port int
+		want string
+	}{
+		{0, "http://localhost:8765/mcp"},
+		{8765, "http://localhost:8765/mcp"},
+		{9000, "http://localhost:9000/mcp"},
+	}
+	for _, tt := range tests {
+		if got := MCPEndpointURL(tt.port); got != tt.want {
+			t.Errorf("MCPEndpointURL(%d) = %q, want %q", tt.port, got, tt.want)
+		}
+	}
+}
+
+func TestHealthCheckURL(t *testing.T) {
+	tests := []struct {
+		port int
+		want string
+	}{
+		{0, "http://localhost:8765/healthz"},
+		{8765, "http://localhost:8765/healthz"},
+		{9000, "http://localhost:9000/healthz"},
+	}
+	for _, tt := range tests {
+		if got := HealthCheckURL(tt.port); got != tt.want {
+			t.Errorf("HealthCheckURL(%d) = %q, want %q", tt.port, got, tt.want)
+		}
+	}
+}
+
+func TestSetRuntimeRunnerForTest(t *testing.T) {
+	t.Setenv(EnvEnableTrovex, "1")
+	dir := t.TempDir()
+
+	var called bool
+	restore := SetRuntimeRunnerForTest(func(_ RuntimeCommandPlan) (string, error) {
+		called = true
+		return "mock", nil
+	})
+	defer restore()
+
+	result, err := RefreshIndex(RefreshOptions{TargetRoot: dir})
+	if err != nil {
+		t.Fatalf("RefreshIndex error: %v", err)
+	}
+	if !called {
+		t.Error("test runner was not called")
+	}
+	if !result.Refreshed {
+		t.Error("result.Refreshed = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds full Trovex MCP integration gated by `LIZA_ENABLE_TROVEX=1` — hooks redirect `.md` read/write to Trovex MCP tools (`trovex_write`, `trovex_search`, `trovex_read`) with graceful degradation when the server is unreachable
- Writes trovex streamable-http endpoint to `.mcp.json` during `liza init`, auto-discovered via `enableAllProjectMcpServers`
- Auto-starts the trovex server during session initialization (fire-and-forget with local fastembed fallback)
- Generates a default `.trovexignore` exempting operational files (contracts, specs, `.liza/` internals) from hook redirection
- Pairing index refreshes trovex index with local fastembed fallback (`BAAI/bge-small-en-v1.5`) when no `OPENAI_API_KEY` is set — reranking activates automatically when key is available

## What's included

| Area | Files | What |
|------|-------|------|
| Core package | `internal/trovex/` (3 files) | Env gate, index/serve command planning, MCP URL helpers, prompt metadata, 27 tests |
| Hooks | `internal/embedded/hooks/trovex-md-{guard,read-guard}.sh` | PreToolUse hooks for Write/Edit/MultiEdit and Read, `.trovexignore` support |
| Session context | `internal/embedded/hooks/session-context.sh` | Auto-starts trovex server, emits MCP tool guidance |
| Settings | `claude-settings.json`, `codex-hooks.json` | Hook registration + `mcp__trovex__*` permission allows (6 tools) |
| Embedded | `embedded.go` | Embed directives, hook deployment, `WriteTrovexMCPEntry()`, `WriteTrovexIgnore()` |
| Init | `init.go` | Writes `.mcp.json` entry and `.trovexignore` when trovex enabled |
| Prompts | `builder.go`, `base_prompt.tmpl`, `agent/prompt.go` | TrovexSearch metadata type, MCP tool guidance in agent prompts |
| Toolchain | `catalog.go` | Trovex as uv-tool, balanced+full profiles |
| Pairing index | `hooks.go` | `trovex index` refresh with local embedding fallback |

## Testing requirements

**Trovex is a private repository.** To test this integration you need access to [Synergix-lab/trovex](https://github.com/Synergix-lab/trovex). Preview access is available on request — contact the maintainer for a preview invitation.

Install trovex for testing:
```bash
uvx install trovex  # once you have access
export LIZA_ENABLE_TROVEX=1
```

## Test plan

- [x] `go build ./...` passes
- [x] All unit tests pass across modified packages (trovex: 27, embedded: 145+)
- [x] No new test failures (pre-existing consistency drift in unrelated packages)
- [ ] Manual: run `LIZA_ENABLE_TROVEX=1 liza init` and verify `.mcp.json` contains trovex entry and `.trovexignore` is generated
- [ ] Manual: verify session-context.sh auto-starts trovex server when `LIZA_ENABLE_TROVEX=1` and `trovex` is on PATH
- [ ] Manual: start `trovex serve`, verify hooks redirect `.md` operations to MCP tools
- [ ] Manual: verify `.trovexignore` patterns (CLAUDE.md, GUARDRAILS.md, specs/) are exempt from redirection
- [ ] Manual: verify graceful degradation when trovex server is not running (hooks allow, session context omits trovex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)