### PR TITLE
ci: share and optimize workflow execution

### DIFF
--- a/.github/ci-benchmark-2026-07-19.json
+++ b/.github/ci-benchmark-2026-07-19.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "retrieved_at": "2026-07-19T20:08:10Z",
+  "repository": "liza-mas/liza",
+  "pull_request": 99,
+  "hosted": {
+    "provider": "GitHub Actions",
+    "workflow_id": 235652292,
+    "selection": {
+      "event": "pull_request",
+      "status": "success",
+      "ordering": "newest to oldest before 2026-07-19T18:57:51Z",
+      "included": "first seven runs with successful final-attempt ubuntu-latest and macos-latest jobs",
+      "workflow_wall_definition": "updated_at minus run_started_at",
+      "job_runtime_definition": "completed_at minus started_at",
+      "queue_definition": "started_at minus created_at",
+      "trial_count": 7
+    },
+    "baseline_runs": [
+      {"run_id": 29415285530, "attempt": 1, "head_sha": "87782c0ce5d8318026ada2771e95bc74444b341d", "wall_seconds": 481, "linux_seconds": 284, "linux_queue_seconds": 2, "macos_seconds": 477, "macos_queue_seconds": 3},
+      {"run_id": 29363238333, "attempt": 1, "head_sha": "1cc5e196151bb0d1d5213ff19306aae22948bc10", "wall_seconds": 390, "linux_seconds": 265, "linux_queue_seconds": 2, "macos_seconds": 386, "macos_queue_seconds": 2},
+      {"run_id": 28765220516, "attempt": 2, "head_sha": "01f8785c8b1a425783738659a433895b42db2082", "wall_seconds": 424, "linux_seconds": 276, "linux_queue_seconds": 1, "macos_seconds": 420, "macos_queue_seconds": 2},
+      {"run_id": 28763866016, "attempt": 1, "head_sha": "1947e77243f64c1d9252701b8959dda49e6dd5d0", "wall_seconds": 354, "linux_seconds": 279, "linux_queue_seconds": 2, "macos_seconds": 351, "macos_queue_seconds": 2},
+      {"run_id": 28754270342, "attempt": 1, "head_sha": "136de2987624b671f06aca89c0f223eff28bd81b", "wall_seconds": 288, "linux_seconds": 276, "linux_queue_seconds": 1, "macos_seconds": 284, "macos_queue_seconds": 2},
+      {"run_id": 28479610536, "attempt": 1, "head_sha": "c7840a596516d70977075a70b1ca9575aaff18b6", "wall_seconds": 302, "linux_seconds": 288, "linux_queue_seconds": 2, "macos_seconds": 300, "macos_queue_seconds": 2},
+      {"run_id": 28478483788, "attempt": 1, "head_sha": "06632431502d108f68a21f92f109e77c3c21f3b0", "wall_seconds": 300, "linux_seconds": 281, "linux_queue_seconds": 2, "macos_seconds": 297, "macos_queue_seconds": 2}
+    ],
+    "baseline_statistics": {
+      "wall_seconds": {"median": 354, "p95_nearest_rank": 481, "median_95_percent_sign_test_interval": [288, 481]},
+      "linux_seconds": {"median": 279, "p95_nearest_rank": 288, "median_95_percent_sign_test_interval": [265, 288]},
+      "macos_seconds": {"median": 351, "p95_nearest_rank": 477, "median_95_percent_sign_test_interval": [284, 477]},
+      "combined_runner_seconds": {"median": 630, "p95_nearest_rank": 761, "median_95_percent_sign_test_interval": [560, 761]},
+      "interval_note": "The minimum-to-maximum non-randomized sign-test interval has 98.4375% coverage at n=7; evolving sources and caches violate iid assumptions, so bounds are descriptive."
+    },
+    "optimized_run": {
+      "run_id": 29699676751,
+      "url": "https://github.com/liza-mas/liza/actions/runs/29699676751",
+      "head_sha": "8810a9ea7fe6d9f73ffbbd9c7de4d5536845ee2e",
+      "wall_seconds": 196,
+      "linux_seconds": 150,
+      "linux_queue_seconds": 2,
+      "macos_seconds": 192,
+      "macos_queue_seconds": 3,
+      "combined_runner_seconds": 342,
+      "success_oracle": "Linux and macOS reusable-workflow jobs completed successfully; release skipped by pull-request policy",
+      "trial_count": 1,
+      "p95": null,
+      "confidence_interval": null
+    },
+    "descriptive_changes_percent": {
+      "wall": -44.632768,
+      "linux": -46.236559,
+      "macos": -45.299145,
+      "combined_runner": -45.714286
+    },
+    "workflow_blobs": {
+      "historical_caller": "c67fe98b6f7ac64d5dd3bb8ec9110a73ab983f81",
+      "optimized_caller": "bf3e91893c677e21a6c382b7741280170b50eae1",
+      "optimized_reusable_core": "d5cb5621b2a63d32bfac2a5ee9af0a3f8642d1ee"
+    },
+    "confounders": [
+      "Source and test workloads differ across historical SHAs.",
+      "Two historical runs saved setup-go caches; the other samples restored cache hits.",
+      "Runner aliases and VM images are mutable.",
+      "The optimized sample has n=1."
+    ],
+    "subprocess_count": "unknown; unavailable from GitHub Actions APIs",
+    "agent_facing_operations": "not applicable; workflows invoke no LLM agents",
+    "model_token_counts": "not applicable"
+  },
+  "cross_repo_act": {
+    "repository": "omni3ai/execution-engine",
+    "environment": "act 0.2.89; Docker 29.4.0; macOS 27.0 arm64; linux/amd64 runner image sha256:5d6a17640b25694988b9db5a4145537b9918e5430116b2cf90d84e837609b382; fresh caches",
+    "protocol": "three serial trials per exact-SHA variant; /usr/bin/time -lp; nearest-rank p95; 27 ordered size-three bootstrap resamples",
+    "baseline": {"head_sha": "9daabf8108a698622afa22fd819eb4128098d61c", "elapsed_seconds": [1384.31, 1223.81, 878.12], "median": 1223.81, "p95": 1384.31, "median_95_ci": [878.12, 1384.31], "docker_exec_starts": [16, 14, 14]},
+    "optimized": {"head_sha": "23b60d07a4c96e322e7f4e5a62f91aeea9d23307", "elapsed_seconds": [781.24, 599.18, 496.63], "median": 599.18, "p95": 781.24, "median_95_ci": [496.63, 781.24], "docker_exec_starts": [9, 9, 9]},
+    "index_matched_descriptive_percent_reduction": {"values": [43.56, 51.04, 43.44], "median": 43.56, "p95": 51.04, "observed_range": [43.44, 51.04]},
+    "success_oracle": "All six invocations completed and reached real tests with clean worktrees; zero workflows succeeded, so timing is directional failed-workflow evidence.",
+    "valid_invocations": 6,
+    "excluded_invocations": 1,
+    "agent_facing_operations": 0,
+    "model_token_operations_inside_benchmark": 0,
+    "orchestration_tokens": "outside benchmark boundary; unavailable"
+  }
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,19 @@
+# Shared CI workflow contract
+
+`ci-core.yml` is the reusable CI implementation for Liza and downstream forks,
+including `omni3ai/execution-engine`.
+
+Availability and compatibility contract:
+
+- Keep this repository public and `.github/workflows/ci-core.yml` at its current
+  path while downstream callers reference it.
+- Consumers must pin a full commit SHA that is reachable from reviewed `main`.
+- Coordinate any repository rename, visibility change, workflow path change, or
+  incompatible input/output change with downstream consumers before applying it.
+- Update consumers only after this workflow passes Linux and macOS CI at the
+  candidate SHA.
+- If ownership must move, publish an identical immutable revision at the new
+  location and repin every consumer before removing the old location.
+
+These rules make the shared implementation immutable for each caller while
+preventing silent drift between Liza and its forks.

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -13,20 +13,10 @@ on:
         required: false
         default: true
         type: boolean
