### PR TITLE
feat(skills): add gandalf review loop

### DIFF
--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -108,6 +108,7 @@ Specialized protocols agents load conditionally. Each contains a single `SKILL.m
 | `testing/` | When writing or analyzing tests (mandatory) |
 | `code-review/` | When reviewing PRs or pending changes |
 | `adversarial-pairing/` | Coordinating doer/reviewer pairing sessions through a Markdown blackboard |
+| `gandalf-review/` | Running local adversarial QA fix/review loops with metrics, pre-PR hooks, progress bars, and aggregate archives |
 | `architecture-planning/` | Defining architecture for a change (architect role) |
 | `software-architecture-review/` | Implementation planning, structural concerns |
 | `clean-code/` | Pre-commit refactoring (Python-focused) |

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -75,8 +75,9 @@ has passed implementation tests but still needs adversarial QA before GitHub
 review. This is useful when repeated push/mention/fix cycles are slowing down
 review.
 
-Git does not provide a native pre-open-PR hook. Prefer an opt-in wrapper such as
-`scripts/pr-ready`, a `gh pr create` wrapper, or a team-approved `pre-push` hook:
+Git does not provide a native pre-open-PR hook. Run the skill explicitly before
+creating the PR, or use an existing team-approved wrapper or `pre-push` hook that
+already lives in the project:
 
 ```bash
 # 1. Finish implementation and local validation.
@@ -92,7 +93,7 @@ git status --short
 During the loop, each fix iteration may be committed separately for recovery.
 After approval, squash those iteration commits into one clean PR commit while
 preserving the Gandalf archive and aggregate metrics. The skill includes helper
-scripts for task-local Codex Fast Mode and final squashing.
+scripts for task-local reviewer setup and final squashing.
 
 ## Recovering from Agent Crashes
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -68,6 +68,32 @@ liza submit-for-review task-1 HEAD --agent-id coder-1
 
 Watch daemon alerts on high review cycles (>= 5). Check with `liza get tasks task-1`.
 
+## Run Gandalf Before Opening a PR
+
+Use the `gandalf-review` skill as a local PR-readiness gate when a change
+has passed implementation tests but still needs adversarial QA before GitHub
+review. This is useful when repeated push/mention/fix cycles are slowing down
+review.
+
+Git does not provide a native pre-open-PR hook. Prefer an opt-in wrapper such as
+`scripts/pr-ready`, a `gh pr create` wrapper, or a team-approved `pre-push` hook:
+
+```bash
+# 1. Finish implementation and local validation.
+git status --short
+
+# 2. Ask the agent to run:
+# "Use gandalf-review against this branch before I open the PR."
+
+# 3. Open the PR only after the run summary reports APPROVED.
+# Full run detail stays under ~/.liza/gandalf-review/.
+```
+
+During the loop, each fix iteration may be committed separately for recovery.
+After approval, squash those iteration commits into one clean PR commit while
+preserving the Gandalf archive and aggregate metrics. The skill includes helper
+scripts for task-local Codex Fast Mode and final squashing.
+
 ## Recovering from Agent Crashes
 
 **Recover by task ID** (recommended — you usually know the task):

--- a/skills/gandalf-review/SKILL.md
+++ b/skills/gandalf-review/SKILL.md
@@ -30,6 +30,8 @@ Archive layout:
 - `~/.liza/gandalf-review/index.jsonl` — global aggregate, one JSON object per run.
 - `~/.liza/gandalf-review/aggregate.md` — human aggregate summary.
 
+`start`, `record`, and `finish` update the current run summary and replace that run's index entry. Use `aggregate` when you need a full rebuild across historical runs or to quarantine corrupt historical data.
+
 If `GANDALF_REVIEW_EXPORT_CMD` is set, the helper runs it after each event and automatically sets these environment variables for that exporter. Do not set them manually:
 
 - `GANDALF_REVIEW_EVENT_PATH`

--- a/skills/gandalf-review/SKILL.md
+++ b/skills/gandalf-review/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: gandalf-review
-description: Run an OmniAgentBot-style local adversarial QA loop after implementation. Use when the user asks for gandalf review, guardian/gatekeeper review loops, adversarial review until approval, automatic fix-and-review cycling, or local replacement for repeatedly pushing PR fixes and asking OmniAgentBot/GitHub reviewers again.
+description: Run a local adversarial QA loop after implementation. Use when the user asks for gandalf review, guardian/gatekeeper review loops, adversarial review until approval, automatic fix-and-review cycling, or local PR-readiness review before asking GitHub reviewers again.
+trigger: User asks for Gandalf review, guardian/gatekeeper review loops, adversarial review until approval, automatic fix-and-review cycling, or local PR-readiness review.
 ---
 
 # Gandalf Review
 
-Run review -> fix -> re-review until both reviewers approve, while archiving each run and producing aggregate metrics.
+Run primary reviewer sub-agent -> fix -> adversarial reviewer sub-agent -> re-review until both reviewers approve, while archiving each run and producing aggregate metrics.
 
-This skill is a local QA loop. It does not replace the active contract: approval gates, safety stops, credential rules, destructive-operation rules, and validation requirements still apply.
+This skill is a local QA loop that spawns reviewer sub-agents. The main agent coordinates scope, fixes, validation, metrics, and user-facing decisions. The reviewer sub-agents produce review artifacts only.
 
-# Metrics Archive
+This skill does not replace the active contract: approval gates, safety stops, credential rules, destructive-operation rules, and validation requirements still apply.
+
+# Main Agent Instructions
+
+## Metrics Archive
 
 Use the helper for every run:
 
@@ -25,7 +30,7 @@ Archive layout:
 - `~/.liza/gandalf-review/index.jsonl` — global aggregate, one JSON object per run.
 - `~/.liza/gandalf-review/aggregate.md` — human aggregate summary.
 
-If `GANDALF_REVIEW_EXPORT_CMD` is set, the helper runs it after each event with these environment variables:
+If `GANDALF_REVIEW_EXPORT_CMD` is set, the helper runs it after each event and automatically sets these environment variables for that exporter. Do not set them manually:
 
 - `GANDALF_REVIEW_EVENT_PATH`
 - `GANDALF_REVIEW_INDEX_PATH`
@@ -38,9 +43,13 @@ Keep this export generic. Do not add Slack-specific behavior here; a Slack forwa
 
 Do not archive secrets. If a finding contains sensitive data, redact before recording the artifact.
 
-# Reviewer Runtime
+## Reviewer Runtime
 
-For small local QA runs, use Codex ACP Fast Mode for the primary reviewer when available. Create a task-local Codex home instead of mutating global `~/.codex/config.toml`:
+Use a fast local reviewer for the primary pass when the change is low risk, then use an independent adversarial reviewer to challenge that result. Keep provider-specific runtime configuration in provider-specific subsections; the general rule is speed for low-risk first pass, independence for the second pass, and stronger review mode for high-risk changes.
+
+## Codex ACP Fast Mode
+
+For small local QA runs with Codex available, use Codex ACP Fast Mode for the primary reviewer. Create a task-local Codex home instead of mutating global `~/.codex/config.toml`:
 
 ```bash
 python3 skills/gandalf-review/scripts/gandalf_codex_fast_home.py \
@@ -48,6 +57,10 @@ python3 skills/gandalf-review/scripts/gandalf_codex_fast_home.py \
 ```
 
 Use the returned `CODEX_HOME` and `CODEX_MODEL` for the primary Codex ACP review command. The helper writes `model_reasoning_effort = "minimal"` and symlinks auth without reading the auth file.
+
+Codex `model_reasoning_effort` values are `minimal`, `low`, `medium`, `high`, and `xhigh`; `xhigh` is model-dependent. Use `minimal` only for bounded, low-risk review passes. Escalate to `medium`, `high`, or `xhigh` when the review touches higher-risk code or repeatedly misses blockers.
+
+The generated task-local Codex config intentionally sets `approval_policy = "never"`, `sandbox_mode = "workspace-write"`, and network access for autonomous local review. Keep that posture task-local, archive only redacted artifacts, and do not copy secrets into the run directory.
 
 Use the stronger/default reviewer mode when any of these are true:
 
@@ -57,15 +70,16 @@ Use the stronger/default reviewer mode when any of these are true:
 
 Keep the secondary adversarial reviewer independent from the primary reviewer. Do not pass the primary review's hidden reasoning; pass only the primary artifact, diff, validation evidence, and unresolved blockers.
 
-# Pre-open PR Hook
+## Pre-open PR Gate
 
-Invite users to run Gandalf before opening a pull request. Git has no native "pre-open PR" hook, so use one of these opt-in wrappers:
+Invite users to run Gandalf before opening a pull request. Git has no native "pre-open PR" hook, and this skill must not assume a wrapper script exists. Use one of these paths:
 
-- A `gh pr create` wrapper that runs Gandalf first and opens the PR only after `APPROVED`.
-- A `pre-push` hook when the team accepts local review before pushing.
-- A project script such as `scripts/pr-ready` that runs tests, Gandalf, and then prints the `gh pr create` command.
+- A direct user prompt such as "Use gandalf-review against this branch before I open the PR."
+- An existing project-approved `gh pr create` wrapper that runs Gandalf first and opens the PR only after `APPROVED`.
+- An existing `pre-push` hook when the team accepts local review before pushing.
+- A new project script only when the user explicitly asks to create one as a separate implementation task.
 
-The hook should:
+The gate should:
 
 1. Refuse to run on a dirty index unless the user explicitly asks to include uncommitted changes.
 2. Start a Gandalf run against the merge base or target branch.
@@ -73,15 +87,21 @@ The hook should:
 4. Print the run summary path and aggregate path.
 5. Open or suggest the PR only after approval.
 
-Do not hide the archive. The hook may suppress loop noise, but it must leave the full run in `~/.liza/gandalf-review/`.
+Do not hide the archive. A wrapper may suppress loop noise, but it must leave the full run in `~/.liza/gandalf-review/`.
 
-# Git Commit Hygiene
+## Git Commit Hygiene
 
-When operating inside a Git repository, create one fix commit per iteration so each repair step is recoverable and reviewable:
+When operating inside a Git repository, follow the repository commit protocol. Get the required approval/checkpoint before commit, reset, or squash operations. Commit subjects must use Conventional Commits, and final commits must include a body explaining why and what changed.
+
+Create one fix commit per iteration so each repair step is recoverable and reviewable:
 
 ```bash
 git add <changed-files>
-git commit -m "fix(gandalf): iteration <n> repair"
+git commit \
+  -m "fix(gandalf): iteration <n> repair" \
+  -m "Why: <why this repair is needed>
+
+What: <what changed and how it was validated>"
 ```
 
 Record the created commit on the fix event:
@@ -102,14 +122,19 @@ After both reviewers approve, squash the iteration commits into one clean final 
 ```bash
 python3 skills/gandalf-review/scripts/gandalf_squash.py \
   --base-ref <base-ref> \
-  --message "<final conventional commit message>"
+  --message "<final conventional commit subject>" \
+  --body "Why: <why the final change is needed>
+
+What: <what the final change contains>"
 ```
+
+For longer messages, write the full Conventional Commit message to a file and pass `--message-file <path>`.
 
 Preserve the metrics archive exactly; do not rewrite `metrics.jsonl`, review artifacts, or summaries to pretend there was only one iteration.
 
 If the worktree contains unrelated user changes, do not squash or stage them. Stop and ask for scope clarification.
 
-# Start
+## Start
 
 1. Establish review scope from the current task, branch, staged diff, pending diff, or PR URL.
 2. Record the run:
@@ -126,9 +151,9 @@ Capture the returned `run_id`.
 
 3. Set `iteration = 1`.
 
-# Default Budgets
+## Default Budgets
 
-Initial defaults are calibrated from recent `omni3ai/omni` OmniAgentBot PR review comments sampled on 2026-06-19: 8 PRs, 22 bot responses, median response latency about 4 minutes, p75 about 5 minutes, max observed about 15 minutes, and max observed paired rounds 7.
+Initial defaults are calibrated from recent local adversarial PR review loops sampled on 2026-06-19: 8 PRs, 22 reviewer responses, median response latency about 4 minutes, p75 about 5 minutes, max observed about 15 minutes, and max observed paired rounds 7.
 
 - Minimum review rounds: 1 full primary + adversarial round. Do not run extra rounds after both approve.
 - Soft convergence checkpoint: after 3 iterations, re-review only unresolved blocker questions and new P0-P2 regressions.
@@ -137,7 +162,7 @@ Initial defaults are calibrated from recent `omni3ai/omni` OmniAgentBot PR revie
 - Review timeout/default blocker threshold: 25 minutes without a completed review pass.
 - Fix timing has no fixed cap; record actual duration and block only when the same finding repeats without progress.
 
-# Review Progress Bars
+## Review Progress Bars
 
 Use `scripts/gandalf_progress.py` when a review command is expected to take long enough that terminal feedback helps. The bar advances based on the normal review time and caps at 99% until the command exits; completion writes 100%.
 
@@ -154,13 +179,27 @@ python3 skills/gandalf-review/scripts/gandalf_progress.py \
 
 Use separate bars and expected durations for the primary and adversarial reviewers. Do not use progress bars for fix implementation; fixes vary by defect and should be reported with regular status messages and measured after completion.
 
