### PR TITLE
feat(providers): unified provider catalog with ACP synthesis and disabled flag

### DIFF
--- a/cmd/liza/cmd_init.go
+++ b/cmd/liza/cmd_init.go
@@ -283,7 +283,7 @@ var providersListCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		for _, p := range cat.ProvidersSorted() {
+		for _, p := range cat.AllProvidersSorted() {
 			fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%t\n", p.ID, p.DisplayName, p.Backend, p.Disabled)
 		}
 		return nil

--- a/cmd/liza/cmd_init.go
+++ b/cmd/liza/cmd_init.go
@@ -284,7 +284,7 @@ var providersListCmd = &cobra.Command{
 			return err
 		}
 		for _, p := range cat.ProvidersSorted() {
-			fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", p.ID, p.DisplayName, p.Backend)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%t\n", p.ID, p.DisplayName, p.Backend, p.Disabled)
 		}
 		return nil
 	},

--- a/cmd/liza/provider_catalog_cmd_test.go
+++ b/cmd/liza/provider_catalog_cmd_test.go
@@ -25,6 +25,10 @@ func TestProvidersListCommandUsesCatalog(t *testing.T) {
 	if !strings.Contains(out.String(), "qwen\tQwen\tcli\tfalse") {
 		t.Fatalf("providers list output missing qwen:\n%s", out.String())
 	}
+	// Synthesized ACP variants should appear in the list output.
+	if !strings.Contains(out.String(), "qwen-acp\tQwen ACP\tacpx\tfalse") {
+		t.Fatalf("providers list output missing synthesized qwen-acp:\n%s", out.String())
+	}
 }
 
 func TestProvidersRefreshCommandWritesCache(t *testing.T) {
@@ -135,6 +139,13 @@ providers:
       prompt_transport: stdin
       run_args: [-p]
       contract_key: qwen
+    acp_runtime:
+      provider_key: qwen
+      executable: acpx
+      prompt_transport: stdin
+      required_executables: [acpx]
+      contract_key: qwen
+      acpx_agent: qwen
 `))
 	}))
 	t.Cleanup(server.Close)

--- a/cmd/liza/provider_catalog_cmd_test.go
+++ b/cmd/liza/provider_catalog_cmd_test.go
@@ -22,7 +22,7 @@ func TestProvidersListCommandUsesCatalog(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("providers list error: %v", err)
 	}
-	if !strings.Contains(out.String(), "qwen\tQwen\tcli") {
+	if !strings.Contains(out.String(), "qwen\tQwen\tcli\tfalse") {
 		t.Fatalf("providers list output missing qwen:\n%s", out.String())
 	}
 }
@@ -78,12 +78,7 @@ func TestSetupDetectableProvidersSkipsRuntimeOnlyACPProviders(t *testing.T) {
 				SkillsDir: "skills",
 			},
 			Runtime: providers.Runtime{Executable: "codex", PromptTransport: "stdin"},
-		},
-		{
-			ID:          "codex-acp",
-			DisplayName: "Codex ACP",
-			Backend:     "acpx",
-			Runtime: providers.Runtime{
+			ACPRuntime: &providers.Runtime{
 				Executable:          "acpx",
 				PromptTransport:     "stdin",
 				RequiredExecutables: []string{"acpx"},
@@ -92,7 +87,6 @@ func TestSetupDetectableProvidersSkipsRuntimeOnlyACPProviders(t *testing.T) {
 	}}
 	results := []providers.DetectionResult{
 		{ID: "codex", DisplayName: "Codex", Installed: true},
-		{ID: "codex-acp", DisplayName: "Codex ACP", Installed: true},
 	}
 	installed := setupDetectableProviders(cat, results)
 	if len(installed) != 1 || installed[0].ID != "codex" {

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -114,7 +114,7 @@ func InitPairingCommand(params InitPairingParams) error {
 	if _, err := os.Stat(coreFile); os.IsNotExist(err) {
 		return fmt.Errorf("global config not found at %s\nRun '%s setup' first", globalDir, brand.BinaryName)
 	}
-	catalog := loadProviderCatalog()
+	catalog := loadProviderCatalog("")
 	selectedProviders, err := resolveCatalogProviders(catalog, canonicalInitProviderIDs(params.Agents))
 	if err != nil {
 		return err
@@ -324,7 +324,7 @@ func isLizaSymlink(path, contractTarget string) bool {
 // given CLI name, at either the repo root or the CLI's global config directory.
 // Returns the path where it was found, or "" if not found.
 func CheckContractConfigured(projectRoot, cliName string) string {
-	catalog := loadProviderCatalog()
+	catalog := loadProviderCatalog("")
 	provider, ok := catalog.Resolve(cliName)
 	if !ok {
 		return ""
@@ -785,7 +785,7 @@ func InitCommandWithConfig(params InitParams) error {
 	// consuming from the same underlying reader (which causes EOF for later readers).
 	stdin := bufio.NewReader(rawStdin)
 	confirmOptions := embedded.ConfirmOptions{AutoConfirm: params.AutoConfirm}
-	catalog := loadProviderCatalog()
+	catalog := loadProviderCatalog("")
 	selectedProviders, err := resolveCatalogProviders(catalog, canonicalInitProviderIDs(params.Agents))
 	if err != nil {
 		return err

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -706,7 +706,8 @@ func canonicalInitProviderIDs(ids []string) []string {
 	}
 	for _, id := range ids {
 		// The --cursor convenience flag prepares Cursor's harness dependencies;
-		// explicit provider IDs such as cursor-acp remain exact catalog requests.
+		// cursor-acp is a synthesized ACP provider resolved from the base
+		// cursor provider's acp_runtime block.
 		if id == "cursor" {
 			appendID("claude")
 			appendID("codex")

--- a/internal/commands/providers.go
+++ b/internal/commands/providers.go
@@ -7,8 +7,8 @@ import (
 	"github.com/liza-mas/liza/internal/providers"
 )
 
-func loadProviderCatalog() providers.Catalog {
-	cat, _ := providers.Load(context.Background(), providers.LoadOptions{})
+func loadProviderCatalog(homeDir string) providers.Catalog {
+	cat, _ := providers.Load(context.Background(), providers.LoadOptions{HomeDir: homeDir})
 	return cat
 }
 

--- a/internal/commands/setup.go
+++ b/internal/commands/setup.go
@@ -79,7 +79,7 @@ func SetupCommand(params SetupParams) error {
 			filepath.Join(params.TargetDir, "AGENT_TOOLS.md"): true,
 		}
 	}
-	catalog := loadProviderCatalog()
+	catalog := loadProviderCatalog(params.HomeDir)
 	setupProviderIDs := append([]string{}, params.ProviderIDs...)
 	setupProviderIDs = append(setupProviderIDs, canonicalSetupProviderIDs(params.Agents)...)
 	selectedProviders, err := resolveCatalogProviders(catalog, setupProviderIDs)

--- a/internal/commands/setup_test.go
+++ b/internal/commands/setup_test.go
@@ -660,6 +660,11 @@ func TestSetupCommand_AgentCursor(t *testing.T) {
 }
 
 func TestSetupCommand_ProviderCursorStaysCatalogRequest(t *testing.T) {
+	// Force the embedded catalog (which has the new acp_runtime structure)
+	// by pointing the catalog URL to an unreachable address. The loaded
+	// cache may still have the old separate -acp entries.
+	t.Setenv("LIZA_PROVIDER_CATALOG_URL", "https://invalid.test/catalog.yaml")
+
 	lizaDir := t.TempDir()
 	homeDir := t.TempDir()
 
@@ -668,13 +673,16 @@ func TestSetupCommand_ProviderCursorStaysCatalogRequest(t *testing.T) {
 		HomeDir:     homeDir,
 		ProviderIDs: []string{"cursor"},
 	})
-	if err == nil {
-		t.Fatal("SetupCommand() error = nil, want cursor-acp setup error")
-	}
-	if !strings.Contains(err.Error(), "provider cursor-acp does not define setup skill symlinks") {
-		t.Fatalf("SetupCommand() error = %q, want cursor-acp setup error", err)
+	if err != nil {
+		t.Fatalf("SetupCommand() error = %v, want nil for cursor provider with setup skills", err)
 	}
 
+	// cursor setup should create .cursor but NOT expand to .claude or .codex
+	// shortcut setup.
+	skillsDir := filepath.Join(homeDir, ".cursor", "skills")
+	if _, statErr := os.Stat(skillsDir); os.IsNotExist(statErr) {
+		t.Fatalf(".cursor/skills state = %v, want present because --provider cursor should set up cursor skills", statErr)
+	}
 	for _, configDir := range []string{".claude", ".codex"} {
 		if _, statErr := os.Stat(filepath.Join(homeDir, configDir)); !os.IsNotExist(statErr) {
 			t.Fatalf("%s state = %v, want absent because --provider cursor must not expand to shortcut setup", configDir, statErr)

--- a/internal/commands/setup_test.go
+++ b/internal/commands/setup_test.go
@@ -660,9 +660,9 @@ func TestSetupCommand_AgentCursor(t *testing.T) {
 }
 
 func TestSetupCommand_ProviderCursorStaysCatalogRequest(t *testing.T) {
-	// Force the embedded catalog (which has the new acp_runtime structure)
-	// by pointing the catalog URL to an unreachable address. The loaded
-	// cache may still have the old separate -acp entries.
+	// Use an unreachable catalog URL so Load() falls back to the embedded
+	// catalog instead of hitting the network. HomeDir is set to a temp dir
+	// so the cache is isolated from any stale real-home cache entries.
 	t.Setenv("LIZA_PROVIDER_CATALOG_URL", "https://invalid.test/catalog.yaml")
 
 	lizaDir := t.TempDir()

--- a/internal/providers/catalog.go
+++ b/internal/providers/catalog.go
@@ -44,6 +44,12 @@ type Provider struct {
 	DisplayName string    `yaml:"display_name"`
 	Aliases     []string  `yaml:"aliases,omitempty"`
 	Backend     string    `yaml:"backend"`
+	// Disabled is informational: it marks providers that are not yet
+	// fully supported (e.g. missing stable CLI or ACP integration).
+	// Disabled providers remain resolvable and detectable; the flag is
+	// surfaced in `providers list` so users can see which providers are
+	// experimental. Enforcement (skipping detection/setup) may be added
+	// later.
 	Disabled    bool      `yaml:"disabled,omitempty"`
 	Detection   Detection `yaml:"detection,omitempty"`
 	Setup       Setup     `yaml:"setup,omitempty"`

--- a/internal/providers/catalog.go
+++ b/internal/providers/catalog.go
@@ -326,6 +326,22 @@ func (c Catalog) ProvidersSorted() []Provider {
 	return providers
 }
 
+// AllProvidersSorted returns every resolvable provider — declared entries plus
+// synthesized ACP variants — sorted by ID. Use this when listing the full
+// catalog surface (e.g. `providers list`); use ProvidersSorted for detection,
+// which should only iterate declared entries.
+func (c Catalog) AllProvidersSorted() []Provider {
+	if c.byID == nil {
+		_ = c.Validate()
+	}
+	all := make([]Provider, 0, len(c.byID))
+	for _, p := range c.byID {
+		all = append(all, p)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
+	return all
+}
+
 func (c Catalog) Resolve(id string) (Provider, bool) {
 	if c.byID == nil {
 		_ = c.Validate()

--- a/internal/providers/catalog.go
+++ b/internal/providers/catalog.go
@@ -44,6 +44,7 @@ type Provider struct {
 	DisplayName string    `yaml:"display_name"`
 	Aliases     []string  `yaml:"aliases,omitempty"`
 	Backend     string    `yaml:"backend"`
+	Disabled    bool      `yaml:"disabled,omitempty"`
 	Detection   Detection `yaml:"detection,omitempty"`
 	Setup       Setup     `yaml:"setup,omitempty"`
 	Runtime     Runtime   `yaml:"runtime"`
@@ -169,6 +170,20 @@ func (c *Catalog) Validate() error {
 		}
 		byID[p.ID] = p
 	}
+	// Synthesize <id>-acp entries from each provider's acp_runtime so that
+	// consumers can resolve ACP variants (e.g. "codex-acp") without separate
+	// catalog entries. The synthesized provider inherits setup/detection from
+	// the base provider and uses the acp_runtime as its Runtime.
+	for _, p := range c.Providers {
+		if p.ACPRuntime == nil {
+			continue
+		}
+		acpID := p.ID + "-acp"
+		if _, exists := byID[acpID]; exists {
+			return fmt.Errorf("duplicate provider id: %s (synthesized from acp_runtime of %s)", acpID, p.ID)
+		}
+		byID[acpID] = synthesizeACPProvider(p)
+	}
 	// Aliases are validated against the complete id set so an alias colliding
 	// with a provider id declared later in the list is still rejected.
 	aliases := make(map[string]string)
@@ -190,6 +205,21 @@ func (c *Catalog) Validate() error {
 	c.byID = byID
 	c.aliases = aliases
 	return nil
+}
+
+// synthesizeACPProvider builds a virtual <id>-acp Provider from a base
+// provider's acp_runtime block. The synthesized provider has backend "acpx",
+// its Runtime populated from the acp_runtime config, and inherits setup and
+// detection from the base provider.
+func synthesizeACPProvider(base Provider) Provider {
+	return Provider{
+		ID:          base.ID + "-acp",
+		DisplayName: base.DisplayName + " ACP",
+		Backend:     "acpx",
+		Detection:   base.Detection,
+		Setup:       base.Setup,
+		Runtime:     *base.ACPRuntime,
+	}
 }
 
 func validateProvider(p Provider) error {
@@ -247,6 +277,34 @@ func validateProvider(p Provider) error {
 			return fmt.Errorf("provider %s has invalid runtime env file %q", p.ID, path)
 		}
 	}
+	if p.ACPRuntime != nil {
+		if err := validateRuntime(p.ID, "acp_runtime", *p.ACPRuntime); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRuntime(providerID, label string, rt Runtime) error {
+	if rt.Executable == "" {
+		return fmt.Errorf("provider %s missing %s.executable", providerID, label)
+	}
+	if !validExecutable(rt.Executable) {
+		return fmt.Errorf("provider %s has invalid %s.executable %q", providerID, label, rt.Executable)
+	}
+	if rt.PromptTransport != "" && rt.PromptTransport != "stdin" && rt.PromptTransport != "arg" && rt.PromptTransport != "file" {
+		return fmt.Errorf("provider %s has unsupported %s prompt transport %q", providerID, label, rt.PromptTransport)
+	}
+	for _, value := range rt.RequiredExecutables {
+		if !validExecutable(value) {
+			return fmt.Errorf("provider %s has invalid %s executable %q", providerID, label, value)
+		}
+	}
+	for _, path := range rt.EnvFiles {
+		if !validRelativePath(path) {
+			return fmt.Errorf("provider %s has invalid %s env file %q", providerID, label, path)
+		}
+	}
 	return nil
 }
 
@@ -295,43 +353,60 @@ func (c Catalog) Resolve(id string) (Provider, bool) {
 }
 
 func (c Catalog) RuntimeTools() map[string]models.AgentToolConfig {
-	out := make(map[string]models.AgentToolConfig, len(c.Providers))
+	out := make(map[string]models.AgentToolConfig, len(c.Providers)*2)
 	for _, p := range c.Providers {
 		out[p.ID] = p.RuntimeToolConfig()
+		if p.ACPRuntime != nil {
+			out[p.ID+"-acp"] = p.ACPToolConfig()
+		}
 	}
 	return out
 }
 
 func (p Provider) RuntimeToolConfig() models.AgentToolConfig {
-	required := append([]string(nil), p.Runtime.RequiredExecutables...)
-	if len(required) == 0 && p.Backend == "acpx" {
+	return runtimeToolConfig(p.ID, p.Backend, p.Runtime)
+}
+
+// ACPToolConfig returns the AgentToolConfig derived from the provider's
+// acp_runtime block. Returns an empty config if the provider has no ACP
+// runtime.
+func (p Provider) ACPToolConfig() models.AgentToolConfig {
+	if p.ACPRuntime == nil {
+		return models.AgentToolConfig{}
+	}
+	return runtimeToolConfig(p.ID+"-acp", "acpx", *p.ACPRuntime)
+}
+
+func runtimeToolConfig(id, backend string, rt Runtime) models.AgentToolConfig {
+	required := append([]string(nil), rt.RequiredExecutables...)
+	if len(required) == 0 && backend == "acpx" {
 		required = []string{"acpx"}
 	}
-	transport := p.Runtime.PromptTransport
+	transport := rt.PromptTransport
 	if transport == "" {
 		transport = "stdin"
 	}
-	providerKey := p.Runtime.ProviderKey
+	providerKey := rt.ProviderKey
 	if providerKey == "" {
-		providerKey = p.ID
+		providerKey = id
 	}
 	return models.AgentToolConfig{
-		Backend:             p.Backend,
+		Backend:             backend,
 		ProviderKey:         providerKey,
-		Executable:          p.Runtime.Executable,
+		Executable:          rt.Executable,
 		PromptTransport:     transport,
-		RunArgs:             append([]string(nil), p.Runtime.RunArgs...),
-		LoggedRunArgs:       append([]string(nil), p.Runtime.LoggedRunArgs...),
-		InteractiveArgs:     append([]string(nil), p.Runtime.InteractiveArgs...),
-		EnvFiles:            append([]string(nil), p.Runtime.EnvFiles...),
+		RunArgs:             append([]string(nil), rt.RunArgs...),
+		LoggedRunArgs:       append([]string(nil), rt.LoggedRunArgs...),
+		InteractiveArgs:     append([]string(nil), rt.InteractiveArgs...),
+		EnvFiles:            append([]string(nil), rt.EnvFiles...),
 		RequiredExecutables: required,
-		ContractKey:         p.Runtime.ContractKey,
-		ACPXAgent:           p.Runtime.ACPXAgent,
-		ACPXSessionName:     p.Runtime.ACPXSessionName,
-		ACPXShowArgs:        append([]string(nil), p.Runtime.ACPXShowArgs...),
-		ACPXEnsureArgs:      append([]string(nil), p.Runtime.ACPXEnsureArgs...),
-		ACPXPromptArgs:      append([]string(nil), p.Runtime.ACPXPromptArgs...),
-		ACPXEventMode:       p.Runtime.ACPXEventMode,
+		ContractKey:         rt.ContractKey,
+		ACPXAgent:           rt.ACPXAgent,
+		ACPXSessionName:     rt.ACPXSessionName,
+		ACPXShowArgs:        append([]string(nil), rt.ACPXShowArgs...),
+		ACPXEnsureArgs:      append([]string(nil), rt.ACPXEnsureArgs...),
+		ACPXPromptArgs:      append([]string(nil), rt.ACPXPromptArgs...),
+		ACPXEventMode:       rt.ACPXEventMode,
 	}
 }
 

--- a/internal/providers/catalog.go
+++ b/internal/providers/catalog.go
@@ -47,6 +47,7 @@ type Provider struct {
 	Detection   Detection `yaml:"detection,omitempty"`
 	Setup       Setup     `yaml:"setup,omitempty"`
 	Runtime     Runtime   `yaml:"runtime"`
+	ACPRuntime  *Runtime  `yaml:"acp_runtime,omitempty"`
 }
 
 type Detection struct {

--- a/internal/providers/catalog.go
+++ b/internal/providers/catalog.go
@@ -232,19 +232,13 @@ func validateProvider(p Provider) error {
 	if p.Backend != "cli" && p.Backend != "acpx" {
 		return fmt.Errorf("provider %s has unsupported backend %q", p.ID, p.Backend)
 	}
-	if p.Runtime.Executable == "" {
-		return fmt.Errorf("provider %s missing runtime.executable", p.ID)
-	}
-	if !validExecutable(p.Runtime.Executable) {
-		return fmt.Errorf("provider %s has invalid runtime.executable %q", p.ID, p.Runtime.Executable)
-	}
-	if p.Runtime.PromptTransport != "" && p.Runtime.PromptTransport != "stdin" && p.Runtime.PromptTransport != "arg" && p.Runtime.PromptTransport != "file" {
-		return fmt.Errorf("provider %s has unsupported prompt transport %q", p.ID, p.Runtime.PromptTransport)
-	}
-	for _, value := range append(append([]string{}, p.Detection.Binaries...), p.Runtime.RequiredExecutables...) {
+	for _, value := range p.Detection.Binaries {
 		if !validExecutable(value) {
 			return fmt.Errorf("provider %s has invalid executable %q", p.ID, value)
 		}
+	}
+	if err := validateRuntime(p.ID, "runtime", p.Runtime); err != nil {
+		return err
 	}
 	for _, arg := range p.Detection.VersionArgs {
 		if strings.ContainsAny(arg, "\x00\r\n") {
@@ -270,11 +264,6 @@ func validateProvider(p Provider) error {
 	for _, link := range p.Setup.Symlinks {
 		if !validRelativePath(link.Source) || !validRelativePath(link.Target) {
 			return fmt.Errorf("provider %s has invalid setup symlink", p.ID)
-		}
-	}
-	for _, path := range p.Runtime.EnvFiles {
-		if !validRelativePath(path) {
-			return fmt.Errorf("provider %s has invalid runtime env file %q", p.ID, path)
 		}
 	}
 	if p.ACPRuntime != nil {

--- a/internal/providers/catalog_test.go
+++ b/internal/providers/catalog_test.go
@@ -17,17 +17,20 @@ import (
 func TestEmbeddedCatalogResolvesBuiltInsAndAliases(t *testing.T) {
 	cat := EmbeddedCatalog()
 
-	for _, id := range []string{"claude", "codex", "codex-acp", "cursor-acp", "opencode", "opencode-acp", "gemini", "mistral", "kimi"} {
+	for _, id := range []string{"claude", "codex", "codex-acp", "cursor", "cursor-acp", "opencode", "opencode-acp", "gemini", "mistral", "kimi"} {
 		if _, ok := cat.Resolve(id); !ok {
 			t.Fatalf("EmbeddedCatalog().Resolve(%q) = false", id)
 		}
 	}
 	cursor, ok := cat.Resolve("cursor")
-	if !ok || cursor.ID != "cursor-acp" {
-		t.Fatalf("Resolve(cursor) = %+v, %v; want cursor-acp", cursor, ok)
+	if !ok || cursor.ID != "cursor" {
+		t.Fatalf("Resolve(cursor) = %+v, %v; want cursor", cursor, ok)
 	}
 	if !cursor.Setup.ActivationAssets.CursorHooks {
-		t.Fatal("cursor-acp missing Cursor hook activation asset")
+		t.Fatal("cursor missing Cursor hook activation asset")
+	}
+	if cursor.ACPRuntime == nil {
+		t.Fatal("cursor missing acp_runtime")
 	}
 	p, ok := cat.Resolve("vibe")
 	if !ok || p.ID != "mistral" {
@@ -57,11 +60,14 @@ func TestRepositoryCatalogAddsRemoteProviders(t *testing.T) {
 		t.Fatal("provider-catalog.yaml missing qwen")
 	}
 	cursor, ok := cat.Resolve("cursor")
-	if !ok || cursor.ID != "cursor-acp" {
-		t.Fatalf("provider-catalog.yaml Resolve(cursor) = %+v, %v; want cursor-acp", cursor, ok)
+	if !ok || cursor.ID != "cursor" {
+		t.Fatalf("provider-catalog.yaml Resolve(cursor) = %+v, %v; want cursor", cursor, ok)
 	}
 	if !cursor.Setup.ActivationAssets.CursorHooks {
-		t.Fatal("provider-catalog.yaml cursor-acp missing Cursor hook activation asset")
+		t.Fatal("provider-catalog.yaml cursor missing Cursor hook activation asset")
+	}
+	if cursor.ACPRuntime == nil {
+		t.Fatal("provider-catalog.yaml cursor missing acp_runtime")
 	}
 	qwenACP, ok := cat.Resolve("qwen-acp")
 	if !ok {

--- a/internal/providers/catalog_test.go
+++ b/internal/providers/catalog_test.go
@@ -256,7 +256,7 @@ providers:
       executable: qwen
       prompt_transport: telepathy
 `))