-      codecov_on_pr:
-        description: Upload public-repository pull request coverage to Codecov
-        required: false
-        default: true
-        type: boolean
     outputs:
       verified_sha:
         description: Commit checked out and verified by the Linux CI job
         value: ${{ jobs.linux.outputs.verified_sha }}
-    secrets:
-      CODECOV_TOKEN:
-        description: Optional token for main-branch Codecov uploads
-        required: false
-
 permissions:
   contents: read
 
@@ -108,15 +98,6 @@ jobs:
 
       - name: Build
         run: make build-nosync
-
-      - name: Upload coverage to Codecov
-        if: ${{ (github.event_name == 'pull_request' && inputs.codecov_on_pr) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
-        with:
-          files: ./coverage.out
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          version: v11.3.1
 
   macos:
     name: macOS compatibility

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: true
         type: boolean
+      codecov_on_pr:
+        description: Upload public-repository pull request coverage to Codecov
+        required: false
+        default: true
+        type: boolean
     outputs:
       verified_sha:
         description: Commit checked out and verified by the Linux CI job
@@ -53,14 +58,41 @@ jobs:
 
       - name: Install Python test dependencies
         if: inputs.setup_python
-        run: python -m pip install pytest==9.0.2 pytest-asyncio==1.3.0
+        run: |
+          cat > "$RUNNER_TEMP/requirements-ci.txt" <<'EOF'
+          iniconfig==2.3.0 \
+              --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
+              --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+          packaging==26.2 \
+              --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+              --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+          pluggy==1.6.0 \
+              --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
+              --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+          pygments==2.20.0 \
+              --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+              --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+          pytest==9.0.2 \
+              --hash=sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b \
+              --hash=sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11
+          pytest-asyncio==1.3.0 \
+              --hash=sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5 \
+              --hash=sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5
+          typing-extensions==4.16.0 \
+              --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
+              --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
+          EOF
+          python -m pip install --require-hashes -r "$RUNNER_TEMP/requirements-ci.txt"
 
       - name: Prepare and verify generated artifacts
         run: |
           make ci-prepare
-          if ! git diff --quiet -- .; then
+          if ! git diff --quiet -- . || \
+             [ -n "$(git status --porcelain --untracked-files=all -- .)" ]; then
             echo "ci-prepare changed tracked files; regenerate and commit them:" >&2
             git diff --exit-code -- .
+            git status --short --untracked-files=all -- . >&2
+            exit 1
           fi
 
       - name: Run linters
@@ -78,8 +110,7 @@ jobs:
         run: make build-nosync
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        continue-on-error: true
+        if: ${{ (github.event_name == 'pull_request' && inputs.codecov_on_pr) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: ./coverage.out

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,0 +1,112 @@
+name: CI core
+
+on:
+  workflow_call:
+    inputs:
+      setup_python:
+        description: Install Python and run the repository's Python test target
+        required: false
+        default: false
+        type: boolean
+      macos_on_pr:
+        description: Run the macOS compatibility job for pull requests
+        required: false
+        default: true
+        type: boolean
+    outputs:
+      verified_sha:
+        description: Commit checked out and verified by the Linux CI job
+        value: ${{ jobs.linux.outputs.verified_sha }}
+    secrets:
+      CODECOV_TOKEN:
+        description: Optional token for main-branch Codecov uploads
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    name: Linux checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      verified_sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Record verified source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        if: inputs.setup_python
+        with:
+          python-version: "3.12"
+
+      - name: Install Python test dependencies
+        if: inputs.setup_python
+        run: python -m pip install pytest==9.0.2 pytest-asyncio==1.3.0
+
+      - name: Prepare and verify generated artifacts
+        run: |
+          make ci-prepare
+          if ! git diff --quiet -- .; then
+            echo "ci-prepare changed tracked files; regenerate and commit them:" >&2
+            git diff --exit-code -- .
+          fi
+
+      - name: Run linters
+        run: make lint-nosync
+
+      - name: Run Go and e2e tests in parallel
+        if: ${{ ! inputs.setup_python }}
+        run: make ci-test-go-nosync
+
+      - name: Run Go, Python, and e2e tests in parallel
+        if: inputs.setup_python
+        run: make ci-test-nosync
+
+      - name: Build
+        run: make build-nosync
+
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          version: v11.3.1
+
+  macos:
+    name: macOS compatibility
+    if: github.event_name != 'pull_request' || inputs.macos_on_pr
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Prepare generated artifacts
+        run: make ci-prepare
+
+      - name: Run Go and e2e tests in parallel
+        run: make ci-test-go-nosync
+
+      - name: Build
+        run: make build-nosync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     with:
       setup_python: false
       macos_on_pr: true
+      codecov_on_pr: true
     secrets:
       CODECOV_TOKEN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CODECOV_TOKEN || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     with:
       setup_python: false
       macos_on_pr: true
-      codecov_on_pr: true
+      codecov_on_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     secrets:
-      CODECOV_TOKEN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CODECOV_TOKEN || '' }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   release:
     name: Release verified tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,44 +1,40 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   pull_request:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  test:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
+  ci:
+    name: Shared CI
+    uses: ./.github/workflows/ci-core.yml
+    with:
+      setup_python: false
+      macos_on_pr: true
+    secrets:
+      CODECOV_TOKEN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CODECOV_TOKEN || '' }}
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Run linters
-        run: make lint
-
-      - name: Run tests
-        run: make test
-
-      - name: Run e2e tests
-        run: make test-e2e
-
-      - name: Build
-        run: make build
-
-      - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.out
-          fail_ci_if_error: false
-          # Requires CODECOV_TOKEN secret — configure in repo settings
-          token: ${{ secrets.CODECOV_TOKEN }}
+  release:
+    name: Release verified tag
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: ci
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      release_tag: ${{ github.ref_name }}
+      release_sha: ${{ needs.ci.outputs.verified_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
     with:
       setup_python: false
       macos_on_pr: true
-      codecov_on_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   release:
     name: Release verified tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
               }
           }
           EOF
-          go run "${RUNNER_TEMP}/validate-semver.go" "${RELEASE_TAG}"
+          go run -mod=readonly "${RUNNER_TEMP}/validate-semver.go" "${RELEASE_TAG}"
           git fetch --no-tags origin \
             "+refs/heads/main:refs/remotes/origin/main" \
             "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,20 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      release_tag:
+        description: SemVer tag that passed the caller's CI jobs
+        required: true
+        type: string
+      release_sha:
+        description: Exact commit checked out by the caller's CI jobs
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ inputs.release_tag }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -11,21 +22,70 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 
-      - name: Sync embedded files
-        run: make sync-embedded
+      - name: Validate and check out release tag
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "release SHA must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          cat > "${RUNNER_TEMP}/validate-semver.go" <<'EOF'
+          package main
 