+# Reviewer Sub-Agent Instructions
+
+Reviewer sub-agents only review. They do not edit files, commit, resolve GitHub threads, mutate metrics, or make user-facing decisions. The main agent passes them the diff, relevant source context, validation evidence, prior review artifact when applicable, and unresolved blockers.
+
+Primary reviewer sub-agent:
+
+- Use the code-review skill when reviewing code changes.
+- Prioritize P0-P2: security, correctness, data integrity, missing behavior tests.
+- Return the required primary review artifact.
+
+Adversarial reviewer sub-agent:
+
+- Challenge the primary review, not just the code.
+- Look for missed high-impact issues, unsupported findings, missing validation, and scope drift.
+- Return the required adversarial review artifact.
+
 # Review Loop
 
 For each iteration:
 
 1. Run the primary review.
-   - Use the code-review skill when reviewing code changes.
-   - Prioritize P0-P2: security, correctness, data integrity, missing behavior tests.
    - Output:
 
 ```markdown
@@ -193,8 +232,6 @@ python3 skills/gandalf-review/scripts/gandalf_metrics.py record \
 ```
 
 3. Run the adversarial review.
-   - Challenge the primary review, not just the code.
-   - Look for missed high-impact issues, unsupported findings, missing validation, and scope drift.
    - Output:
 
 ```markdown

--- a/skills/gandalf-review/SKILL.md
+++ b/skills/gandalf-review/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: gandalf-review
+description: Run an OmniAgentBot-style local adversarial QA loop after implementation. Use when the user asks for gandalf review, guardian/gatekeeper review loops, adversarial review until approval, automatic fix-and-review cycling, or local replacement for repeatedly pushing PR fixes and asking OmniAgentBot/GitHub reviewers again.
+---
+
+# Gandalf Review
+
+Run review -> fix -> re-review until both reviewers approve, while archiving each run and producing aggregate metrics.
+
+This skill is a local QA loop. It does not replace the active contract: approval gates, safety stops, credential rules, destructive-operation rules, and validation requirements still apply.
+
+# Metrics Archive
+
+Use the helper for every run:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py --root ~/.liza/gandalf-review <command>
+```
+
+Archive layout:
+
+- `~/.liza/gandalf-review/runs/<run-id>/metrics.jsonl` — event stream for one run.
+- `~/.liza/gandalf-review/runs/<run-id>/summary.md` — human recap for one run.
+- `~/.liza/gandalf-review/runs/<run-id>/artifacts/` — review and fix artifacts by iteration.
+- `~/.liza/gandalf-review/index.jsonl` — global aggregate, one JSON object per run.
+- `~/.liza/gandalf-review/aggregate.md` — human aggregate summary.
+
+If `GANDALF_REVIEW_EXPORT_CMD` is set, the helper runs it after each event with these environment variables:
+
+- `GANDALF_REVIEW_EVENT_PATH`
+- `GANDALF_REVIEW_INDEX_PATH`
+- `GANDALF_REVIEW_AGGREGATE_PATH`
+- `GANDALF_REVIEW_RUN_SUMMARY_PATH`
+- `GANDALF_REVIEW_RUN_DIR`
+- `GANDALF_REVIEW_RUN_ID`
+
+Keep this export generic. Do not add Slack-specific behavior here; a Slack forwarder can consume the paths above.
+
+Do not archive secrets. If a finding contains sensitive data, redact before recording the artifact.
+
+# Reviewer Runtime
+
+For small local QA runs, use Codex ACP Fast Mode for the primary reviewer when available. Create a task-local Codex home instead of mutating global `~/.codex/config.toml`:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_codex_fast_home.py \
+  --output-dir <run-dir>/codex-fast-home
+```
+
+Use the returned `CODEX_HOME` and `CODEX_MODEL` for the primary Codex ACP review command. The helper writes `model_reasoning_effort = "minimal"` and symlinks auth without reading the auth file.
+
+Use the stronger/default reviewer mode when any of these are true:
+
+- The diff touches auth, security, money, data loss, migrations, or public APIs.
+- A prior fast review missed a blocker.
+- The user explicitly asks for a deep review.
+
+Keep the secondary adversarial reviewer independent from the primary reviewer. Do not pass the primary review's hidden reasoning; pass only the primary artifact, diff, validation evidence, and unresolved blockers.
+
+# Pre-open PR Hook
+
+Invite users to run Gandalf before opening a pull request. Git has no native "pre-open PR" hook, so use one of these opt-in wrappers:
+
+- A `gh pr create` wrapper that runs Gandalf first and opens the PR only after `APPROVED`.
+- A `pre-push` hook when the team accepts local review before pushing.
+- A project script such as `scripts/pr-ready` that runs tests, Gandalf, and then prints the `gh pr create` command.
+
+The hook should:
+
+1. Refuse to run on a dirty index unless the user explicitly asks to include uncommitted changes.
+2. Start a Gandalf run against the merge base or target branch.
+3. Run the review loop until `APPROVED` or `BLOCKED`.
+4. Print the run summary path and aggregate path.
+5. Open or suggest the PR only after approval.
+
+Do not hide the archive. The hook may suppress loop noise, but it must leave the full run in `~/.liza/gandalf-review/`.
+
+# Git Commit Hygiene
+
+When operating inside a Git repository, create one fix commit per iteration so each repair step is recoverable and reviewable:
+
+```bash
+git add <changed-files>
+git commit -m "fix(gandalf): iteration <n> repair"
+```
+
+Record the created commit on the fix event:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py record \
+  --run-id <run-id> \
+  --kind fix_finished \
+  --iteration <n> \
+  --duration-kind fix \
+  --duration-ms <milliseconds> \
+  --commit <fix-commit-sha> \
+  --summary "<what changed and how it was validated>"
+```
+
+After both reviewers approve, squash the iteration commits into one clean final commit for the branch:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_squash.py \
+  --base-ref <base-ref> \
+  --message "<final conventional commit message>"
+```
+
+Preserve the metrics archive exactly; do not rewrite `metrics.jsonl`, review artifacts, or summaries to pretend there was only one iteration.
+
+If the worktree contains unrelated user changes, do not squash or stage them. Stop and ask for scope clarification.
+
+# Start
+
+1. Establish review scope from the current task, branch, staged diff, pending diff, or PR URL.
+2. Record the run:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py start \
+  --repo <repo-name-or-url> \
+  --branch <current-branch> \
+  --base-ref <base-ref> \
+  --goal "<one-line QA goal>"
+```
+
+Capture the returned `run_id`.
+
+3. Set `iteration = 1`.
+
+# Default Budgets
+
+Initial defaults are calibrated from recent `omni3ai/omni` OmniAgentBot PR review comments sampled on 2026-06-19: 8 PRs, 22 bot responses, median response latency about 4 minutes, p75 about 5 minutes, max observed about 15 minutes, and max observed paired rounds 7.
+
+- Minimum review rounds: 1 full primary + adversarial round. Do not run extra rounds after both approve.
+- Soft convergence checkpoint: after 3 iterations, re-review only unresolved blocker questions and new P0-P2 regressions.
+- Hard iteration cap: 7 iterations.
+- Slow review warning: record a warning when one review pass exceeds 10 minutes.
+- Review timeout/default blocker threshold: 25 minutes without a completed review pass.
+- Fix timing has no fixed cap; record actual duration and block only when the same finding repeats without progress.
+
+# Review Progress Bars
+
+Use `scripts/gandalf_progress.py` when a review command is expected to take long enough that terminal feedback helps. The bar advances based on the normal review time and caps at 99% until the command exits; completion writes 100%.
+
+Example for a primary review with a 4-minute expected duration:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_progress.py \
+  --label "primary review" \
+  --expected-ms 240000 \
+  --stdout-file <primary-review.md> \
+  --stderr-file <primary-review.err> \
+  -- <review-command> <args>
+```
+
+Use separate bars and expected durations for the primary and adversarial reviewers. Do not use progress bars for fix implementation; fixes vary by defect and should be reported with regular status messages and measured after completion.
+
+# Review Loop
+
+For each iteration:
+
+1. Run the primary review.
+   - Use the code-review skill when reviewing code changes.
+   - Prioritize P0-P2: security, correctness, data integrity, missing behavior tests.
+   - Output:
+
+```markdown
+**Verdict:** Approved | Changes requested
+
+**Findings**
+- Blocking findings, or "No blocking findings."
+
+**Validation**
+- What was checked.
+
+**Residual risk**
+- Remaining risk or "Low."
+```
+
+2. Record the primary review artifact:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py record \
+  --run-id <run-id> \
+  --kind primary_review_finished \
+  --iteration <n> \
+  --reviewer primary \
+  --verdict "<Approved|Changes requested>" \
+  --duration-kind review \
+  --duration-ms <milliseconds> \
+  --summary "<short finding summary>" \
+  --content-file <primary-review.md> \
+  --artifact-name primary-review.md
+```
+
+3. Run the adversarial review.
+   - Challenge the primary review, not just the code.
+   - Look for missed high-impact issues, unsupported findings, missing validation, and scope drift.
+   - Output:
+
+```markdown
+**Adversarial verdict:** Approved | Changes requested
+
+**Challenge**
+- What the primary pass missed, overstated, or got right.
+
+**Action**
+- The next blocking action, or "No action required."
+```
+
+4. Record the adversarial artifact with `--kind adversarial_review_finished --reviewer adversarial`.
+
+5. If both verdicts approve, run final validation, record validation duration, finish with `APPROVED`, and stop.
+
+6. If either verdict requests changes:
+   - Extract only blocking findings and material concerns.
+   - Do not send nits, style preferences, or already-fixed findings into the fix pass.
+   - Apply the smallest fix that addresses root cause.
+   - Update or add tests when behavior changed.
+   - Validate the changed path with realistic inputs.
+   - Commit the fix before the next review pass when working in Git.
+   - Record a fix artifact:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py record \
+  --run-id <run-id> \
+  --kind fix_finished \
+  --iteration <n> \
+  --duration-kind fix \
+  --duration-ms <milliseconds> \
+  --commit <fix-commit-sha> \
+  --summary "<what changed and how it was validated>" \
+  --content-file <fix-summary.md> \
+  --artifact-name fix-summary.md
+```
+
+7. Increment `iteration` and repeat with a narrowed re-review:
+   - Round 2 checks previous blockers, new fix diff, and new P0-P2 regressions only.
+   - Round 3+ requires a specific unresolved question. Do not broaden into a fresh review.
+
+# Stop Conditions
+
+Stop and finish with `BLOCKED` if any condition applies:
+
+- The same finding repeats after two fix attempts without new evidence.
+- Fixing one reviewer blocker reintroduces another blocker.
+- The loop reaches 7 iterations.
+- Validation cannot exercise the changed behavior.
+- The review requires credentials, external systems, destructive operations, or user decisions not available locally.
+
+Record the block:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py finish \
+  --run-id <run-id> \
+  --final-verdict BLOCKED \
+  --summary "<short recap>" \
+  --blocker "<specific blocker>"
+```
+
+# Finish
+
+On approval:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py finish \
+  --run-id <run-id> \
+  --final-verdict APPROVED \
+  --summary "<iterations, main fixes, validation, residual risk>"
+```
+
+Rebuild aggregate when needed:
+
+```bash
+python3 skills/gandalf-review/scripts/gandalf_metrics.py aggregate
+```
+
+Use Iteration Ledger as the default final user recap:
+
+```markdown
+# Gandalf Review Ledger
+
+Final verdict: <APPROVED|BLOCKED|STOPPED>
+Total elapsed: <duration>
+Total review: <duration>
+Total fix: <duration>
+Total validation: <duration>
+
+| Iteration | Primary | Adversarial | Fix | Commit | Result |
+|---:|---|---|---|---|---|
+| 1 | Changes requested | Changes requested | <fix summary> | <sha> | Re-review |
+| 2 | Approved | Approved | None | n/a | APPROVED |
+
+Validation:
+- `<command>` -> <result>
+
+Artifacts:
+- Run summary: `<summary.md path>`
+- Aggregate: `<aggregate.md path>`
+- Index: `<index.jsonl path>`
+```
+
+Final user recap must include:
+
+- Final verdict.
+- Iteration count.
+- Total review time and fix time.
+- Key fixes made.
+- Validation run.
+- Paths to `summary.md`, `aggregate.md`, and `index.jsonl`.
+
+Do not dump every review note unless the user asks. The archive contains the detail.
+
+# Production Lessons
+
+Apply these hardening lessons from dogfooding this skill on itself:
+
+- Treat archive data as untrusted input. A corrupt historical run must not break future `start`, `record`, `finish`, or `aggregate` operations.
+- Quarantine corrupt runs as `CORRUPT`; do not count them as approved, blocked, or completed.
+- Record wrapper/tool failures separately from reviewer verdicts when a useful verdict artifact still exists.
+- Keep reviewer prompts narrow after the first failed round. Round 2+ should verify prior blockers, the fix diff, and new P0-P2 regressions only.
+- Preserve detailed iteration history in the archive even when Git history is squashed for a clean PR.

--- a/skills/gandalf-review/scripts/gandalf_codex_fast_home.py
+++ b/skills/gandalf-review/scripts/gandalf_codex_fast_home.py
@@ -7,6 +7,8 @@ import argparse
 import json
 from pathlib import Path
 
+REASONING_EFFORT_VALUES = ("minimal", "low", "medium", "high", "xhigh")
+
 
 def config_text(model: str, reasoning_effort: str) -> str:
     return f"""model = "{model}"
@@ -63,8 +65,9 @@ def parser() -> argparse.ArgumentParser:
     base.add_argument("--model", default="gpt-5.5", help="Codex model for the fast reviewer")
     base.add_argument(
         "--reasoning-effort",
+        choices=REASONING_EFFORT_VALUES,
         default="minimal",
-        help="Codex reasoning effort for fast reviews; Liza config validation accepts minimal",
+        help="Codex reasoning effort for fast reviews",
     )
     base.add_argument("--auth-source", default="~/.codex/auth.json", help="auth file to symlink without reading")
     base.add_argument("--no-auth-link", action="store_true", help="do not symlink an auth file into CODEX_HOME")

--- a/skills/gandalf-review/scripts/gandalf_codex_fast_home.py
+++ b/skills/gandalf-review/scripts/gandalf_codex_fast_home.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Create a task-local Codex home configured for fast Gandalf ACP reviews."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def config_text(model: str, reasoning_effort: str) -> str:
+    return f"""model = "{model}"
+approval_policy = "never"
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "{reasoning_effort}"
+personality = "pragmatic"
+
+[permissions.workspace.network]
+enabled = true
+
+[sandbox_workspace_write]
+network_access = true
+exclude_tmpdir_env_var = false
+exclude_slash_tmp = false
+"""
+
+
+def command_create(args: argparse.Namespace) -> None:
+    codex_home = Path(args.output_dir).expanduser()
+    codex_home.mkdir(parents=True, exist_ok=True)
+    config_path = codex_home / "config.toml"
+    config_path.write_text(config_text(args.model, args.reasoning_effort), encoding="utf-8")
+
+    auth_linked = False
+    if not args.no_auth_link:
+        auth_source = Path(args.auth_source).expanduser()
+        auth_target = codex_home / "auth.json"
+        if auth_source.exists() and not auth_target.exists():
+            auth_target.symlink_to(auth_source)
+            auth_linked = True
+
+    print(
+        json.dumps(
+            {
+                "auth_linked": auth_linked,
+                "codex_home": str(codex_home),
+                "config_path": str(config_path),
+                "env": {
+                    "CODEX_HOME": str(codex_home),
+                    "CODEX_MODEL": args.model,
+                },
+                "model": args.model,
+                "reasoning_effort": args.reasoning_effort,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    base = argparse.ArgumentParser(description=__doc__)
+    base.add_argument("--output-dir", required=True, help="task-local CODEX_HOME directory to create")
+    base.add_argument("--model", default="gpt-5.5", help="Codex model for the fast reviewer")
+    base.add_argument(
+        "--reasoning-effort",
+        default="minimal",
+        help="Codex reasoning effort for fast reviews; Liza config validation accepts minimal",
+    )
+    base.add_argument("--auth-source", default="~/.codex/auth.json", help="auth file to symlink without reading")
+    base.add_argument("--no-auth-link", action="store_true", help="do not symlink an auth file into CODEX_HOME")
+    base.set_defaults(func=command_create)
+    return base
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/gandalf-review/scripts/gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/gandalf_metrics.py
@@ -318,6 +318,14 @@ def write_aggregate_files(root: Path, entries: list[dict[str, Any]]) -> None:
     write_text_atomic(root / AGGREGATE_FILE, "\n".join(aggregate))
 
 
+def validate_aggregate_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    for index, entry in enumerate(entries, start=1):
+        run_id = entry.get("run_id")
+        if not isinstance(run_id, str) or not run_id:
+            raise ValueError(f"{INDEX_FILE}:{index} must contain a non-empty run_id")
+    return entries
+
+
 def write_aggregate(root: Path) -> list[dict[str, Any]]:
     entries = collect_run_entries(root, rewrite_summaries=True)
     write_aggregate_files(root, entries)
@@ -327,7 +335,11 @@ def write_aggregate(root: Path) -> list[dict[str, Any]]:
 def update_aggregate_entry(root: Path, entry: dict[str, Any]) -> list[dict[str, Any]]:
     index_path = root / INDEX_FILE
     try:
-        entries = read_jsonl(index_path) if index_path.exists() else collect_run_entries(root, rewrite_summaries=False)
+        entries = (
+            validate_aggregate_entries(read_jsonl(index_path))
+            if index_path.exists()
+            else collect_run_entries(root, rewrite_summaries=False)
+        )
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
         entries = collect_run_entries(root, rewrite_summaries=False)
 

--- a/skills/gandalf-review/scripts/gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/gandalf_metrics.py
@@ -319,10 +319,21 @@ def write_aggregate_files(root: Path, entries: list[dict[str, Any]]) -> None:
 
 
 def validate_aggregate_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    required_fields = {
+        "run_id",
+        "final_verdict",
+        "iterations",
+        "review_duration_ms",
+        "fix_duration_ms",
+        "validation_duration_ms",
+    }
     for index, entry in enumerate(entries, start=1):
         run_id = entry.get("run_id")
         if not isinstance(run_id, str) or not run_id:
             raise ValueError(f"{INDEX_FILE}:{index} must contain a non-empty run_id")
+        missing = sorted(required_fields.difference(entry))
+        if missing:
+            raise ValueError(f"{INDEX_FILE}:{index} missing fields: {', '.join(missing)}")
     return entries
 
 

--- a/skills/gandalf-review/scripts/gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/gandalf_metrics.py
@@ -253,7 +253,7 @@ def corrupt_run_entry(run_id: str, child: Path, error: Exception) -> dict[str, A
     }
 
 
-def write_aggregate(root: Path) -> list[dict[str, Any]]:
+def collect_run_entries(root: Path, *, rewrite_summaries: bool) -> list[dict[str, Any]]:
     entries: list[dict[str, Any]] = []
     runs_root = root / "runs"
     if runs_root.exists():
@@ -266,15 +266,22 @@ def write_aggregate(root: Path) -> list[dict[str, Any]]:
                 continue
             run_id = safe_run_id(child.name)
             try:
-                metadata = read_json(metadata_file)
-                events = read_jsonl(metrics_file)
-                entry = summarize_run(metadata, events, root, run_id)
-                summary_path(root, run_id).parent.mkdir(parents=True, exist_ok=True)
-                write_summary(root, run_id)
+                if rewrite_summaries:
+                    summary_path(root, run_id).parent.mkdir(parents=True, exist_ok=True)
+                    entry = write_summary(root, run_id)
+                else:
+                    metadata = read_json(metadata_file)
+                    events = read_jsonl(metrics_file)
+                    entry = summarize_run(metadata, events, root, run_id)
             except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
                 entries.append(corrupt_run_entry(run_id, child, error))
                 continue
             entries.append(entry)
+    return entries
+
+
+def write_aggregate_files(root: Path, entries: list[dict[str, Any]]) -> None:
+    entries = sorted(entries, key=lambda entry: entry["run_id"])
 
     root.mkdir(parents=True, exist_ok=True)
     write_text_atomic(root / INDEX_FILE, "".join(json_line(entry) for entry in entries))
@@ -309,6 +316,32 @@ def write_aggregate(root: Path) -> list[dict[str, Any]]:
         )
     aggregate.append("")
     write_text_atomic(root / AGGREGATE_FILE, "\n".join(aggregate))
+
+
+def write_aggregate(root: Path) -> list[dict[str, Any]]:
+    entries = collect_run_entries(root, rewrite_summaries=True)
+    write_aggregate_files(root, entries)
+    return entries
+
+
+def update_aggregate_entry(root: Path, entry: dict[str, Any]) -> list[dict[str, Any]]:
+    index_path = root / INDEX_FILE
+    try:
+        entries = read_jsonl(index_path) if index_path.exists() else collect_run_entries(root, rewrite_summaries=False)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        entries = collect_run_entries(root, rewrite_summaries=False)
+
+    run_id = entry["run_id"]
+    updated = False
+    for index, existing in enumerate(entries):
+        if existing.get("run_id") == run_id:
+            entries[index] = entry
+            updated = True
+            break
+    if not updated:
+        entries.append(entry)
+
+    write_aggregate_files(root, entries)
     return entries
 
 
@@ -374,8 +407,8 @@ def command_start(args: argparse.Namespace) -> None:
             raise SystemExit(f"run id already exists: {run_id}") from None
         write_text_atomic(metadata_path(root, run_id), json.dumps(metadata, indent=2, sort_keys=True) + "\n")
         append_jsonl(metrics_path(root, run_id), event)
-        write_summary(root, run_id)
-        write_aggregate(root)
+        entry = write_summary(root, run_id)
+        update_aggregate_entry(root, entry)
     export_event(root, run_id, event, no_export=args.no_export)
     print(json.dumps({"run_id": run_id, "run_dir": str(directory)}, sort_keys=True))
 
@@ -399,8 +432,8 @@ def command_record(args: argparse.Namespace) -> None:
         if artifact_path:
             event["artifact_path"] = artifact_path
         append_jsonl(metrics_path(root, run_id), event)
-        write_summary(root, run_id)
-        write_aggregate(root)
+        entry = write_summary(root, run_id)
+        update_aggregate_entry(root, entry)
     export_event(root, run_id, event, no_export=args.no_export)
     print(json.dumps(event, sort_keys=True))
 
@@ -423,7 +456,7 @@ def command_finish(args: argparse.Namespace) -> None:
             raise SystemExit(f"unknown run id: {run_id}")
         append_jsonl(metrics_path(root, run_id), event)
         entry = write_summary(root, run_id)
-        write_aggregate(root)
+        update_aggregate_entry(root, entry)
     export_event(root, run_id, event, no_export=args.no_export)
     print(json.dumps(entry, sort_keys=True))
 

--- a/skills/gandalf-review/scripts/gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/gandalf_metrics.py
@@ -319,21 +319,20 @@ def write_aggregate_files(root: Path, entries: list[dict[str, Any]]) -> None:
 
 
 def validate_aggregate_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    required_fields = {
-        "run_id",
-        "final_verdict",
-        "iterations",
-        "review_duration_ms",
-        "fix_duration_ms",
-        "validation_duration_ms",
-    }
+    required_int_fields = ("iterations", "review_duration_ms", "fix_duration_ms", "validation_duration_ms")
     for index, entry in enumerate(entries, start=1):
         run_id = entry.get("run_id")
         if not isinstance(run_id, str) or not run_id:
             raise ValueError(f"{INDEX_FILE}:{index} must contain a non-empty run_id")
-        missing = sorted(required_fields.difference(entry))
+        final_verdict = entry.get("final_verdict")
+        if not isinstance(final_verdict, str) or not final_verdict:
+            raise ValueError(f"{INDEX_FILE}:{index} must contain a non-empty final_verdict")
+        missing = [field for field in required_int_fields if field not in entry]
         if missing:
             raise ValueError(f"{INDEX_FILE}:{index} missing fields: {', '.join(missing)}")
+        wrong_type = [field for field in required_int_fields if not isinstance(entry[field], int)]
+        if wrong_type:
+            raise ValueError(f"{INDEX_FILE}:{index} fields must be integers: {', '.join(wrong_type)}")
     return entries
 
 

--- a/skills/gandalf-review/scripts/gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/gandalf_metrics.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Archive and aggregate gandalf-review review metrics."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+APP_DIR = "gandalf-review"
+INDEX_FILE = "index.jsonl"
+AGGREGATE_FILE = "aggregate.md"
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_root() -> Path:
+    return Path.home() / ".liza" / APP_DIR
+
+
+def slug(value: str, fallback: str = "run") -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-._")
+    return normalized[:80] or fallback
+
+
+def safe_run_id(value: str) -> str:
+    return slug(value, "run")
+
+
+def json_line(data: dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError(f"{path.name} must contain a JSON object")
+    return data
+
+
+def append_jsonl(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json_line(data))
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if line.strip():
+            event = json.loads(line)
+            if not isinstance(event, dict):
+                raise TypeError(f"{path.name}:{line_number} must contain a JSON object")
+            events.append(event)
+    return events
+
+
+def run_dir(root: Path, run_id: str) -> Path:
+    return root / "runs" / safe_run_id(run_id)
+
+
+def metrics_path(root: Path, run_id: str) -> Path:
+    return run_dir(root, run_id) / "metrics.jsonl"
+
+
+def metadata_path(root: Path, run_id: str) -> Path:
+    return run_dir(root, run_id) / "metadata.json"
+
+
+def summary_path(root: Path, run_id: str) -> Path:
+    return run_dir(root, run_id) / "summary.md"
+
+
+def make_run_id(repo: str, branch: str, started_at: str) -> str:
+    digest = hashlib.sha256(f"{repo}\0{branch}\0{started_at}".encode()).hexdigest()[:8]
+    stamp = started_at.replace("-", "").replace(":", "").replace("Z", "")
+    return f"{stamp}-{slug(repo)}-{slug(branch)}-{digest}"
+
+
+def copy_artifact(root: Path, run_id: str, args: argparse.Namespace) -> str | None:
+    if not args.content_file:
+        return None
+    source = Path(args.content_file)
+    if not source.is_file():
+        raise SystemExit(f"content file does not exist: {source}")
+
+    iteration = f"iteration-{args.iteration}" if args.iteration is not None else "run"
+    artifact_name = args.artifact_name or f"{args.kind}.md"
+    destination = run_dir(root, run_id) / "artifacts" / iteration / slug(artifact_name, "artifact.md")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+    return str(destination)
+
+
+def write_summary(root: Path, run_id: str) -> dict[str, Any]:
+    run_id = safe_run_id(run_id)
+    metadata = read_json(metadata_path(root, run_id))
+    events = read_jsonl(metrics_path(root, run_id))
+    entry = summarize_run(metadata, events, root, run_id)
+
+    lines = [
+        f"# Gandalf Review: {run_id}",
+        "",
+        f"- Repo: {entry.get('repo', '')}",
+        f"- Branch: {entry.get('branch', '')}",
+        f"- Base ref: {entry.get('base_ref', '')}",
+        f"- Final verdict: {entry.get('final_verdict', 'IN_PROGRESS')}",
+        f"- Iterations: {entry.get('iterations', 0)}",
+        f"- Total duration: {entry.get('total_duration_ms', 0)} ms",
+        f"- Review time: {entry.get('review_duration_ms', 0)} ms",
+        f"- Fix time: {entry.get('fix_duration_ms', 0)} ms",
+        f"- Validation time: {entry.get('validation_duration_ms', 0)} ms",
+        "",
+        "## Recap",
+        "",
+        entry.get("recap") or "No recap recorded.",
+        "",
+        "## Timeline",
+        "",
+    ]
+    for event in events:
+        detail = event.get("summary") or event.get("verdict") or event.get("duration_kind") or ""
+        iteration = event.get("iteration")
+        suffix = f" iteration={iteration}" if iteration is not None else ""
+        lines.append(f"- {event['timestamp']} `{event['kind']}`{suffix} {detail}".rstrip())
+    lines.append("")
+
+    summary_path(root, run_id).write_text("\n".join(lines), encoding="utf-8")
+    return entry
+
+
+def summarize_run(metadata: dict[str, Any], events: list[dict[str, Any]], root: Path, run_id: str) -> dict[str, Any]:
+    run_id = safe_run_id(run_id)
+    started_at = metadata.get("started_at")
+    finished = next((event for event in reversed(events) if event["kind"] in {"run_finished", "run_blocked"}), None)
+    ended_at = finished.get("timestamp") if finished else None
+    iterations = 0
+    review_duration_ms = 0
+    fix_duration_ms = 0
+    validation_duration_ms = 0
+
+    for event in events:
+        if isinstance(event.get("iteration"), int):
+            iterations = max(iterations, event["iteration"])
+        if not isinstance(event.get("duration_ms"), int):
+            continue
+        duration_kind = event.get("duration_kind")
+        if duration_kind == "review":
+            review_duration_ms += event["duration_ms"]
+        elif duration_kind == "fix":
+            fix_duration_ms += event["duration_ms"]
+        elif duration_kind == "validation":
+            validation_duration_ms += event["duration_ms"]
+
+    total_duration_ms = None
+    if started_at is not None and not isinstance(started_at, str):
+        raise TypeError("started_at must be an ISO timestamp string")
+    if ended_at is not None and not isinstance(ended_at, str):
+        raise TypeError("ended_at must be an ISO timestamp string")
+    if started_at and ended_at:
+        total_duration_ms = int(
+            (
+                dt.datetime.fromisoformat(ended_at.replace("Z", "+00:00"))
+                - dt.datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            ).total_seconds()
+            * 1000
+        )
+
+    return {
+        "run_id": run_id,
+        "repo": metadata.get("repo"),
+        "branch": metadata.get("branch"),
+        "base_ref": metadata.get("base_ref"),
+        "goal": metadata.get("goal"),
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "total_duration_ms": total_duration_ms,
+        "iterations": iterations,
+        "final_verdict": finished.get("final_verdict") if finished else "IN_PROGRESS",
+        "blocker": finished.get("blocker") if finished else None,
+        "review_duration_ms": review_duration_ms,
+        "fix_duration_ms": fix_duration_ms,
+        "validation_duration_ms": validation_duration_ms,
+        "recap": finished.get("summary") if finished else metadata.get("goal"),
+        "artifact_path": str(run_dir(root, run_id)),
+        "summary_path": str(summary_path(root, run_id)),
+    }
+
+
+def corrupt_run_entry(run_id: str, child: Path, error: Exception) -> dict[str, Any]:
+    return {
+        "run_id": safe_run_id(run_id),
+        "repo": None,
+        "branch": None,
+        "base_ref": None,
+        "goal": None,
+        "started_at": None,
+        "ended_at": None,
+        "total_duration_ms": None,
+        "iterations": 0,
+        "final_verdict": "CORRUPT",
+        "blocker": f"cannot read run metrics: {error}",
+        "review_duration_ms": 0,
+        "fix_duration_ms": 0,
+        "validation_duration_ms": 0,
+        "recap": "Run metrics are corrupt; inspect artifact directory.",
+        "artifact_path": str(child),
+        "summary_path": str(child / "summary.md"),
+    }
+
+
+def write_aggregate(root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    runs_root = root / "runs"
+    if runs_root.exists():
+        for child in sorted(runs_root.iterdir()):
+            if not child.is_dir():
+                continue
+            metadata_file = child / "metadata.json"
+            metrics_file = child / "metrics.jsonl"
+            if not metadata_file.exists() or not metrics_file.exists():
+                continue
+            run_id = safe_run_id(child.name)
+            try:
+                metadata = read_json(metadata_file)
+                events = read_jsonl(metrics_file)
+                entry = summarize_run(metadata, events, root, run_id)
+                summary_path(root, run_id).parent.mkdir(parents=True, exist_ok=True)
+                write_summary(root, run_id)
+            except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+                entries.append(corrupt_run_entry(run_id, child, error))
+                continue
+            entries.append(entry)
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / INDEX_FILE).write_text("".join(json_line(entry) for entry in entries), encoding="utf-8")
+
+    completed = [entry for entry in entries if entry["final_verdict"] in {"APPROVED", "BLOCKED", "STOPPED"}]
+    approved = [entry for entry in completed if entry["final_verdict"] == "APPROVED"]
+    blocked = [entry for entry in completed if entry["final_verdict"] == "BLOCKED"]
+    corrupt = [entry for entry in entries if entry["final_verdict"] == "CORRUPT"]
+    total_review = sum(entry["review_duration_ms"] for entry in completed)
+    total_fix = sum(entry["fix_duration_ms"] for entry in completed)
+    total_iterations = sum(entry["iterations"] for entry in completed)
+    aggregate = [
+        "# Gandalf Review Aggregate",
+        "",
+        f"- Runs: {len(entries)}",
+        f"- Completed/blocked runs: {len(completed)}",
+        f"- Approved runs: {len(approved)}",
+        f"- Blocked runs: {len(blocked)}",
+        f"- Corrupt runs: {len(corrupt)}",
+        f"- Total iterations: {total_iterations}",
+        f"- Total review time: {total_review} ms",
+        f"- Total fix time: {total_fix} ms",
+        "",
+        "## Runs",
+        "",
+    ]
+    for entry in entries:
+        aggregate.append(
+            f"- `{entry['run_id']}` {entry['final_verdict']} "
+            f"iterations={entry['iterations']} review_ms={entry['review_duration_ms']} "
+            f"fix_ms={entry['fix_duration_ms']}"
+        )
+    aggregate.append("")
+    (root / AGGREGATE_FILE).write_text("\n".join(aggregate), encoding="utf-8")
+    return entries
+
+
+def export_event(root: Path, run_id: str, event: dict[str, Any], *, no_export: bool) -> None:
+    if no_export:
+        return
+    command = os.environ.get("GANDALF_REVIEW_EXPORT_CMD")
+    if not command:
+        return
+
+    export_dir = run_dir(root, run_id) / "export"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    event_path = export_dir / "latest_event.json"
+    event_path.write_text(json.dumps(event, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GANDALF_REVIEW_EVENT_PATH": str(event_path),
+            "GANDALF_REVIEW_INDEX_PATH": str(root / INDEX_FILE),
+            "GANDALF_REVIEW_AGGREGATE_PATH": str(root / AGGREGATE_FILE),
+            "GANDALF_REVIEW_RUN_SUMMARY_PATH": str(summary_path(root, run_id)),
+            "GANDALF_REVIEW_RUN_DIR": str(run_dir(root, run_id)),
+            "GANDALF_REVIEW_RUN_ID": run_id,
+        }
+    )
+    subprocess.run(shlex.split(command), check=True, env=env, text=True, timeout=60)
+
+
+def command_start(args: argparse.Namespace) -> None:
+    root = Path(args.root).expanduser()
+    started_at = utc_now()
+    run_id = safe_run_id(args.run_id) if args.run_id else make_run_id(args.repo, args.branch, started_at)
+    directory = run_dir(root, run_id)
+    directory.mkdir(parents=True, exist_ok=False)
+
+    metadata = {
+        "run_id": run_id,
+        "repo": args.repo,
+        "branch": args.branch,
+        "base_ref": args.base_ref,
+        "goal": args.goal,
+        "started_at": started_at,
+    }
+    metadata_path(root, run_id).write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    event = {"kind": "run_started", "timestamp": started_at, "run_id": run_id, "summary": args.goal}
+    append_jsonl(metrics_path(root, run_id), event)
+    write_summary(root, run_id)
+    write_aggregate(root)
+    export_event(root, run_id, event, no_export=args.no_export)
+    print(json.dumps({"run_id": run_id, "run_dir": str(directory)}, sort_keys=True))
+
+
+def command_record(args: argparse.Namespace) -> None:
+    root = Path(args.root).expanduser()
+    run_id = safe_run_id(args.run_id)
+    if not metadata_path(root, run_id).exists():
+        raise SystemExit(f"unknown run id: {run_id}")
+    event = {
+        "kind": args.kind,
+        "timestamp": utc_now(),
+        "run_id": run_id,
+    }
+    for field in ("iteration", "reviewer", "verdict", "duration_kind", "duration_ms", "summary", "commit"):
+        value = getattr(args, field)
+        if value is not None:
+            event[field] = value
+    artifact_path = copy_artifact(root, run_id, args)
+    if artifact_path:
+        event["artifact_path"] = artifact_path
+    append_jsonl(metrics_path(root, run_id), event)
+    write_summary(root, run_id)
+    write_aggregate(root)
+    export_event(root, run_id, event, no_export=args.no_export)
+    print(json.dumps(event, sort_keys=True))
+
+
+def command_finish(args: argparse.Namespace) -> None:
+    root = Path(args.root).expanduser()
+    run_id = safe_run_id(args.run_id)
+    if not metadata_path(root, run_id).exists():
+        raise SystemExit(f"unknown run id: {run_id}")
+    kind = "run_blocked" if args.final_verdict == "BLOCKED" else "run_finished"
+    event = {
+        "kind": kind,
+        "timestamp": utc_now(),
+        "run_id": run_id,
+        "final_verdict": args.final_verdict,
+        "summary": args.summary,
+    }
+    if args.blocker:
+        event["blocker"] = args.blocker
+    append_jsonl(metrics_path(root, run_id), event)
+    entry = write_summary(root, run_id)
+    write_aggregate(root)
+    export_event(root, run_id, event, no_export=args.no_export)
+    print(json.dumps(entry, sort_keys=True))
+
+
+def command_aggregate(args: argparse.Namespace) -> None:
+    root = Path(args.root).expanduser()
+    entries = write_aggregate(root)
+    print(json.dumps({"runs": len(entries), "index": str(root / INDEX_FILE)}, sort_keys=True))
+
+
+def parser() -> argparse.ArgumentParser:
+    base = argparse.ArgumentParser(description=__doc__)
+    base.add_argument("--root", default=str(default_root()), help="metrics root directory")
+    subcommands = base.add_subparsers(dest="command", required=True)
+
+    start = subcommands.add_parser("start", help="start a new review loop run")
+    start.add_argument("--run-id")
+    start.add_argument("--repo", required=True)
+    start.add_argument("--branch", required=True)
+    start.add_argument("--base-ref", required=True)
+    start.add_argument("--goal", required=True)
+    start.add_argument("--no-export", action="store_true")
+    start.set_defaults(func=command_start)
+
+    record = subcommands.add_parser("record", help="record one event or artifact")
+    record.add_argument("--run-id", required=True)
+    record.add_argument("--kind", required=True)
+    record.add_argument("--iteration", type=int)
+    record.add_argument("--reviewer", choices=["primary", "adversarial", "implementer"])
+    record.add_argument("--verdict")
+    record.add_argument("--duration-kind", choices=["review", "fix", "validation", "other"])
+    record.add_argument("--duration-ms", type=int)
+    record.add_argument("--summary")
+    record.add_argument("--commit")
+    record.add_argument("--content-file")
+    record.add_argument("--artifact-name")
+    record.add_argument("--no-export", action="store_true")
+    record.set_defaults(func=command_record)
+
+    finish = subcommands.add_parser("finish", help="finish or block a run")
+    finish.add_argument("--run-id", required=True)
+    finish.add_argument("--final-verdict", choices=["APPROVED", "BLOCKED", "STOPPED"], required=True)
+    finish.add_argument("--summary", required=True)
+    finish.add_argument("--blocker")
+    finish.add_argument("--no-export", action="store_true")
+    finish.set_defaults(func=command_finish)
+
+    aggregate = subcommands.add_parser("aggregate", help="rebuild the global aggregate")
+    aggregate.set_defaults(func=command_aggregate)
+    return base
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/gandalf-review/scripts/gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/gandalf_metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import fcntl
 import hashlib
 import json
 import os
@@ -12,6 +13,10 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +44,33 @@ def safe_run_id(value: str) -> str:
 
 def json_line(data: dict[str, Any]) -> str:
     return json.dumps(data, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+@contextmanager
+def locked_archive(root: Path) -> Iterator[None]:
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / ".gandalf_metrics.lock"
+    with lock_path.open("w", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
 
 
 def read_json(path: Path) -> dict[str, Any]:
@@ -137,7 +169,7 @@ def write_summary(root: Path, run_id: str) -> dict[str, Any]:
         lines.append(f"- {event['timestamp']} `{event['kind']}`{suffix} {detail}".rstrip())
     lines.append("")
 
-    summary_path(root, run_id).write_text("\n".join(lines), encoding="utf-8")
+    write_text_atomic(summary_path(root, run_id), "\n".join(lines))
     return entry
 
 
@@ -245,7 +277,7 @@ def write_aggregate(root: Path) -> list[dict[str, Any]]:
             entries.append(entry)
 
     root.mkdir(parents=True, exist_ok=True)
-    (root / INDEX_FILE).write_text("".join(json_line(entry) for entry in entries), encoding="utf-8")
+    write_text_atomic(root / INDEX_FILE, "".join(json_line(entry) for entry in entries))
 
     completed = [entry for entry in entries if entry["final_verdict"] in {"APPROVED", "BLOCKED", "STOPPED"}]
     approved = [entry for entry in completed if entry["final_verdict"] == "APPROVED"]
@@ -276,8 +308,16 @@ def write_aggregate(root: Path) -> list[dict[str, Any]]:
             f"fix_ms={entry['fix_duration_ms']}"
         )
     aggregate.append("")
-    (root / AGGREGATE_FILE).write_text("\n".join(aggregate), encoding="utf-8")
+    write_text_atomic(root / AGGREGATE_FILE, "\n".join(aggregate))
     return entries
+
+
+def exporter_failure_message(error: Exception) -> str:
+    if isinstance(error, subprocess.CalledProcessError):
+        return f"exit {error.returncode}"
+    if isinstance(error, subprocess.TimeoutExpired):
+        return "timed out"
+    return str(error)
 
 
 def export_event(root: Path, run_id: str, event: dict[str, Any], *, no_export: bool) -> None:
@@ -290,7 +330,7 @@ def export_event(root: Path, run_id: str, event: dict[str, Any], *, no_export: b
     export_dir = run_dir(root, run_id) / "export"
     export_dir.mkdir(parents=True, exist_ok=True)
     event_path = export_dir / "latest_event.json"
-    event_path.write_text(json.dumps(event, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_text_atomic(event_path, json.dumps(event, indent=2, sort_keys=True) + "\n")
 
     env = os.environ.copy()
     env.update(
@@ -303,7 +343,13 @@ def export_event(root: Path, run_id: str, event: dict[str, Any], *, no_export: b
             "GANDALF_REVIEW_RUN_ID": run_id,
         }
     )
-    subprocess.run(shlex.split(command), check=True, env=env, text=True, timeout=60)
+    try:
+        subprocess.run(shlex.split(command), check=True, env=env, text=True, timeout=60)
+    except (FileNotFoundError, OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        print(
+            f"warning: GANDALF_REVIEW_EXPORT_CMD failed: {command!r}: {exporter_failure_message(error)}",
+            file=sys.stderr,
+        )
 
 
 def command_start(args: argparse.Namespace) -> None:
@@ -311,7 +357,6 @@ def command_start(args: argparse.Namespace) -> None:
     started_at = utc_now()
     run_id = safe_run_id(args.run_id) if args.run_id else make_run_id(args.repo, args.branch, started_at)
     directory = run_dir(root, run_id)
-    directory.mkdir(parents=True, exist_ok=False)
 
     metadata = {
         "run_id": run_id,
@@ -321,11 +366,16 @@ def command_start(args: argparse.Namespace) -> None:
         "goal": args.goal,
         "started_at": started_at,
     }
-    metadata_path(root, run_id).write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     event = {"kind": "run_started", "timestamp": started_at, "run_id": run_id, "summary": args.goal}
-    append_jsonl(metrics_path(root, run_id), event)
-    write_summary(root, run_id)
-    write_aggregate(root)
+    with locked_archive(root):
+        try:
+            directory.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            raise SystemExit(f"run id already exists: {run_id}") from None
+        write_text_atomic(metadata_path(root, run_id), json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+        append_jsonl(metrics_path(root, run_id), event)
+        write_summary(root, run_id)
+        write_aggregate(root)
     export_event(root, run_id, event, no_export=args.no_export)
     print(json.dumps({"run_id": run_id, "run_dir": str(directory)}, sort_keys=True))
 
@@ -333,8 +383,6 @@ def command_start(args: argparse.Namespace) -> None:
 def command_record(args: argparse.Namespace) -> None:
     root = Path(args.root).expanduser()
     run_id = safe_run_id(args.run_id)
-    if not metadata_path(root, run_id).exists():
-        raise SystemExit(f"unknown run id: {run_id}")
     event = {
         "kind": args.kind,
         "timestamp": utc_now(),
@@ -344,12 +392,15 @@ def command_record(args: argparse.Namespace) -> None:
         value = getattr(args, field)
         if value is not None:
             event[field] = value
-    artifact_path = copy_artifact(root, run_id, args)
-    if artifact_path:
-        event["artifact_path"] = artifact_path
-    append_jsonl(metrics_path(root, run_id), event)
-    write_summary(root, run_id)
-    write_aggregate(root)
+    with locked_archive(root):
+        if not metadata_path(root, run_id).exists():
+            raise SystemExit(f"unknown run id: {run_id}")
+        artifact_path = copy_artifact(root, run_id, args)
+        if artifact_path:
+            event["artifact_path"] = artifact_path
+        append_jsonl(metrics_path(root, run_id), event)
+        write_summary(root, run_id)
+        write_aggregate(root)
     export_event(root, run_id, event, no_export=args.no_export)
     print(json.dumps(event, sort_keys=True))
 
@@ -357,8 +408,6 @@ def command_record(args: argparse.Namespace) -> None:
 def command_finish(args: argparse.Namespace) -> None:
     root = Path(args.root).expanduser()
     run_id = safe_run_id(args.run_id)
-    if not metadata_path(root, run_id).exists():
-        raise SystemExit(f"unknown run id: {run_id}")
     kind = "run_blocked" if args.final_verdict == "BLOCKED" else "run_finished"
     event = {
         "kind": kind,
@@ -369,16 +418,20 @@ def command_finish(args: argparse.Namespace) -> None:
     }
     if args.blocker:
         event["blocker"] = args.blocker
-    append_jsonl(metrics_path(root, run_id), event)
-    entry = write_summary(root, run_id)
-    write_aggregate(root)
+    with locked_archive(root):
+        if not metadata_path(root, run_id).exists():
+            raise SystemExit(f"unknown run id: {run_id}")
+        append_jsonl(metrics_path(root, run_id), event)
+        entry = write_summary(root, run_id)
+        write_aggregate(root)
     export_event(root, run_id, event, no_export=args.no_export)
     print(json.dumps(entry, sort_keys=True))
 
 
 def command_aggregate(args: argparse.Namespace) -> None:
     root = Path(args.root).expanduser()
-    entries = write_aggregate(root)
+    with locked_archive(root):
+        entries = write_aggregate(root)
     print(json.dumps({"runs": len(entries), "index": str(root / INDEX_FILE)}, sort_keys=True))
 
 

--- a/skills/gandalf-review/scripts/gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/gandalf_metrics.py
@@ -330,7 +330,7 @@ def validate_aggregate_entries(entries: list[dict[str, Any]]) -> list[dict[str, 
         missing = [field for field in required_int_fields if field not in entry]
         if missing:
             raise ValueError(f"{INDEX_FILE}:{index} missing fields: {', '.join(missing)}")
-        wrong_type = [field for field in required_int_fields if not isinstance(entry[field], int)]
+        wrong_type = [field for field in required_int_fields if type(entry[field]) is not int]
         if wrong_type:
             raise ValueError(f"{INDEX_FILE}:{index} fields must be integers: {', '.join(wrong_type)}")
     return entries

--- a/skills/gandalf-review/scripts/gandalf_progress.py
+++ b/skills/gandalf-review/scripts/gandalf_progress.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Run a command with an ETA-style progress bar for Gandalf review waits."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import TextIO
+
+
+def progress_line(label: str, elapsed_ms: int, expected_ms: int, width: int) -> str:
+    if expected_ms <= 0:
+        percent = 0
+    else:
+        percent = min(99, int((elapsed_ms / expected_ms) * 100))
+    filled = int((percent / 100) * width)
+    bar = "#" * filled + "-" * (width - filled)
+    return f"\r{label} [{bar}] {percent:>3}% {elapsed_ms}ms"
+
+
+def run_with_progress(args: argparse.Namespace) -> int:
+    stdout_handle: TextIO | None = None
+    stderr_handle: TextIO | None = None
+    try:
+        if args.stdout_file:
+            stdout_path = Path(args.stdout_file)
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            stdout_handle = stdout_path.open("w", encoding="utf-8")
+        if args.stderr_file:
+            stderr_path = Path(args.stderr_file)
+            stderr_path.parent.mkdir(parents=True, exist_ok=True)
+            stderr_handle = stderr_path.open("w", encoding="utf-8")
+
+        started = time.monotonic()
+        process = subprocess.Popen(args.command, stdout=stdout_handle, stderr=stderr_handle)
+        while process.poll() is None:
+            if not args.no_progress:
+                elapsed_ms = int((time.monotonic() - started) * 1000)
+                sys.stderr.write(progress_line(args.label, elapsed_ms, args.expected_ms, args.width))
+                sys.stderr.flush()
+            time.sleep(args.interval_ms / 1000)
+
+        duration_ms = int((time.monotonic() - started) * 1000)
+        if not args.no_progress:
+            sys.stderr.write(f"\r{args.label} [{'#' * args.width}] 100% {duration_ms}ms\n")
+            sys.stderr.flush()
+
+        result = {
+            "command": args.command,
+            "duration_ms": duration_ms,
+            "exit_code": process.returncode,
+            "stderr_file": args.stderr_file,
+            "stdout_file": args.stdout_file,
+        }
+        print(json.dumps(result, sort_keys=True))
+        return process.returncode or 0
+    finally:
+        if stdout_handle:
+            stdout_handle.close()
+        if stderr_handle:
+            stderr_handle.close()
+
+
+def parser() -> argparse.ArgumentParser:
+    base = argparse.ArgumentParser(description=__doc__)
+    base.add_argument("--label", default="review", help="label shown before the progress bar")
+    base.add_argument("--expected-ms", type=int, required=True, help="expected duration before the bar reaches 99%%")
+    base.add_argument("--interval-ms", type=int, default=500, help="progress refresh interval")
+    base.add_argument("--width", type=int, default=24, help="bar width in terminal cells")
+    base.add_argument("--stdout-file", help="write command stdout to this file")
+    base.add_argument("--stderr-file", help="write command stderr to this file")
+    base.add_argument("--no-progress", action="store_true", help="suppress the terminal progress bar")
+    base.add_argument("command", nargs=argparse.REMAINDER, help="command to run, preceded by --")
+    return base
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        raise SystemExit("missing command after --")
+    return run_with_progress(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/gandalf-review/scripts/gandalf_squash.py
+++ b/skills/gandalf-review/scripts/gandalf_squash.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Squash Gandalf iteration commits into one clean branch commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return completed.stdout.strip()
+
+
+def ensure_clean(repo: Path) -> None:
+    status = git(repo, "status", "--porcelain")
+    if status:
+        raise SystemExit("refusing to squash with uncommitted changes")
+
+
+def commit_count(repo: Path, base_ref: str) -> int:
+    count = git(repo, "rev-list", "--count", f"{base_ref}..HEAD")
+    return int(count or "0")
+
+
+def command_squash(args: argparse.Namespace) -> None:
+    repo = Path(args.repo).expanduser().resolve()
+    ensure_clean(repo)
+    count = commit_count(repo, args.base_ref)
+    head_before = git(repo, "rev-parse", "HEAD")
+    merge_base = git(repo, "merge-base", args.base_ref, "HEAD")
+
+    if count <= 1:
+        print(
+            json.dumps(
+                {
+                    "base_ref": args.base_ref,
+                    "commit_count": count,
+                    "head_after": head_before,
+                    "head_before": head_before,
+                    "no_op": True,
+                },
+                sort_keys=True,
+            )
+        )
+        return
+
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "base_ref": args.base_ref,
+                    "commit_count": count,
+                    "head_before": head_before,
+                    "merge_base": merge_base,
+                    "no_op": False,
+                    "would_squash": True,
+                },
+                sort_keys=True,
+            )
+        )
+        return
+
+    git(repo, "reset", "--soft", merge_base)
+    git(repo, "commit", "-m", args.message)
+    head_after = git(repo, "rev-parse", "HEAD")
+    print(
+        json.dumps(
+            {
+                "base_ref": args.base_ref,
+                "commit_count": count,
+                "head_after": head_after,
+                "head_before": head_before,
+                "merge_base": merge_base,
+                "no_op": False,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    base = argparse.ArgumentParser(description=__doc__)
+    base.add_argument("--repo", default=".", help="repository to squash")
+    base.add_argument("--base-ref", default="main", help="base ref to squash commits onto")
+    base.add_argument("--message", required=True, help="final squashed commit message")
+    base.add_argument("--dry-run", action="store_true", help="report what would be squashed without rewriting history")
+    base.set_defaults(func=command_squash)
+    return base
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/gandalf-review/scripts/gandalf_squash.py
+++ b/skills/gandalf-review/scripts/gandalf_squash.py
@@ -80,7 +80,16 @@ def command_squash(args: argparse.Namespace) -> None:
         return
 
     git(repo, "reset", "--soft", merge_base)
-    git(repo, *commit_args(args))
+    try:
+        git(repo, *commit_args(args))
+    except subprocess.CalledProcessError as error:
+        try:
+            git(repo, "reset", "--hard", head_before)
+        except subprocess.CalledProcessError as restore_error:
+            detail = restore_error.stderr.strip() or str(restore_error)
+            raise SystemExit(f"commit failed and restoring HEAD failed: {detail}") from error
+        detail = error.stderr.strip() or str(error)
+        raise SystemExit(f"commit failed; restored HEAD to {head_before}: {detail}") from error
     head_after = git(repo, "rev-parse", "HEAD")
     print(
         json.dumps(

--- a/skills/gandalf-review/scripts/gandalf_squash.py
+++ b/skills/gandalf-review/scripts/gandalf_squash.py
@@ -30,7 +30,18 @@ def commit_count(repo: Path, base_ref: str) -> int:
     return int(count or "0")
 
 
+def commit_args(args: argparse.Namespace) -> list[str]:
+    if args.message_file:
+        return ["commit", "-F", str(Path(args.message_file).expanduser())]
+    command = ["commit", "-m", args.message]
+    if args.body:
+        command.extend(["-m", args.body])
+    return command
+
+
 def command_squash(args: argparse.Namespace) -> None:
+    if args.message_file and args.body:
+        raise SystemExit("--body can only be used with --message")
     repo = Path(args.repo).expanduser().resolve()
     ensure_clean(repo)
     count = commit_count(repo, args.base_ref)
@@ -69,7 +80,7 @@ def command_squash(args: argparse.Namespace) -> None:
         return
 
     git(repo, "reset", "--soft", merge_base)
-    git(repo, "commit", "-m", args.message)
+    git(repo, *commit_args(args))
     head_after = git(repo, "rev-parse", "HEAD")
     print(
         json.dumps(
@@ -90,7 +101,10 @@ def parser() -> argparse.ArgumentParser:
     base = argparse.ArgumentParser(description=__doc__)
     base.add_argument("--repo", default=".", help="repository to squash")
     base.add_argument("--base-ref", default="main", help="base ref to squash commits onto")
-    base.add_argument("--message", required=True, help="final squashed commit message")
+    message = base.add_mutually_exclusive_group(required=True)
+    message.add_argument("--message", help="final squashed commit subject")
+    message.add_argument("--message-file", help="file containing the full final squashed commit message")
+    base.add_argument("--body", help="final squashed commit body; only valid with --message")
     base.add_argument("--dry-run", action="store_true", help="report what would be squashed without rewriting history")
     base.set_defaults(func=command_squash)
     return base

--- a/skills/gandalf-review/scripts/test_gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/test_gandalf_metrics.py
@@ -336,6 +336,46 @@ def test_start_recovers_from_wrong_type_cached_index_entry(tmp_path: Path) -> No
     assert "healthy" in (root / "aggregate.md").read_text()
 
 
+def test_start_recovers_from_boolean_cached_index_integer_fields(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    root.mkdir()
+    (root / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "run_id": "bad",
+                "final_verdict": "APPROVED",
+                "iterations": True,
+                "review_duration_ms": True,
+                "fix_duration_ms": 0,
+                "validation_duration_ms": 0,
+            }
+        )
+        + "\n"
+    )
+
+    started = run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy",
+        "--repo",
+        "liza",
+        "--branch",
+        "feature/index",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Recover boolean aggregate cache",
+    )
+
+    assert started["run_id"] == "healthy"
+    index = read_jsonl(root / "index.jsonl")
+    assert [entry["run_id"] for entry in index] == ["healthy"]
+    aggregate = (root / "aggregate.md").read_text()
+    assert "Total iterations: 0" in aggregate
+    assert "Total review time: 0 ms" in aggregate
+
+
 def test_concurrent_records_keep_metrics_and_aggregate_consistent(tmp_path: Path) -> None:
     root = tmp_path / "gandalf"
     run_metrics(

--- a/skills/gandalf-review/scripts/test_gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/test_gandalf_metrics.py
@@ -246,6 +246,32 @@ def test_duplicate_run_id_exits_without_traceback(tmp_path: Path) -> None:
     assert "Traceback" not in completed.stderr
 
 
+def test_start_recovers_from_malformed_cached_index(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    root.mkdir()
+    (root / "index.jsonl").write_text("{}\n")
+
+    started = run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy",
+        "--repo",
+        "liza",
+        "--branch",
+        "feature/index",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Recover aggregate cache",
+    )
+
+    assert started["run_id"] == "healthy"
+    index = read_jsonl(root / "index.jsonl")
+    assert [entry["run_id"] for entry in index] == ["healthy"]
+    assert "healthy" in (root / "aggregate.md").read_text()
+
+
 def test_concurrent_records_keep_metrics_and_aggregate_consistent(tmp_path: Path) -> None:
     root = tmp_path / "gandalf"
     run_metrics(
@@ -717,3 +743,41 @@ def test_squash_helper_accepts_message_file(tmp_path: Path) -> None:
     assert result["commit_count"] == 2
     assert git(repo, "rev-list", "--count", "main..HEAD") == "1"
     assert git(repo, "log", "-1", "--pretty=%B") == message_file.read_text().strip()
+
+
+def test_squash_helper_restores_head_when_commit_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "gandalf@example.test")
+    git(repo, "config", "user.name", "Gandalf Test")
+    commit_file(repo, "README.md", "base\n", "chore: base")
+    git(repo, "checkout", "-b", "feature/gandalf")
+    commit_file(repo, "one.txt", "one\n", "fix(gandalf): iteration 1 repair")
+    commit_file(repo, "two.txt", "two\n", "fix(gandalf): iteration 2 repair")
+    head_before = git(repo, "rev-parse", "HEAD")
+    hook = repo / ".git/hooks/pre-commit"
+    hook.write_text("#!/bin/sh\necho failing hook >&2\nexit 1\n")
+    hook.chmod(0o755)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SQUASH_SCRIPT),
+            "--repo",
+            str(repo),
+            "--base-ref",
+            "main",
+            "--message",
+            "feat(gandalf): final approval loop",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert completed.returncode != 0
+    assert "commit failed; restored HEAD" in completed.stderr
+    assert git(repo, "rev-parse", "HEAD") == head_before
+    assert git(repo, "rev-list", "--count", "main..HEAD") == "2"
+    assert git(repo, "status", "--porcelain") == ""

--- a/skills/gandalf-review/scripts/test_gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/test_gandalf_metrics.py
@@ -298,6 +298,44 @@ def test_start_recovers_from_incomplete_cached_index_entry(tmp_path: Path) -> No
     assert "healthy" in (root / "aggregate.md").read_text()
 
 
+def test_start_recovers_from_wrong_type_cached_index_entry(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    root.mkdir()
+    (root / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "run_id": "bad",
+                "final_verdict": "APPROVED",
+                "iterations": 0,
+                "review_duration_ms": "oops",
+                "fix_duration_ms": 0,
+                "validation_duration_ms": 0,
+            }
+        )
+        + "\n"
+    )
+
+    started = run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy",
+        "--repo",
+        "liza",
+        "--branch",
+        "feature/index",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Recover wrong-type aggregate cache",
+    )
+
+    assert started["run_id"] == "healthy"
+    index = read_jsonl(root / "index.jsonl")
+    assert [entry["run_id"] for entry in index] == ["healthy"]
+    assert "healthy" in (root / "aggregate.md").read_text()
+
+
 def test_concurrent_records_keep_metrics_and_aggregate_consistent(tmp_path: Path) -> None:
     root = tmp_path / "gandalf"
     run_metrics(

--- a/skills/gandalf-review/scripts/test_gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/test_gandalf_metrics.py
@@ -165,6 +165,147 @@ def test_export_command_receives_generic_paths(tmp_path: Path) -> None:
     assert exported[4] == "export-run"
 
 
+def test_export_failure_warns_without_failing_core_archive(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    env = os.environ.copy()
+    env["GANDALF_REVIEW_EXPORT_CMD"] = f'{sys.executable} -c "import sys; sys.exit(7)"'
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "start",
+            "--run-id",
+            "export-fails",
+            "--repo",
+            "liza",
+            "--branch",
+            "feature/export",
+            "--base-ref",
+            "main",
+            "--goal",
+            "Check export warning",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert json.loads(completed.stdout)["run_id"] == "export-fails"
+    assert "warning: GANDALF_REVIEW_EXPORT_CMD failed" in completed.stderr
+    assert (root / "runs/export-fails/metrics.jsonl").exists()
+    assert (root / "index.jsonl").exists()
+
+
+def test_duplicate_run_id_exits_without_traceback(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "duplicate",
+        "--repo",
+        "liza",
+        "--branch",
+        "feature/duplicate",
+        "--base-ref",
+        "main",
+        "--goal",
+        "First run",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "start",
+            "--run-id",
+            "duplicate",
+            "--repo",
+            "liza",
+            "--branch",
+            "feature/duplicate",
+            "--base-ref",
+            "main",
+            "--goal",
+            "Second run",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+    assert "run id already exists: duplicate" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_concurrent_records_keep_metrics_and_aggregate_consistent(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "concurrent",
+        "--repo",
+        "liza",
+        "--branch",
+        "feature/concurrent",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Check concurrent records",
+    )
+
+    commands = [
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "record",
+            "--run-id",
+            "concurrent",
+            "--kind",
+            "fix_finished",
+            "--iteration",
+            str(iteration),
+            "--duration-kind",
+            "fix",
+            "--duration-ms",
+            "10",
+            "--summary",
+            f"fix {iteration}",
+        ]
+        for iteration in range(1, 9)
+    ]
+
+    processes = [
+        subprocess.Popen(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) for command in commands
+    ]
+    results = [process.communicate(timeout=10) + (process.returncode,) for process in processes]
+
+    for stdout, stderr, returncode in results:
+        assert returncode == 0, stderr
+        assert json.loads(stdout)["kind"] == "fix_finished"
+
+    events = read_jsonl(root / "runs/concurrent/metrics.jsonl")
+    fix_events = [event for event in events if event["kind"] == "fix_finished"]
+    assert len(fix_events) == 8
+    assert {event["iteration"] for event in fix_events} == set(range(1, 9))
+
+    index = read_jsonl(root / "index.jsonl")
+    assert index[0]["run_id"] == "concurrent"
+    assert index[0]["iterations"] == 8
+    assert index[0]["fix_duration_ms"] == 80
+
+
 def test_custom_run_id_is_confined_to_runs_root(tmp_path: Path) -> None:
     root = tmp_path / "gandalf"
 
@@ -461,6 +602,8 @@ def test_squash_helper_collapses_iteration_commits(tmp_path: Path) -> None:
             "main",
             "--message",
             "feat(gandalf): final approval loop",
+            "--body",
+            "Why: collapse reviewed repair commits.\n\nWhat: preserve the approved final tree.",
         ],
         check=True,
         text=True,
@@ -472,5 +615,45 @@ def test_squash_helper_collapses_iteration_commits(tmp_path: Path) -> None:
     assert result["no_op"] is False
     assert git(repo, "rev-list", "--count", "main..HEAD") == "1"
     assert git(repo, "log", "-1", "--pretty=%s") == "feat(gandalf): final approval loop"
+    assert "Why: collapse reviewed repair commits." in git(repo, "log", "-1", "--pretty=%B")
     assert (repo / "one.txt").read_text() == "one\n"
     assert (repo / "two.txt").read_text() == "two\n"
+
+
+def test_squash_helper_accepts_message_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "gandalf@example.test")
+    git(repo, "config", "user.name", "Gandalf Test")
+    commit_file(repo, "README.md", "base\n", "chore: base")
+    git(repo, "checkout", "-b", "feature/gandalf")
+    commit_file(repo, "one.txt", "one\n", "fix(gandalf): iteration 1 repair")
+    commit_file(repo, "two.txt", "two\n", "fix(gandalf): iteration 2 repair")
+    message_file = tmp_path / "commit-message.txt"
+    message_file.write_text(
+        "feat(gandalf): final approval loop\n\n"
+        "Why: preserve reviewability during fixes and ship one clean PR commit.\n\n"
+        "What: squash iteration commits after both reviewers approve.\n"
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SQUASH_SCRIPT),
+            "--repo",
+            str(repo),
+            "--base-ref",
+            "main",
+            "--message-file",
+            str(message_file),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["commit_count"] == 2
+    assert git(repo, "rev-list", "--count", "main..HEAD") == "1"
+    assert git(repo, "log", "-1", "--pretty=%B") == message_file.read_text().strip()

--- a/skills/gandalf-review/scripts/test_gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/test_gandalf_metrics.py
@@ -306,6 +306,66 @@ def test_concurrent_records_keep_metrics_and_aggregate_consistent(tmp_path: Path
     assert index[0]["fix_duration_ms"] == 80
 
 
+def test_record_updates_current_run_without_rewriting_historical_summaries(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "historical",
+        "--repo",
+        "liza",
+        "--branch",
+        "main",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Historical run",
+    )
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "active",
+        "--repo",
+        "liza",
+        "--branch",
+        "feature/perf",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Active run",
+    )
+    historical_summary = root / "runs/historical/summary.md"
+    historical_summary.write_text("sentinel historical summary\n")
+
+    run_metrics(
+        root,
+        "record",
+        "--run-id",
+        "active",
+        "--kind",
+        "fix_finished",
+        "--iteration",
+        "1",
+        "--duration-kind",
+        "fix",
+        "--duration-ms",
+        "25",
+        "--summary",
+        "incremental fix",
+    )
+
+    assert historical_summary.read_text() == "sentinel historical summary\n"
+    index = {entry["run_id"]: entry for entry in read_jsonl(root / "index.jsonl")}
+    assert index["historical"]["final_verdict"] == "IN_PROGRESS"
+    assert index["active"]["iterations"] == 1
+    assert index["active"]["fix_duration_ms"] == 25
+    aggregate = (root / "aggregate.md").read_text()
+    assert "`historical` IN_PROGRESS" in aggregate
+    assert "`active` IN_PROGRESS iterations=1 review_ms=0 fix_ms=25" in aggregate
+
+
 def test_custom_run_id_is_confined_to_runs_root(tmp_path: Path) -> None:
     root = tmp_path / "gandalf"
 

--- a/skills/gandalf-review/scripts/test_gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/test_gandalf_metrics.py
@@ -1,0 +1,476 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("gandalf_metrics.py")
+PROGRESS_SCRIPT = Path(__file__).with_name("gandalf_progress.py")
+FAST_HOME_SCRIPT = Path(__file__).with_name("gandalf_codex_fast_home.py")
+SQUASH_SCRIPT = Path(__file__).with_name("gandalf_squash.py")
+
+
+def run_metrics(root: Path, *args: str, env: dict[str, str] | None = None) -> dict:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    return json.loads(completed.stdout)
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_records_run_artifacts_and_rebuilds_aggregate(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    review = tmp_path / "review.md"
+    review.write_text("**Verdict:** Changes requested\n\nFix auth guard.\n")
+
+    started = run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "test-run",
+        "--repo",
+        "omni",
+        "--branch",
+        "feature/auth",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Review auth change",
+    )
+    assert started["run_id"] == "test-run"
+
+    run_metrics(
+        root,
+        "record",
+        "--run-id",
+        "test-run",
+        "--kind",
+        "primary_review_finished",
+        "--iteration",
+        "1",
+        "--reviewer",
+        "primary",
+        "--verdict",
+        "Changes requested",
+        "--duration-kind",
+        "review",
+        "--duration-ms",
+        "1200",
+        "--summary",
+        "Auth guard missing",
+        "--content-file",
+        str(review),
+        "--artifact-name",
+        "primary-review.md",
+    )
+    run_metrics(
+        root,
+        "record",
+        "--run-id",
+        "test-run",
+        "--kind",
+        "fix_finished",
+        "--iteration",
+        "1",
+        "--duration-kind",
+        "fix",
+        "--duration-ms",
+        "3400",
+        "--summary",
+        "Added guard and regression test",
+        "--commit",
+        "abc1234",
+    )
+    finished = run_metrics(
+        root,
+        "finish",
+        "--run-id",
+        "test-run",
+        "--final-verdict",
+        "APPROVED",
+        "--summary",
+        "Approved after one fix loop",
+    )
+
+    assert finished["iterations"] == 1
+    assert finished["review_duration_ms"] == 1200
+    assert finished["fix_duration_ms"] == 3400
+    assert finished["final_verdict"] == "APPROVED"
+
+    artifact = root / "runs/test-run/artifacts/iteration-1/primary-review.md"
+    assert artifact.read_text() == review.read_text()
+    assert "Approved after one fix loop" in (root / "runs/test-run/summary.md").read_text()
+
+    aggregate = run_metrics(root, "aggregate")
+    assert aggregate["runs"] == 1
+    index = read_jsonl(root / "index.jsonl")
+    assert index[0]["run_id"] == "test-run"
+    assert index[0]["review_duration_ms"] == 1200
+    fix_event = next(
+        item for item in read_jsonl(root / "runs/test-run/metrics.jsonl") if item["kind"] == "fix_finished"
+    )
+    assert fix_event["commit"] == "abc1234"
+    assert index[0]["artifact_path"].endswith("runs/test-run")
+    assert index[0]["recap"] == "Approved after one fix loop"
+    assert "Total iterations: 1" in (root / "aggregate.md").read_text()
+
+
+def test_export_command_receives_generic_paths(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    export_log = tmp_path / "export.log"
+    exporter = tmp_path / "exporter.py"
+    exporter.write_text(
+        "import os, pathlib\n"
+        "pathlib.Path(os.environ['EXPORT_LOG']).write_text('\\n'.join([\n"
+        "os.environ['GANDALF_REVIEW_EVENT_PATH'],\n"
+        "os.environ['GANDALF_REVIEW_INDEX_PATH'],\n"
+        "os.environ['GANDALF_REVIEW_AGGREGATE_PATH'],\n"
+        "os.environ['GANDALF_REVIEW_RUN_SUMMARY_PATH'],\n"
+        "os.environ['GANDALF_REVIEW_RUN_ID'],\n"
+        "]))\n"
+    )
+
+    env = os.environ.copy()
+    env["EXPORT_LOG"] = str(export_log)
+    env["GANDALF_REVIEW_EXPORT_CMD"] = f"{sys.executable} {exporter}"
+
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "export-run",
+        "--repo",
+        "omni",
+        "--branch",
+        "feature/export",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Check export",
+        env=env,
+    )
+
+    exported = export_log.read_text().splitlines()
+    assert exported[0].endswith("latest_event.json")
+    assert exported[1].endswith("index.jsonl")
+    assert exported[2].endswith("aggregate.md")
+    assert exported[3].endswith("summary.md")
+    assert exported[4] == "export-run"
+
+
+def test_custom_run_id_is_confined_to_runs_root(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+
+    started = run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "../escape/../../bad",
+        "--repo",
+        "omni",
+        "--branch",
+        "feature/auth",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Review auth change",
+    )
+
+    assert started["run_id"] == "escape-..-..-bad"
+    assert (root / "runs" / "escape-..-..-bad" / "metadata.json").exists()
+    assert not (root.parent / "bad").exists()
+
+    recorded = run_metrics(
+        root,
+        "record",
+        "--run-id",
+        "../escape/../../bad",
+        "--kind",
+        "fix_finished",
+        "--iteration",
+        "1",
+        "--summary",
+        "safe lookup",
+    )
+
+    assert recorded["run_id"] == "escape-..-..-bad"
+
+
+def test_aggregate_survives_corrupt_historical_run(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    corrupt = root / "runs" / "corrupt-run"
+    corrupt.mkdir(parents=True)
+    (corrupt / "metadata.json").write_text('{"run_id": "corrupt-run"}')
+    (corrupt / "metrics.jsonl").write_text("{not json}\n")
+
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy-run",
+        "--repo",
+        "omni",
+        "--branch",
+        "feature/auth",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Review auth change",
+    )
+
+    index = read_jsonl(root / "index.jsonl")
+    corrupt_entry = next(item for item in index if item["run_id"] == "corrupt-run")
+    healthy_entry = next(item for item in index if item["run_id"] == "healthy-run")
+    assert corrupt_entry["final_verdict"] == "CORRUPT"
+    assert "cannot read run metrics" in corrupt_entry["blocker"]
+    assert healthy_entry["final_verdict"] == "IN_PROGRESS"
+    aggregate = (root / "aggregate.md").read_text()
+    assert "Completed/blocked runs: 0" in aggregate
+    assert "Corrupt runs: 1" in aggregate
+
+
+def test_aggregate_survives_structurally_corrupt_historical_run(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    corrupt = root / "runs" / "structural-corrupt-run"
+    corrupt.mkdir(parents=True)
+    (corrupt / "metadata.json").write_text('{"run_id": "structural-corrupt-run", "started_at": "not-a-date"}')
+    (corrupt / "metrics.jsonl").write_text(
+        '{"kind": "run_finished", "timestamp": "2026-06-19T00:00:00Z", '
+        '"final_verdict": "APPROVED", "summary": "bad historical data"}\n'
+    )
+
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy-run",
+        "--repo",
+        "omni",
+        "--branch",
+        "feature/auth",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Review auth change",
+    )
+
+    index = read_jsonl(root / "index.jsonl")
+    corrupt_entry = next(item for item in index if item["run_id"] == "structural-corrupt-run")
+    healthy_entry = next(item for item in index if item["run_id"] == "healthy-run")
+    assert corrupt_entry["final_verdict"] == "CORRUPT"
+    assert "Invalid isoformat string" in corrupt_entry["blocker"]
+    assert healthy_entry["final_verdict"] == "IN_PROGRESS"
+
+
+def test_aggregate_survives_wrong_json_shapes_in_historical_run(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    bad_metadata = root / "runs" / "bad-metadata-shape"
+    bad_metadata.mkdir(parents=True)
+    (bad_metadata / "metadata.json").write_text("[]")
+    (bad_metadata / "metrics.jsonl").write_text('{"kind": "run_started", "timestamp": "2026-06-19T00:00:00Z"}\n')
+
+    bad_event = root / "runs" / "bad-event-shape"
+    bad_event.mkdir(parents=True)
+    (bad_event / "metadata.json").write_text('{"run_id": "bad-event-shape"}')
+    (bad_event / "metrics.jsonl").write_text("[]\n")
+
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy-run",
+        "--repo",
+        "omni",
+        "--branch",
+        "feature/auth",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Review auth change",
+    )
+
+    index = read_jsonl(root / "index.jsonl")
+    corrupt_entries = {
+        item["run_id"]: item for item in index if item["run_id"] in {"bad-metadata-shape", "bad-event-shape"}
+    }
+    assert corrupt_entries["bad-metadata-shape"]["final_verdict"] == "CORRUPT"
+    assert "metadata.json must contain a JSON object" in corrupt_entries["bad-metadata-shape"]["blocker"]
+    assert corrupt_entries["bad-event-shape"]["final_verdict"] == "CORRUPT"
+    assert "metrics.jsonl:1 must contain a JSON object" in corrupt_entries["bad-event-shape"]["blocker"]
+
+
+def test_aggregate_survives_wrong_timestamp_type_in_historical_run(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    corrupt = root / "runs" / "bad-timestamp-type"
+    corrupt.mkdir(parents=True)
+    (corrupt / "metadata.json").write_text('{"run_id": "bad-timestamp-type", "started_at": 1700000000}')
+    (corrupt / "metrics.jsonl").write_text(
+        '{"kind": "run_finished", "timestamp": "2026-06-19T00:00:00Z", '
+        '"final_verdict": "APPROVED", "summary": "bad historical data"}\n'
+    )
+
+    run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy-run",
+        "--repo",
+        "omni",
+        "--branch",
+        "feature/auth",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Review auth change",
+    )
+
+    index = read_jsonl(root / "index.jsonl")
+    corrupt_entry = next(item for item in index if item["run_id"] == "bad-timestamp-type")
+    healthy_entry = next(item for item in index if item["run_id"] == "healthy-run")
+    assert corrupt_entry["final_verdict"] == "CORRUPT"
+    assert "started_at must be an ISO timestamp string" in corrupt_entry["blocker"]
+    assert healthy_entry["final_verdict"] == "IN_PROGRESS"
+
+
+def test_progress_wrapper_records_duration_and_stdout_file(tmp_path: Path) -> None:
+    output = tmp_path / "review.md"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(PROGRESS_SCRIPT),
+            "--label",
+            "primary",
+            "--expected-ms",
+            "1000",
+            "--no-progress",
+            "--stdout-file",
+            str(output),
+            "--",
+            sys.executable,
+            "-c",
+            "print('approved')",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["exit_code"] == 0
+    assert result["stdout_file"] == str(output)
+    assert result["duration_ms"] >= 0
+    assert output.read_text().strip() == "approved"
+
+
+def test_progress_wrapper_caps_waiting_bar_at_99_percent(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(PROGRESS_SCRIPT),
+            "--label",
+            "primary",
+            "--expected-ms",
+            "1",
+            "--interval-ms",
+            "5",
+            "--width",
+            "10",
+            "--stdout-file",
+            str(tmp_path / "out.txt"),
+            "--",
+            sys.executable,
+            "-c",
+            "import time; time.sleep(0.03)",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert " 99%" in completed.stderr
+    assert "100%" in completed.stderr
+
+
+def test_codex_fast_home_writes_task_local_fast_config(tmp_path: Path) -> None:
+    auth_source = tmp_path / "auth.json"
+    auth_source.write_text("{}")
+    codex_home = tmp_path / "codex-home"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(FAST_HOME_SCRIPT),
+            "--output-dir",
+            str(codex_home),
+            "--auth-source",
+            str(auth_source),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    result = json.loads(completed.stdout)
+    config = (codex_home / "config.toml").read_text()
+    assert result["env"]["CODEX_HOME"] == str(codex_home)
+    assert result["reasoning_effort"] == "minimal"
+    assert 'model_reasoning_effort = "minimal"' in config
+    assert 'approval_policy = "never"' in config
+    assert (codex_home / "auth.json").is_symlink()
+    assert (codex_home / "auth.json").resolve() == auth_source
+
+
+def git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(["git", "-C", str(repo), *args], check=True, text=True, capture_output=True)
+    return completed.stdout.strip()
+
+
+def commit_file(repo: Path, name: str, content: str, message: str) -> str:
+    path = repo / name
+    path.write_text(content)
+    git(repo, "add", name)
+    git(repo, "commit", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+def test_squash_helper_collapses_iteration_commits(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "gandalf@example.test")
+    git(repo, "config", "user.name", "Gandalf Test")
+    commit_file(repo, "README.md", "base\n", "chore: base")
+    git(repo, "checkout", "-b", "feature/gandalf")
+    commit_file(repo, "one.txt", "one\n", "fix(gandalf): iteration 1 repair")
+    commit_file(repo, "two.txt", "two\n", "fix(gandalf): iteration 2 repair")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SQUASH_SCRIPT),
+            "--repo",
+            str(repo),
+            "--base-ref",
+            "main",
+            "--message",
+            "feat(gandalf): final approval loop",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["commit_count"] == 2
+    assert result["no_op"] is False
+    assert git(repo, "rev-list", "--count", "main..HEAD") == "1"
+    assert git(repo, "log", "-1", "--pretty=%s") == "feat(gandalf): final approval loop"
+    assert (repo / "one.txt").read_text() == "one\n"
+    assert (repo / "two.txt").read_text() == "two\n"

--- a/skills/gandalf-review/scripts/test_gandalf_metrics.py
+++ b/skills/gandalf-review/scripts/test_gandalf_metrics.py
@@ -272,6 +272,32 @@ def test_start_recovers_from_malformed_cached_index(tmp_path: Path) -> None:
     assert "healthy" in (root / "aggregate.md").read_text()
 
 
+def test_start_recovers_from_incomplete_cached_index_entry(tmp_path: Path) -> None:
+    root = tmp_path / "gandalf"
+    root.mkdir()
+    (root / "index.jsonl").write_text('{"run_id":"bad"}\n')
+
+    started = run_metrics(
+        root,
+        "start",
+        "--run-id",
+        "healthy",
+        "--repo",
+        "liza",
+        "--branch",
+        "feature/index",
+        "--base-ref",
+        "main",
+        "--goal",
+        "Recover incomplete aggregate cache",
+    )
+
+    assert started["run_id"] == "healthy"
+    index = read_jsonl(root / "index.jsonl")
+    assert [entry["run_id"] for entry in index] == ["healthy"]
+    assert "healthy" in (root / "aggregate.md").read_text()
+
+
 def test_concurrent_records_keep_metrics_and_aggregate_consistent(tmp_path: Path) -> None:
     root = tmp_path / "gandalf"
     run_metrics(

--- a/specs/functional/1.6 - Skills.md
+++ b/specs/functional/1.6 - Skills.md
@@ -27,6 +27,7 @@ The contract remains the governing layer. Skills do not override gates or invari
 - 1.6.15 — [Have You Considered](../../skills/have-you-considered/SKILL.md) — Structured alternative exploration
 - 1.6.16 — [Feynman](../../skills/feynman/SKILL.md) — Explain complex topics in simplified form
 - 1.6.17 — [Context Engineering](../../skills/context-engineering/SKILL.md) — Analyze agent prompts and outputs for context quality, bloat, handoff fit, and prompt-output feedback loops
+- 1.6.18 — [Gandalf Review](../../skills/gandalf-review/SKILL.md) — Local adversarial QA fix/review loops with per-run metrics, aggregate archives, pre-PR hooks, fix commits, and reviewer progress bars
 
 ## Boundaries
 
@@ -41,5 +42,5 @@ The contract remains the governing layer. Skills do not override gates or invari
 
 ---
 *Status: active*
-*Last verified: 2026-02-22*
+*Last verified: 2026-06-19*
 *Parent: [Product Description](<1 - Liza.md>)*

--- a/specs/spec-mapping.yaml
+++ b/specs/spec-mapping.yaml
@@ -1,6 +1,6 @@
 version: 1
 repository: "git@github.com:liza-mas/liza.git"
-last_updated: "2026-02-22T17:11:25Z"
+last_updated: "2026-06-19T00:00:00Z"
 code_classification:
   "cmd/liza/main.go": {type: functional, confidence: confirmed}
   "internal/commands/claim_task.go": {type: functional, confidence: confirmed}
@@ -37,6 +37,11 @@ code_classification:
   skills/debugging/SKILL.md: {type: functional, confidence: confirmed}
   skills/feynman/SKILL.md: {type: functional, confidence: confirmed}
   skills/generic-subagent/SKILL.md: {type: functional, confidence: confirmed}
+  skills/gandalf-review/SKILL.md: {type: functional, confidence: confirmed}
+  skills/gandalf-review/scripts/gandalf_codex_fast_home.py: {type: functional, confidence: confirmed}
+  skills/gandalf-review/scripts/gandalf_metrics.py: {type: functional, confidence: confirmed}
+  skills/gandalf-review/scripts/gandalf_progress.py: {type: functional, confidence: confirmed}
+  skills/gandalf-review/scripts/gandalf_squash.py: {type: functional, confidence: confirmed}
   skills/have-you-considered/SKILL.md: {type: functional, confidence: confirmed}
   skills/lesson-capture/SKILL.md: {type: functional, confidence: confirmed}
   skills/software-architecture-review/SKILL.md: {type: functional, confidence: confirmed}
@@ -553,6 +558,51 @@ mappings:
     confidence: confirmed
     conflict_details: null
     last_verified: "2026-02-22"
+  skills/gandalf-review/SKILL.md:
+    status: new
+    code_sha: null
+    spec_sha: null
+    spec_path: specs/functional/1.6 - Skills.md
+    spec_title: Skills
+    confidence: unverified
+    conflict_details: null
+    last_verified: null
+  skills/gandalf-review/scripts/gandalf_codex_fast_home.py:
+    status: new
+    code_sha: null
+    spec_sha: null
+    spec_path: specs/functional/1.6 - Skills.md
+    spec_title: Skills
+    confidence: unverified
+    conflict_details: null
+    last_verified: null
+  skills/gandalf-review/scripts/gandalf_metrics.py:
+    status: new
+    code_sha: null
+    spec_sha: null
+    spec_path: specs/functional/1.6 - Skills.md
+    spec_title: Skills
+    confidence: unverified
+    conflict_details: null
+    last_verified: null
+  skills/gandalf-review/scripts/gandalf_progress.py:
+    status: new
+    code_sha: null
+    spec_sha: null
+    spec_path: specs/functional/1.6 - Skills.md
+    spec_title: Skills
+    confidence: unverified
+    conflict_details: null
+    last_verified: null
+  skills/gandalf-review/scripts/gandalf_squash.py:
+    status: new
+    code_sha: null
+    spec_sha: null
+    spec_path: specs/functional/1.6 - Skills.md
+    spec_title: Skills
+    confidence: unverified
+    conflict_details: null
+    last_verified: null
   skills/have-you-considered/SKILL.md:
     status: aligned
     code_sha: 6ea75a8
@@ -1482,6 +1532,11 @@ specs:
       - skills/debugging/SKILL.md
       - skills/feynman/SKILL.md
       - skills/generic-subagent/SKILL.md
+      - skills/gandalf-review/SKILL.md
+      - skills/gandalf-review/scripts/gandalf_codex_fast_home.py
+      - skills/gandalf-review/scripts/gandalf_metrics.py
+      - skills/gandalf-review/scripts/gandalf_progress.py
+      - skills/gandalf-review/scripts/gandalf_squash.py
       - skills/have-you-considered/SKILL.md
       - skills/lesson-capture/SKILL.md
       - skills/software-architecture-review/SKILL.md

--- a/stacklit-insights.json
+++ b/stacklit-insights.json
@@ -49,6 +49,7 @@
     "scripts/repro": "Shell reproducers for operational debugging scenarios such as pre-commit bootstrap flows.",
     "skills/adversarial-pairing/scripts": "Skill-local Python tooling for locked Markdown blackboard writes in adversarial-pairing workflows.",
     "skills/context-engineering/scripts": "Python tooling for indexing prompt, output, and context corpora for context-engineering analysis.",
+    "skills/gandalf-review/scripts": "Scripts",
     "skills/liza-logs/scripts": "Python tooling for analyzing and querying Liza logs and blackboard state dumps.",
     "skills/spec-backfill/scripts": "Shell tooling for detecting stale specs and updating spec-to-code mappings.",
     "skills/white-box-red-testing/scripts": "Python target discovery support for white-box red-test generation."

--- a/stacklit-insights.json
+++ b/stacklit-insights.json
@@ -49,7 +49,7 @@
     "scripts/repro": "Shell reproducers for operational debugging scenarios such as pre-commit bootstrap flows.",
     "skills/adversarial-pairing/scripts": "Skill-local Python tooling for locked Markdown blackboard writes in adversarial-pairing workflows.",
     "skills/context-engineering/scripts": "Python tooling for indexing prompt, output, and context corpora for context-engineering analysis.",
-    "skills/gandalf-review/scripts": "Scripts",
+    "skills/gandalf-review/scripts": "Python tooling for Gandalf review metrics archives, progress capture, task-local reviewer config, and final squash commits.",
     "skills/liza-logs/scripts": "Python tooling for analyzing and querying Liza logs and blackboard state dumps.",
     "skills/spec-backfill/scripts": "Shell tooling for detecting stale specs and updating spec-to-code mappings.",
     "skills/white-box-red-testing/scripts": "Python target discovery support for white-box red-test generation."


### PR DESCRIPTION
## Summary
- Add the `gandalf-review` skill for local adversarial review/fix loops before opening a PR.
- Archive per-run metrics, artifacts, aggregate summaries, and optional generic export events.
- Add helper scripts for task-local Codex Fast Mode, reviewer progress bars, per-iteration commit tracking, and final squash cleanup.
- Document the pre-open PR workflow and map the skill/helpers into the skills spec.

## Output Example

```markdown
# Gandalf Review Ledger