-		if err == nil || !strings.Contains(err.Error(), "unsupported prompt transport") {
+		if err == nil || !strings.Contains(err.Error(), "unsupported") || !strings.Contains(err.Error(), "prompt transport") {
 			t.Fatalf("ParseCatalog error = %v, want prompt transport error", err)
 		}
 	})

--- a/internal/providers/catalog_test.go
+++ b/internal/providers/catalog_test.go
@@ -32,6 +32,23 @@ func TestEmbeddedCatalogResolvesBuiltInsAndAliases(t *testing.T) {
 	if cursor.ACPRuntime == nil {
 		t.Fatal("cursor missing acp_runtime")
 	}
+	// Cursor provider must use cursor-agent (documented Agent CLI entrypoint),
+	// not the `cursor` IDE binary. See https://docs.cursor.com/en/cli/overview
+	if cursor.Runtime.Executable != "cursor-agent" {
+		t.Fatalf("cursor runtime executable = %q, want cursor-agent", cursor.Runtime.Executable)
+	}
+	if !slices.Equal(cursor.Detection.Binaries, []string{"cursor-agent"}) {
+		t.Fatalf("cursor detection binaries = %v, want [cursor-agent]", cursor.Detection.Binaries)
+	}
+	if !slices.Equal(cursor.Runtime.RunArgs, []string{"-p"}) {
+		t.Fatalf("cursor run_args = %v, want [-p]", cursor.Runtime.RunArgs)
+	}
+	// logged_run_args must not include --verbose (undocumented Cursor CLI flag)
+	for _, arg := range cursor.Runtime.LoggedRunArgs {
+		if arg == "--verbose" {
+			t.Fatalf("cursor logged_run_args must not include --verbose (undocumented): %v", cursor.Runtime.LoggedRunArgs)
+		}
+	}
 	p, ok := cat.Resolve("vibe")
 	if !ok || p.ID != "mistral" {
 		t.Fatalf("Resolve(vibe) = %+v, %v; want mistral", p, ok)
@@ -68,6 +85,12 @@ func TestRepositoryCatalogAddsRemoteProviders(t *testing.T) {
 	}
 	if cursor.ACPRuntime == nil {
 		t.Fatal("provider-catalog.yaml cursor missing acp_runtime")
+	}
+	if cursor.Runtime.Executable != "cursor-agent" {
+		t.Fatalf("provider-catalog.yaml cursor runtime executable = %q, want cursor-agent", cursor.Runtime.Executable)
+	}
+	if !slices.Equal(cursor.Detection.Binaries, []string{"cursor-agent"}) {
+		t.Fatalf("provider-catalog.yaml cursor detection binaries = %v, want [cursor-agent]", cursor.Detection.Binaries)
 	}
 	qwenACP, ok := cat.Resolve("qwen-acp")
 	if !ok {

--- a/internal/providers/embedded.go
+++ b/internal/providers/embedded.go
@@ -70,7 +70,7 @@ providers:
     display_name: Cursor
     backend: cli
     detection:
-      binaries: [cursor]
+      binaries: [cursor-agent]
       version_args: [--version]
     setup:
       config_dir: .cursor
@@ -82,10 +82,10 @@ providers:
         cursor_hooks: true
     runtime:
       provider_key: cursor
-      executable: cursor
+      executable: cursor-agent
       prompt_transport: stdin
       run_args: [-p]
-      logged_run_args: [-p, --verbose, --output-format, stream-json]
+      logged_run_args: [-p, --output-format, stream-json]
       env_files: [cursor.env]
       contract_key: cursor
     acp_runtime:

--- a/internal/providers/embedded.go
+++ b/internal/providers/embedded.go
@@ -53,18 +53,7 @@ providers:
       run_args: [exec, "-"]
       logged_run_args: [exec, --json, "-"]
       contract_key: codex
-
-  - id: codex-acp
-    display_name: Codex ACP
-    backend: acpx
-    detection:
-      binaries: [acpx]
-      version_args: [--version]
-    setup:
-      contract:
-        repo_file: AGENTS.md
-        global_fallback: .codex/AGENTS.md
-    runtime:
+    acp_runtime:
       provider_key: codex
       executable: acpx
       prompt_transport: stdin
@@ -77,20 +66,29 @@ providers:
       acpx_prompt_args: [--cwd, "{{projectRoot}}", --format, json, --approve-all, "{{acpxAgent}}", prompt, -s, "{{sessionName}}", --file, "-"]
       acpx_event_mode: json
 
-  - id: cursor-acp
-    display_name: Cursor ACP
-    aliases: [cursor]
-    backend: acpx
+  - id: cursor
+    display_name: Cursor
+    backend: cli
     detection:
-      binaries: [cursor-agent]
+      binaries: [cursor]
       version_args: [--version]
     setup:
+      config_dir: .cursor
+      skills_dir: skills
       contract:
         repo_file: AGENTS.md
-        global_fallback: .codex/AGENTS.md
+        global_fallback: .cursor/AGENTS.md
       activation_assets:
         cursor_hooks: true
     runtime:
+      provider_key: cursor
+      executable: cursor
+      prompt_transport: stdin
+      run_args: [-p]
+      logged_run_args: [-p, --verbose, --output-format, stream-json]
+      env_files: [cursor.env]
+      contract_key: cursor
+    acp_runtime:
       provider_key: cursor
       executable: acpx
       prompt_transport: stdin
@@ -124,18 +122,7 @@ providers:
       run_args: [run, "{{prompt}}", --dangerously-skip-permissions]
       logged_run_args: [run, "{{prompt}}", --dangerously-skip-permissions, --format, json]
       contract_key: opencode
-
-  - id: opencode-acp
-    display_name: OpenCode ACP
-    backend: acpx
-    detection:
-      binaries: [acpx]
-      version_args: [--version]
-    setup:
-      contract:
-        repo_file: AGENTS.md
-        global_fallback: .config/opencode/AGENTS.md
-    runtime:
+    acp_runtime:
       provider_key: opencode
       executable: acpx
       prompt_transport: stdin
@@ -151,6 +138,7 @@ providers:
   - id: gemini
     display_name: Gemini
     backend: cli
+    disabled: true
     detection:
       binaries: [gemini]
       version_args: [--version]
@@ -172,6 +160,7 @@ providers:
     display_name: Mistral
     aliases: [vibe]
     backend: cli
+    disabled: true
     detection:
       binaries: [vibe]
       version_args: [--version]
@@ -210,4 +199,69 @@ providers:
       run_args: [-p]
       logged_run_args: [-p, --verbose, --output-format, stream-json]
       contract_key: claude
+
+  - id: qwen
+    display_name: Qwen
+    aliases: [qwen-code]
+    backend: cli
+    detection:
+      binaries: [qwen]
+      version_args: [--version]
+    setup:
+      config_dir: .qwen
+      skills_dir: skills
+      contract:
+        repo_file: QWEN.md
+        global_fallback: .qwen/QWEN.md
+    runtime:
+      provider_key: qwen
+      executable: qwen
+      prompt_transport: stdin
+      run_args: [-p]
+      logged_run_args: [-p, --output-format, stream-json]
+      contract_key: qwen
+    acp_runtime:
+      provider_key: qwen
+      executable: acpx
+      prompt_transport: stdin
+      required_executables: [acpx]
+      contract_key: qwen
+      acpx_agent: qwen
+      acpx_session_name: liza-qwen-{{agentID}}
+      acpx_show_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", sessions, show, --name, "{{sessionName}}"]
+      acpx_ensure_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", sessions, ensure, --name, "{{sessionName}}"]
+      acpx_prompt_args: [--cwd, "{{projectRoot}}", --format, json, --approve-all, "{{acpxAgent}}", prompt, -s, "{{sessionName}}", --file, "-"]
+      acpx_event_mode: json
+
+  - id: devin
+    display_name: Devin
+    backend: cli
+    detection:
+      binaries: [devin]
+      version_args: [--version]
+    setup:
+      config_dir: .config/devin
+      skills_dir: skills
+      contract:
+        repo_file: .windsurf/rules/liza.md
+        global_fallback: .config/devin/liza.md
+    runtime:
+      provider_key: devin
+      executable: devin
+      prompt_transport: arg
+      run_args: [--permission-mode, dangerous, -p, "{{prompt}}"]
+      logged_run_args: [--permission-mode, dangerous, -p, "{{prompt}}"]
+      contract_key: devin
+    acp_runtime:
+      provider_key: devin
+      executable: acpx
+      prompt_transport: stdin
+      required_executables: [acpx, devin]
+      contract_key: devin
+      acpx_agent: devin acp
+      acpx_session_name: liza-devin-{{agentID}}
+      acpx_show_args: [--cwd, "{{projectRoot}}", --agent, "{{acpxAgent}}", sessions, show, --name, "{{sessionName}}"]
+      acpx_ensure_args: [--cwd, "{{projectRoot}}", --agent, "{{acpxAgent}}", sessions, ensure, --name, "{{sessionName}}"]
+      acpx_prompt_args: [--cwd, "{{projectRoot}}", --format, json, --approve-all, --agent, "{{acpxAgent}}", prompt, -s, "{{sessionName}}", --file, "-"]
+      acpx_event_mode: json
 `

--- a/provider-catalog.yaml
+++ b/provider-catalog.yaml
@@ -51,18 +51,7 @@ providers:
       run_args: [exec, "-"]
       logged_run_args: [exec, --json, "-"]
       contract_key: codex
-
-  - id: codex-acp
-    display_name: Codex ACP
-    backend: acpx
-    detection:
-      binaries: [acpx]
-      version_args: [--version]
-    setup:
-      contract:
-        repo_file: AGENTS.md
-        global_fallback: .codex/AGENTS.md
-    runtime:
+    acp_runtime:
       provider_key: codex
       executable: acpx
       prompt_transport: stdin
@@ -75,20 +64,29 @@ providers:
       acpx_prompt_args: [--cwd, "{{projectRoot}}", --format, json, --approve-all, "{{acpxAgent}}", prompt, -s, "{{sessionName}}", --file, "-"]
       acpx_event_mode: json
 
-  - id: cursor-acp
-    display_name: Cursor ACP
-    aliases: [cursor]
-    backend: acpx
+  - id: cursor
+    display_name: Cursor
+    backend: cli
     detection:
-      binaries: [cursor-agent]
+      binaries: [cursor]
       version_args: [--version]
     setup:
+      config_dir: .cursor
+      skills_dir: skills
       contract:
         repo_file: AGENTS.md
-        global_fallback: .codex/AGENTS.md
+        global_fallback: .cursor/AGENTS.md
       activation_assets:
         cursor_hooks: true
     runtime:
+      provider_key: cursor
+      executable: cursor
+      prompt_transport: stdin
+      run_args: [-p]
+      logged_run_args: [-p, --verbose, --output-format, stream-json]
+      env_files: [cursor.env]
+      contract_key: cursor
+    acp_runtime:
       provider_key: cursor
       executable: acpx
       prompt_transport: stdin
@@ -122,18 +120,7 @@ providers:
       run_args: [run, "{{prompt}}", --dangerously-skip-permissions]
       logged_run_args: [run, "{{prompt}}", --dangerously-skip-permissions, --format, json]
       contract_key: opencode
-
-  - id: opencode-acp
-    display_name: OpenCode ACP
-    backend: acpx
-    detection:
-      binaries: [acpx]
-      version_args: [--version]
-    setup:
-      contract:
-        repo_file: AGENTS.md
-        global_fallback: .config/opencode/AGENTS.md
-    runtime:
+    acp_runtime:
       provider_key: opencode
       executable: acpx
       prompt_transport: stdin
@@ -229,18 +216,7 @@ providers:
       run_args: [-p]
       logged_run_args: [-p, --output-format, stream-json]
       contract_key: qwen
-
-  - id: qwen-acp
-    display_name: Qwen ACP
-    backend: acpx
-    detection:
-      binaries: [acpx]
-      version_args: [--version]
-    setup:
-      contract:
-        repo_file: QWEN.md
-        global_fallback: .qwen/QWEN.md
-    runtime:
+    acp_runtime:
       provider_key: qwen
       executable: acpx
       prompt_transport: stdin
@@ -272,18 +248,7 @@ providers:
       run_args: [--permission-mode, dangerous, -p, "{{prompt}}"]
       logged_run_args: [--permission-mode, dangerous, -p, "{{prompt}}"]
       contract_key: devin
-
-  - id: devin-acp
-    display_name: Devin ACP
-    backend: acpx
-    detection:
-      binaries: [devin]
-      version_args: [--version]
-    setup:
-      contract:
-        repo_file: .windsurf/rules/liza.md
-        global_fallback: .config/devin/liza.md
-    runtime:
+    acp_runtime:
       provider_key: devin
       executable: acpx
       prompt_transport: stdin

--- a/provider-catalog.yaml
+++ b/provider-catalog.yaml
@@ -68,7 +68,7 @@ providers:
     display_name: Cursor
     backend: cli
     detection:
-      binaries: [cursor]
+      binaries: [cursor-agent]
       version_args: [--version]
     setup:
       config_dir: .cursor
@@ -80,10 +80,10 @@ providers:
         cursor_hooks: true
     runtime:
       provider_key: cursor
-      executable: cursor
+      executable: cursor-agent
       prompt_transport: stdin
       run_args: [-p]
-      logged_run_args: [-p, --verbose, --output-format, stream-json]
+      logged_run_args: [-p, --output-format, stream-json]
       env_files: [cursor.env]
       contract_key: cursor
     acp_runtime:

--- a/provider-catalog.yaml
+++ b/provider-catalog.yaml
@@ -136,6 +136,7 @@ providers:
   - id: gemini
     display_name: Gemini
     backend: cli
+    disabled: true
     detection:
       binaries: [gemini]
       version_args: [--version]
@@ -157,6 +158,7 @@ providers:
     display_name: Mistral
     aliases: [vibe]
     backend: cli
+    disabled: true
     detection:
       binaries: [vibe]
       version_args: [--version]

--- a/support-docs/CONFIGURATION.md
+++ b/support-docs/CONFIGURATION.md
@@ -911,11 +911,12 @@ Headless watch automatically runs the repair-agent-pool behavior when a task is 
 | `claude` | Claude Code (fallback default when no config is set) |
 | `codex` | OpenAI Codex CLI |
 | `codex-acp` | OpenAI Codex through ACPX. Requires the `acpx` executable on the spawned agent's `PATH`; install it with `npm install -g acpx`. §BRAND_NAME_TITLE§ preflights this prerequisite before direct `§BRAND_BINARY_NAME§ agent` execution and before TUI/API agent spawning. `codex-acp` reuses Codex `AGENTS.md` contract setup and runs ACPX with non-interactive auto-approval inside §BRAND_NAME_TITLE§ task worktrees. During `acpx prompt`, streams stdout JSON-RPC and stderr diagnostics to `§BRAND_PROJECT_DIRNAME§/agent-outputs/`, returns parsed message chunks to the supervisor, and logs lifecycle/usage metadata. Short ACPX session control calls are not transcript-logged. |
+| `cursor` | Cursor CLI (`cursor-agent`). Use `§BRAND_BINARY_NAME§ setup --provider cursor` for global skills and `§BRAND_BINARY_NAME§ init --provider cursor` for contract setup. Set `§BRAND_ENV_PREFIX§_ENABLE_BASH_POLICY=1` before init when selected providers should receive standalone bash-policy hooks. |
 | `cursor-acp` | Cursor through ACPX. Requires `acpx` on `PATH` and an authenticated Cursor CLI (`cursor-agent`). Reuses the shared `AGENTS.md` contract setup and selects the ACPX Cursor target; it is not a Cursor executable name. Use `§BRAND_BINARY_NAME§ init --cursor` for contract setup; it includes the Claude and Codex project setup Cursor relies on. Set `§BRAND_ENV_PREFIX§_ENABLE_BASH_POLICY=1` before init when selected providers should receive standalone bash-policy hooks. |
 | `opencode` | OpenCode CLI through `opencode run`. Requires `§BRAND_BINARY_NAME§ setup --opencode` and `§BRAND_BINARY_NAME§ init --opencode` for contract and skill activation. Logged runs add JSON output. |
 | `opencode-acp` | OpenCode through ACPX. Requires `acpx` on `PATH`, reuses OpenCode `AGENTS.md` contract setup, and selects the ACPX OpenCode target; it is not an OpenCode executable name. |
-| `gemini` | Google Gemini CLI |
-| `mistral` | Mistral Le Chat CLI |
+| `gemini` | Google Gemini CLI. Marked `disabled: true` in the catalog — informational only, the provider remains detectable and resolvable. |
+| `mistral` | Mistral Le Chat CLI. Marked `disabled: true` in the catalog — informational only, the provider remains detectable and resolvable. |
 | `kimi` | Kimi (alias to claude with Kimi-specific env vars) |
 | `qwen` | Qwen CLI from the remote provider catalog. Use `§BRAND_BINARY_NAME§ setup --provider qwen` and `§BRAND_BINARY_NAME§ init --provider qwen` for contract and skill activation. |
 | `qwen-acp` | Qwen through ACPX from the remote provider catalog. Requires `acpx` on `PATH`, reuses Qwen's `QWEN.md` contract setup, and uses catalog-defined ACPX session and prompt argv. |
@@ -934,11 +935,22 @@ timeout can be changed with `§BRAND_ENV_PREFIX§_PROVIDER_CATALOG_TIMEOUT`.
 
 Use `§BRAND_BINARY_NAME§ providers list`, `§BRAND_BINARY_NAME§ providers detect`,
 and `§BRAND_BINARY_NAME§ providers refresh` to inspect and refresh the catalog.
-Remote YAML is accepted only after HTTPS fetch (localhost is allowed for tests)
-and strict schema validation. Catalog entries describe structured argv, env-file
-paths, contract links, and setup assets, not arbitrary shell scripts. Path fields
-must stay relative to their intended project or home roots, and executable names
-must be bare command names.
+`providers list` outputs four tab-separated columns: provider ID, display name,
+backend (`cli` or `acpx`), and disabled (boolean). Synthesized ACP variants
+(e.g. `codex-acp`, `cursor-acp`) appear in the list alongside their base
+providers. Remote YAML is accepted only after HTTPS fetch (localhost is allowed
+for tests) and strict schema validation. Catalog entries describe structured
+argv, env-file paths, contract links, and setup assets, not arbitrary shell
+scripts. Path fields must stay relative to their intended project or home roots,
+and executable names must be bare command names.
+
+**ACP synthesis:** Providers with an `acp_runtime` block automatically
+synthesize a virtual `<id>-acp` provider at catalog validation time. The
+synthesized provider inherits setup and detection from the base provider and
+uses the `acp_runtime` as its runtime. This means `Resolve("codex-acp")` works
+without a separate catalog entry. The `disabled` field is informational: it
+marks providers that are not yet fully supported, but disabled providers remain
+detectable, resolvable, and available for setup.
 
 The provider catalog is a launch trust boundary. Catalog-defined argv can include
 provider permission flags such as ACPX `--approve-all` or OpenCode


### PR DESCRIPTION
## Summary

- **Consolidated ACP configuration**: Separate `-acp` provider entries (e.g. `cursor` + `cursor-acp`) merged into single entries with `runtime` (CLI) + `acp_runtime` (ACP) fields
- **ACP synthesis**: `Validate()` now auto-creates virtual `<id>-acp` providers from `acp_runtime` blocks, so `Resolve("codex-acp")` still works without separate catalog entries — all existing consumer code remains unchanged
- **Disabled flag**: Added `Disabled bool` field to `Provider` struct; `gemini` and `mistral` marked `disabled: true` in catalog and embedded fallback
- **`providers list` command**: Now outputs 4th column (disabled boolean)
- **Unified embedded catalog**: `cursor` is now a base CLI provider with `acp_runtime` (was only an alias of `cursor-acp`); added `devin` and `qwen` CLI providers with `acp_runtime` blocks
- **Added `ACPToolConfig()` and `validateRuntime()` helpers** for ACP runtime support

#### Test plan
- [x] `go test ./internal/providers/...` passes
- [x] `go test ./internal/commands/...` passes
- [x] `go test ./cmd/liza/...` passes
- [x] `go test ./internal/agent/...` passes
- [x] `go build ./...` passes

Generated with [Devin](https://devin.ai)