-      - uses: goreleaser/goreleaser-action@v6
+          import (
+              "fmt"
+              "os"
+              "strings"
+
+              "golang.org/x/mod/semver"
+          )
+
+          func main() {
+              if len(os.Args) != 2 {
+                  fmt.Fprintf(os.Stderr, "release tag must be valid SemVer prefixed with v: %q\n", os.Args[1:])
+                  os.Exit(1)
+              }
+              tag := os.Args[1]
+              core := strings.SplitN(strings.SplitN(strings.TrimPrefix(tag, "v"), "-", 2)[0], "+", 2)[0]
+              if !semver.IsValid(tag) || len(strings.Split(core, ".")) != 3 {
+                  fmt.Fprintf(os.Stderr, "release tag must be valid SemVer prefixed with v: %q\n", tag)
+                  os.Exit(1)
+              }
+          }
+          EOF
+          go run "${RUNNER_TEMP}/validate-semver.go" "${RELEASE_TAG}"
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          release_commit="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          if [[ "${release_commit}" != "${RELEASE_SHA}" ]]; then
+            echo "Release tag does not resolve to the commit verified by CI" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${RELEASE_SHA}" origin/main; then
+            echo "Release commit must be reachable from origin/main" >&2
+            exit 1
+          fi
+          git checkout --detach "${RELEASE_SHA}"
+
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
-          version: '~> v2'
+          version: v2.17.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.release_tag }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-e2e clean install lint check-testhelpers check-embedded release package build-all tidy run coverage help
+.PHONY: build build-nosync ci-prepare ci-test-nosync ci-test-go-nosync test test-nosync test-e2e test-e2e-nosync clean install lint lint-nosync check-testhelpers check-embedded release package build-all tidy run coverage help
 
 # Brand variables
 BRAND_NAME_LOWER?=liza