Final verdict: APPROVED
Total elapsed: 27m34s
Total review: 15m04s
Total fix: 2m27s
Total validation: 2m25s

| Iteration | Primary | Adversarial | Fix | Commit | Result |
|---:|---|---|---|---|---|
| 1 | Changes requested | Changes requested | Sanitize run IDs and quarantine corrupt JSON archives | <sha> | Re-review |
| 2 | Changes requested | Not run | Quarantine semantic summary failures | <sha> | Re-review |
| 3 | Changes requested | Not run | Validate metadata/event JSON object shape | <sha> | Re-review |
| 4 | Approved | Changes requested | Validate timestamp field types | <sha> | Re-review |
| 5 | Approved | Approved | None | n/a | APPROVED |

Validation:
- `pytest -q skills/gandalf-review/scripts/test_gandalf_metrics.py` -> passed
- `pre-commit run --files ...` -> passed
- `make sync-embedded && make check-embedded` -> passed
- `GIT_CONFIG_GLOBAL=/dev/null make test` -> passed

Artifacts:
- Run summary: `~/.liza/gandalf-review/runs/<run-id>/summary.md`
- Aggregate: `~/.liza/gandalf-review/aggregate.md`
- Index: `~/.liza/gandalf-review/index.jsonl`
```

## Validation
- `pytest -q skills/gandalf-review/scripts/test_gandalf_metrics.py` -> 11 passed
- `quick_validate.py skills/gandalf-review` -> passed
- `pre-commit run --files ...` -> passed
- `make sync-embedded && make check-embedded` -> passed
- `GIT_CONFIG_GLOBAL=/dev/null make test` -> passed