@@ -47,6 +47,9 @@ sync-embedded:
 
 # Build the binaries
 build: sync-embedded
+	@$(MAKE) build-nosync
+
+build-nosync:
 	@echo "Building $(BINARY_NAME) (version=$(VERSION), commit=$(GIT_COMMIT), date=$(BUILD_DATE))"
 	@go build $(LDFLAGS) -o $(BINARY_NAME) ./cmd/liza
 
@@ -54,11 +57,24 @@ build: sync-embedded
 # IMPORTANT: Always use `make test`, not bare `go test ./...`.
 # The sync-embedded step copies contracts/ and skills/ into internal/embedded/ for go:embed.
 # claude-settings.json and hooks/ are mastered directly in internal/embedded/.
-test: sync-embedded check-testhelpers
+ci-prepare: sync-embedded check-testhelpers
+
+ci-test-nosync: ci-test-go-nosync
+
+ci-test-go-nosync:
+	@$(MAKE) -j2 test-nosync test-e2e-nosync
+
+test: ci-prepare
+	@$(MAKE) test-nosync
+
+test-nosync:
 	go test -race -coverprofile=coverage.out ./...
 
 # Run e2e tests (full sprint sequence with mock CLI — ~40s)
-test-e2e: sync-embedded check-testhelpers
+test-e2e: ci-prepare
+	@$(MAKE) test-e2e-nosync
+
+test-e2e-nosync:
 	go test -race -tags e2e -run TestFullSprintSequence ./internal/integration/ -count=1
 
 # Run tests with coverage report
@@ -108,8 +124,16 @@ check-embedded:
 	@echo "✓ Embedded artifacts are consistent with masters"
 
 # Run linters
-lint: sync-embedded check-testhelpers check-embedded
-	go fmt ./...
+lint: ci-prepare check-embedded
+	@$(MAKE) lint-nosync
+
+lint-nosync:
+	@unformatted="$$(gofmt -l $$(find . -name '*.go' -type f -not -path './vendor/*'))"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "Go files need formatting:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 	go vet ./...
 
 # Tidy dependencies
@@ -160,12 +184,19 @@ package: release
 help:
 	@echo "Available targets:"
 	@echo "  build              - Build $(BINARY_NAME) binary"
+	@echo "  build-nosync       - Build against an already-synced checkout"
+	@echo "  ci-prepare         - Sync generated files and run shared CI checks"
+	@echo "  ci-test-nosync     - Run all available tests concurrently without syncing"
+	@echo "  ci-test-go-nosync  - Run Go and e2e tests concurrently without syncing"
 	@echo "  test               - Run tests (includes testhelpers check)"
+	@echo "  test-nosync        - Run tests against an already-synced checkout"
 	@echo "  test-e2e           - Run e2e full sprint test (~40s, requires -tags e2e)"
+	@echo "  test-e2e-nosync    - Run e2e tests against an already-synced checkout"
 	@echo "  coverage           - Run tests with coverage report"
 	@echo "  clean              - Clean build artifacts"
 	@echo "  install            - Install $(BINARY_NAME) binary"
 	@echo "  lint               - Run linters (includes testhelpers check)"
+	@echo "  lint-nosync        - Run nonmutating format and vet checks without syncing"
 	@echo "  check-testhelpers  - Verify testhelpers not in production code"
 	@echo "  check-embedded     - Verify embedded copies match repo masters"
 	@echo "  tidy               - Tidy dependencies"

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1546,12 +1546,12 @@ func TestRenderFooter_InlineMode_ContainsInlineHints(t *testing.T) {
 
 func TestRenderFooter_ConfirmationMode_ContainsConfirmHints(t *testing.T) {
 	m := Model{
-		width:       120,
-		height:      40,
-		inputMode:   InputModeInline,
+		width:        120,
+		height:       40,
+		inputMode:    InputModeInline,
 		inlineAction: InlineActionStopConfirm,
-		keys:        NewKeyMap(),
-		styles:      NewStyles(120),
+		keys:         NewKeyMap(),
+		styles:       NewStyles(120),
 	}
 	got := m.renderFooter()
 


### PR DESCRIPTION
## Why

Liza and its execution-engine fork were paying the setup/synchronization cost repeatedly and running Go unit and e2e suites serially. The fork also paid for macOS on every pull request, where macOS hosted minutes dominate list-price cost.

This introduces one reusable CI contract in Liza so both repositories can share the same implementation while retaining repository-specific policy:

- Liza keeps Linux and macOS pull-request coverage.
- execution-engine can set `macos_on_pr: false` and keep macOS on trusted main/tag runs.
- Unit and e2e tests run concurrently on each runner after one preparation pass.
- Build, lint, and tests reuse the prepared checkout instead of re-running embedded-file synchronization.
- External actions and tool versions are immutable or exact.
- Tag publication waits for the complete CI result and is bound to the exact commit CI checked out.

## Implementation

- Add `.github/workflows/ci-core.yml` as a typed reusable workflow.
- Reduce `ci.yml` to policy, inputs, explicit secret mapping, concurrency, and gated release orchestration.
- Add non-sync Make targets and run independent test suites through Make job parallelism.
- Keep macOS PR coverage configurable, defaulting to enabled.
- Hash-lock the complete Python CI dependency graph.
- Keep coverage-enabled tests and `coverage.out`; remove the unconfigured Codecov upload that had no repository token and could only fail or be ignored.
- Pin action SHAs and GoReleaser `v2.17.0`.
- Remove duplicate release synchronization already performed by GoReleaser.
- Replace mutating `go fmt` CI behavior with a formatting check. The test-file diff is gofmt-only.
- Make release SemVer validation module-readonly.
- Document the public reusable-workflow ownership and availability contract for downstream forks.

## Measurements

### Historical GitHub-hosted Liza

Recent successful CI runs before this change:

| Metric | Duration |
| --- | ---: |
| Workflow median | 5m 54s |
| Ubuntu job median | 4m 39s |
| macOS job median | 5m 51s |

Baseline: seven immediately preceding successful pull-request runs with both legacy jobs successful. Raw run IDs, SHAs, workflow blobs, selection rules, p95 values, conservative median intervals, cache notes, and timing definitions are committed in [`.github/ci-benchmark-2026-07-19.json`](https://github.com/liza-mas/liza/blob/codex/ci-fast-low-cost-shared/.github/ci-benchmark-2026-07-19.json).

Liza is public, so standard hosted-runner billing is currently $0; its benefit is shorter feedback and less runner work rather than direct cash savings.

### Hosted result for this PR

First GitHub-hosted run on commit `8810a9ea7fe6d9f73ffbbd9c7de4d5536845ee2e`:

| Metric | Historical median | PR run | Change |
| --- | ---: | ---: | ---: |
| Workflow wall time | 5m 54s | 3m 16s | -44.6% |
| Linux job | 4m 39s | 2m 30s | -46.2% |
| macOS job | 5m 51s | 3m 12s | -45.3% |
| Combined runner runtime | 10m 30s | 5m 42s | -45.7% |

Queue time was 2s on Linux and 3s on macOS. Both jobs passed; release correctly skipped on the pull request. This is one post-change hosted run compared with historical medians, so it is direct production evidence but not yet a stable post-change distribution.

[Workflow run](https://github.com/liza-mas/liza/actions/runs/29699676751)

### Controlled local execution-engine `act` experiment

Environment: `act 0.2.89`, Docker `29.4.0`, identical amd64 image/emulation, fresh action/cache directories per trial, sequential variants, three trials each.

| Variant | Exact SHA | Trial durations | Variant median |
| --- | --- | --- | ---: |
| Baseline | `9daabf8108a698622afa22fd819eb4128098d61c` | 1384.31s, 1223.81s, 878.12s | 1223.81s |
| Optimized | `23b60d07a4c96e322e7f4e5a62f91aeea9d23307` | 781.24s, 599.18s, 496.63s | 599.18s |

Descriptive variant-median reduction: **51.04%**. Median Docker exec-start proxy: **14 to 9**.

These are bounded local measurements, not a production performance claim:

- `n=3`; p95/confidence claims are not meaningful.
- All six `act` workflows reached real tests but exited non-zero on local environment-sensitive tests before build/Codecov.
- Baseline trials 2-3 also had one matrix leg affected by an `act` pip race.
- macOS was represented by the same Linux container image.
- The optimized SHA also includes a test-stability timeout adjustment, so the experiment does not perfectly isolate workflow changes.
- Fresh caches model cold starts; hosted queue time, cache telemetry, and billed minutes were not measured.

For execution-engine, the structural cost change is independent of that timing sample: pull requests move from one rounded Linux job plus one rounded macOS job to one Linux job. At current list rates, a representative historical 7-minute Linux + 6-minute macOS run models as `$0.042 + $0.372 = $0.414` before included quota; the post-change hosted duration must be measured after its PR runs.

## Verification

- Final-head hosted run [`29703018651`](https://github.com/liza-mas/liza/actions/runs/29703018651): Linux `2m31s`, macOS `4m19s`; both passed.
- `GIT_CONFIG_GLOBAL=/dev/null make ci-test-nosync`: passed all unit/race packages and `TestFullSprintSequence`; approximately 78s.
- `make lint`: passed formatting, embedded-artifact checks, and `go vet`.
- `make build-nosync`: passed.
- `actionlint .github/workflows/*.yml`: passed.
- `git diff --check`: passed.
- `act -l`: recognized the reusable Linux/macOS jobs, caller, and release workflow.
- Real `v0.8.0` fixture: tag resolved to `98fc7dfaf4f7006ce22f3c7751e8addd46c69a40`, was reachable from main, and detached checkout matched.
- GitNexus: low risk, one gofmt-only test symbol, zero affected callers/processes.
- Independent correctness and security reviews: no introduced P0-P2 findings.

## Follow-up

After this PR has a stable commit SHA, execution-engine will reference:

```yaml
uses: liza-mas/liza/.github/workflows/ci-core.yml@<full-commit-sha>
```

The full SHA is intentional: remote reusable workflows must not float on a branch or mutable tag.
