### PR TITLE
fix: set Cursor ACP sessions to agent mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
 
       - id: go-fmt
         name: go fmt (formatting)
-        entry: /usr/local/go/bin/gofmt -w -l
+        entry: bash -c 'export PATH="$(go env GOROOT)/bin:$PATH"; exec gofmt -w -l "$@"' --
         language: system
         files: \.go$
 

--- a/internal/agent/acpx_agent.go
+++ b/internal/agent/acpx_agent.go
@@ -80,6 +80,22 @@ func (a *ACPXAgent) Run(ctx context.Context, req LLMAgentRunRequest) (LLMAgentRu
 		})
 		return LLMAgentRunResult{ExitCode: 1, Output: errText, WarmUsage: warm, SessionID: sessionName}, maskedErr
 	}
+	if err := a.configureSession(ctx, req.AgentID, plan); err != nil {
+		errText := a.maskText(err.Error())
+		maskedErr := maskedError{message: errText, err: err}
+		emitLLMAgentEvent(ctx, req.EventSink, LLMAgentEvent{
+			Kind:        LLMAgentEventCompleted,
+			BackendName: req.BackendName,
+			AgentID:     req.AgentID,
+			TaskID:      req.TaskID,
+			SessionID:   sessionName,
+			Message:     errText,
+			Payload: map[string]any{
+				"error": errText,
+			},
+		})
+		return LLMAgentRunResult{ExitCode: 1, Output: errText, WarmUsage: warm, SessionID: sessionName}, maskedErr
+	}
 	a.markSessionSeen(sessionName)
 
 	output, usage, err := a.prompt(ctx, req, plan)
@@ -236,6 +252,17 @@ func (a *ACPXAgent) ensureSession(ctx context.Context, agentID string, projectRo
 	out, err := a.runACPX(ctx, plan.Executable, agentID, args, "")
 	if err != nil {
 		return fmt.Errorf("acpx sessions ensure: %w\n%s", err, out)
+	}
+	return nil
+}
+
+func (a *ACPXAgent) configureSession(ctx context.Context, agentID string, plan LaunchPlan) error {
+	if len(plan.ACPXSetModeArgs) == 0 {
+		return nil
+	}
+	out, err := a.runACPX(ctx, plan.Executable, agentID, plan.ACPXSetModeArgs, "")
+	if err != nil {
+		return fmt.Errorf("acpx set-mode: %w\n%s", err, out)
 	}
 	return nil
 }

--- a/internal/agent/acpx_agent_test.go
+++ b/internal/agent/acpx_agent_test.go
@@ -164,6 +164,7 @@ func TestACPXAgentRunUsesCursorTarget(t *testing.T) {
 	log := readTextForTest(t, logPath)
 	for _, want := range []string{
 		"ARGS:--cwd " + req.ProjectRoot + " cursor sessions ensure --name liza-coder-1",
+		"ARGS:--cwd " + req.ProjectRoot + " cursor set-mode agent -s liza-coder-1",
 		"ARGS:--cwd " + req.ProjectRoot + " --format json --approve-all cursor prompt -s liza-coder-1 --file -",
 		"STDIN:implement the requested change",
 	} {
@@ -171,6 +172,11 @@ func TestACPXAgentRunUsesCursorTarget(t *testing.T) {
 			t.Fatalf("fake acpx log missing %q:\n%s", want, log)
 		}
 	}
+	assertLogOrder(t, log,
+		"cursor sessions ensure --name liza-coder-1",
+		"cursor set-mode agent -s liza-coder-1",
+		"cursor prompt -s liza-coder-1",
+	)
 }
 
 func TestACPXAgentRunUsesConfiguredQwenTarget(t *testing.T) {
@@ -635,6 +641,9 @@ case "$*" in
   *" sessions ensure "*)
     exit 0
     ;;
+  *" set-mode "*)
+    exit 0
+    ;;
   *" prompt "*)
     prompt="$(cat)"
     printf 'STDIN:%s\n' "$prompt" >> "` + logPath + `"
@@ -703,6 +712,18 @@ func readSingleGlobForTest(t *testing.T, pattern string) string {
 		t.Fatalf("glob %s matched %d files: %v", pattern, len(matches), matches)
 	}
 	return readTextForTest(t, matches[0])
+}
+
+func assertLogOrder(t *testing.T, log string, ordered ...string) {
+	t.Helper()
+	offset := 0
+	for _, want := range ordered {
+		idx := strings.Index(log[offset:], want)
+		if idx < 0 {
+			t.Fatalf("log missing %q after offset %d:\n%s", want, offset, log)
+		}
+		offset += idx + len(want)
+	}
 }
 
 func hasLLMAgentEvent(events []LLMAgentEvent, kind LLMAgentEventKind) bool {

--- a/internal/agent/launch_resolver.go
+++ b/internal/agent/launch_resolver.go
@@ -52,6 +52,7 @@ type LaunchPlan struct {
 	ACPXSessionName      string
 	ACPXShowArgs         []string
 	ACPXEnsureArgs       []string
+	ACPXSetModeArgs      []string
 	ACPXPromptArgs       []string
 	ACPXEventMode        string
 }
@@ -77,7 +78,18 @@ func BuiltInAgentTools() map[string]models.AgentToolConfig {
 		cat, _ := providers.Load(context.Background(), providers.LoadOptions{})
 		runtimeCatalog = cat
 	})
-	return runtimeCatalog.RuntimeTools()
+	return agentToolsFromCatalogs(providers.EmbeddedCatalog(), runtimeCatalog)
+}
+
+func agentToolsFromCatalogs(embedded, loaded providers.Catalog) map[string]models.AgentToolConfig {
+	registry := embedded.RuntimeTools()
+	for name, tool := range loaded.RuntimeTools() {
+		if _, exists := registry[name]; exists {
+			continue
+		}
+		registry[name] = tool
+	}
+	return registry
 }
 
 func AgentToolRegistry(config models.Config) map[string]models.AgentToolConfig {
@@ -184,7 +196,7 @@ func ResolveLaunchPlan(req LaunchPlanRequest) (LaunchPlan, error) {
 	}
 	sessionTemplate := strings.TrimSpace(tool.ACPXSessionName)
 	if sessionTemplate == "" && backend == ToolBackendACPX {
-		sessionTemplate = "liza-{{agentID}}"
+		sessionTemplate = acpxSessionName("{{agentID}}")
 	}
 
 	vars := launchTemplateVars(req, toolName)
@@ -211,6 +223,10 @@ func ResolveLaunchPlan(req LaunchPlanRequest) (LaunchPlan, error) {
 	if err != nil {
 		return LaunchPlan{}, fmt.Errorf("%s acpx ensure args: %w", toolName, err)
 	}
+	acpxSetModeArgs, err := renderArgs(tool.ACPXSetModeArgs, vars)
+	if err != nil {
+		return LaunchPlan{}, fmt.Errorf("%s acpx set-mode args: %w", toolName, err)
+	}
 	acpxPromptArgs, err := renderArgs(tool.ACPXPromptArgs, vars)
 	if err != nil {
 		return LaunchPlan{}, fmt.Errorf("%s acpx prompt args: %w", toolName, err)
@@ -235,6 +251,7 @@ func ResolveLaunchPlan(req LaunchPlanRequest) (LaunchPlan, error) {
 		ACPXSessionName:      acpxSessionName,
 		ACPXShowArgs:         acpxShowArgs,
 		ACPXEnsureArgs:       acpxEnsureArgs,
+		ACPXSetModeArgs:      acpxSetModeArgs,
 		ACPXPromptArgs:       acpxPromptArgs,
 		ACPXEventMode:        strings.TrimSpace(tool.ACPXEventMode),
 	}, nil
@@ -283,6 +300,9 @@ func mergeAgentToolConfig(name string, base, override models.AgentToolConfig) mo
 	}
 	if len(override.ACPXEnsureArgs) > 0 {
 		out.ACPXEnsureArgs = append([]string(nil), override.ACPXEnsureArgs...)
+	}
+	if len(override.ACPXSetModeArgs) > 0 {
+		out.ACPXSetModeArgs = append([]string(nil), override.ACPXSetModeArgs...)
 	}
 	if len(override.ACPXPromptArgs) > 0 {
 		out.ACPXPromptArgs = append([]string(nil), override.ACPXPromptArgs...)

--- a/internal/agent/launch_resolver.go
+++ b/internal/agent/launch_resolver.go
@@ -24,8 +24,10 @@ const (
 var templateExprRE = regexp.MustCompile(`\{\{([^{}]+)\}\}`)
 
 var (
-	runtimeCatalogOnce sync.Once
-	runtimeCatalog     providers.Catalog
+	runtimeCatalogOnce  sync.Once
+	runtimeCatalog      providers.Catalog
+	embeddedCatalogOnce sync.Once
+	embeddedCatalog     providers.Catalog
 )
 
 type ResolvedProfile struct {
@@ -74,20 +76,20 @@ type LaunchPlanRequest struct {
 }
 
 func BuiltInAgentTools() map[string]models.AgentToolConfig {
+	embeddedCatalogOnce.Do(func() {
+		embeddedCatalog = providers.EmbeddedCatalog()
+	})
 	runtimeCatalogOnce.Do(func() {
 		cat, _ := providers.Load(context.Background(), providers.LoadOptions{})
 		runtimeCatalog = cat
 	})
-	return agentToolsFromCatalogs(providers.EmbeddedCatalog(), runtimeCatalog)
+	return agentToolsFromCatalogs(embeddedCatalog, runtimeCatalog)
 }
 
 func agentToolsFromCatalogs(embedded, loaded providers.Catalog) map[string]models.AgentToolConfig {
 	registry := embedded.RuntimeTools()
 	for name, tool := range loaded.RuntimeTools() {
-		if _, exists := registry[name]; exists {
-			continue
-		}
-		registry[name] = tool
+		registry[name] = mergeAgentToolConfig(name, registry[name], tool)
 	}
 	return registry
 }
@@ -201,14 +203,14 @@ func ResolveLaunchPlan(req LaunchPlanRequest) (LaunchPlan, error) {
 
 	vars := launchTemplateVars(req, toolName)
 	vars["acpxAgent"] = acpxAgent
-	acpxSessionName := ""
+	renderedSessionName := ""
 	if sessionTemplate != "" {
 		var err error
-		acpxSessionName, err = renderArg(sessionTemplate, vars)
+		renderedSessionName, err = renderArg(sessionTemplate, vars)
 		if err != nil {
 			return LaunchPlan{}, fmt.Errorf("%s acpx session name: %w", toolName, err)
 		}
-		vars["sessionName"] = acpxSessionName
+		vars["sessionName"] = renderedSessionName
 	}
 
 	renderedArgs, err := renderArgs(args, vars)
@@ -248,7 +250,7 @@ func ResolveLaunchPlan(req LaunchPlanRequest) (LaunchPlan, error) {
 		RequiresCodexWrapper: toolName == "codex",
 		ProviderKey:          strings.TrimSpace(tool.ProviderKey),
 		ACPXAgent:            acpxAgent,
-		ACPXSessionName:      acpxSessionName,
+		ACPXSessionName:      renderedSessionName,
 		ACPXShowArgs:         acpxShowArgs,
 		ACPXEnsureArgs:       acpxEnsureArgs,
 		ACPXSetModeArgs:      acpxSetModeArgs,

--- a/internal/agent/launch_resolver_test.go
+++ b/internal/agent/launch_resolver_test.go
@@ -68,6 +68,80 @@ func TestAgentToolRegistryMergesCustomTools(t *testing.T) {
 	}
 }
 
+func TestAgentToolsFromCatalogsMergesLoadedOverEmbedded(t *testing.T) {
+	embedded := providers.Catalog{
+		Providers: []providers.Provider{
+			{
+				ID:      "cursor",
+				Backend: "cli",
+				Runtime: providers.Runtime{
+					Executable:      "cursor",
+					RunArgs:         []string{"--embedded"},
+					ACPXSetModeArgs: []string{"embedded-set-mode"},
+					ACPXPromptArgs:  []string{"embedded-prompt"},
+				},
+			},
+			{
+				ID:      "claude",
+				Backend: "cli",
+				Runtime: providers.Runtime{
+					Executable: "claude",
+					RunArgs:    []string{"-p"},
+				},
+			},
+		},
+	}
+	loaded := providers.Catalog{
+		Providers: []providers.Provider{
+			{
+				ID:      "cursor",
+				Backend: "cli",
+				Runtime: providers.Runtime{
+					Executable:      "cursor-agent",
+					RunArgs:         []string{"--loaded"},
+					ACPXSetModeArgs: []string{"loaded-set-mode"},
+				},
+			},
+			{
+				ID:      "newtool",
+				Backend: "cli",
+				Runtime: providers.Runtime{
+					Executable: "newtool",
+					RunArgs:    []string{"--new"},
+				},
+			},
+		},
+	}
+
+	registry := agentToolsFromCatalogs(embedded, loaded)
+
+	cursor, ok := registry["cursor"]
+	if !ok {
+		t.Fatal("cursor tool missing from merged registry")
+	}
+	if cursor.Executable != "cursor-agent" {
+		t.Fatalf("cursor executable = %q, want loaded catalog value", cursor.Executable)
+	}
+	if !slices.Equal(cursor.RunArgs, []string{"--loaded"}) {
+		t.Fatalf("cursor run args = %v, want loaded catalog value", cursor.RunArgs)
+	}
+	if !slices.Equal(cursor.ACPXSetModeArgs, []string{"loaded-set-mode"}) {
+		t.Fatalf("cursor set-mode args = %v, want loaded catalog value", cursor.ACPXSetModeArgs)
+	}
+	if !slices.Equal(cursor.ACPXPromptArgs, []string{"embedded-prompt"}) {
+		t.Fatalf("cursor prompt args = %v, want embedded fallback value", cursor.ACPXPromptArgs)
+	}
+
+	if _, ok := registry["claude"]; !ok {
+		t.Fatal("embedded-only tool missing from merged registry")
+	}
+	if newTool, ok := registry["newtool"]; !ok {
+		t.Fatal("loaded-only tool missing from merged registry")
+	} else if newTool.Executable != "newtool" {
+		t.Fatalf("newtool executable = %q, want loaded catalog value", newTool.Executable)
+	}
+}
+
 func TestResolveProfileAndCLIWithStructuredProfiles(t *testing.T) {
 	config := models.Config{
 		DefaultDoerProfile: "careful",

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -178,6 +178,7 @@ type AgentToolConfig struct {
 	ACPXSessionName     string   `yaml:"acpx_session_name,omitempty"`
 	ACPXShowArgs        []string `yaml:"acpx_show_args,omitempty"`
 	ACPXEnsureArgs      []string `yaml:"acpx_ensure_args,omitempty"`
+	ACPXSetModeArgs     []string `yaml:"acpx_set_mode_args,omitempty"`
 	ACPXPromptArgs      []string `yaml:"acpx_prompt_args,omitempty"`
 	ACPXEventMode       string   `yaml:"acpx_event_mode,omitempty"`
 }

--- a/internal/providers/catalog.go
+++ b/internal/providers/catalog.go
@@ -159,6 +159,7 @@ type Runtime struct {
 	ACPXSessionName     string   `yaml:"acpx_session_name,omitempty"`
 	ACPXShowArgs        []string `yaml:"acpx_show_args,omitempty"`
 	ACPXEnsureArgs      []string `yaml:"acpx_ensure_args,omitempty"`
+	ACPXSetModeArgs     []string `yaml:"acpx_set_mode_args,omitempty"`
 	ACPXPromptArgs      []string `yaml:"acpx_prompt_args,omitempty"`
 	ACPXEventMode       string   `yaml:"acpx_event_mode,omitempty"`
 }
@@ -503,6 +504,7 @@ func runtimeToolConfig(id, backend string, rt Runtime) models.AgentToolConfig {
 		ACPXSessionName:     rt.ACPXSessionName,
 		ACPXShowArgs:        append([]string(nil), rt.ACPXShowArgs...),
 		ACPXEnsureArgs:      append([]string(nil), rt.ACPXEnsureArgs...),
+		ACPXSetModeArgs:     append([]string(nil), rt.ACPXSetModeArgs...),
 		ACPXPromptArgs:      append([]string(nil), rt.ACPXPromptArgs...),
 		ACPXEventMode:       rt.ACPXEventMode,
 	}

--- a/internal/providers/catalog_test.go
+++ b/internal/providers/catalog_test.go
@@ -77,6 +77,10 @@ func TestEmbeddedCatalogResolvesBuiltInsAndAliases(t *testing.T) {
 	if q.Backend != "acpx" || q.ACPXAgent != "codex" || !slices.Equal(q.RequiredExecutables, []string{"acpx"}) {
 		t.Fatalf("codex-acp runtime = %+v, want configured ACPX target", q)
 	}
+	cursorTool := tools["cursor-acp"]
+	if !slices.Equal(cursorTool.ACPXSetModeArgs, []string{"--cwd", "{{projectRoot}}", "{{acpxAgent}}", "set-mode", "agent", "-s", "{{sessionName}}"}) {
+		t.Fatalf("cursor-acp ACPXSetModeArgs = %v, want Cursor agent mode before prompt", cursorTool.ACPXSetModeArgs)
+	}
 	if tools["kimi"].ContractKey != "claude" {
 		t.Fatalf("kimi contract key = %q, want claude", tools["kimi"].ContractKey)
 	}
@@ -169,6 +173,16 @@ func TestRepositoryCatalogAddsRemoteProviders(t *testing.T) {
 	}
 	if !slices.Equal(cursor.Detection.Binaries, []string{"cursor-agent"}) {
 		t.Fatalf("provider-catalog.yaml cursor detection binaries = %v, want [cursor-agent]", cursor.Detection.Binaries)
+	}
+	// ACPXSetModeArgs is an ACP-specific field; check it on the synthesized
+	// cursor-acp provider's tool config, not the base cursor CLI runtime.
+	cursorACP, ok := cat.Resolve("cursor-acp")
+	if !ok {
+		t.Fatal("provider-catalog.yaml missing synthesized cursor-acp")
+	}
+	cursorACPTool := cursorACP.RuntimeToolConfig()
+	if !slices.Equal(cursorACPTool.ACPXSetModeArgs, []string{"--cwd", "{{projectRoot}}", "{{acpxAgent}}", "set-mode", "agent", "-s", "{{sessionName}}"}) {
+		t.Fatalf("provider-catalog.yaml cursor-acp ACPXSetModeArgs = %v, want Cursor agent mode before prompt", cursorACPTool.ACPXSetModeArgs)
 	}
 	qwenACP, ok := cat.Resolve("qwen-acp")
 	if !ok {

--- a/internal/providers/embedded.go
+++ b/internal/providers/embedded.go
@@ -103,6 +103,7 @@ providers:
       acpx_session_name: liza-{{agentID}}
       acpx_show_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", sessions, show, --name, "{{sessionName}}"]
       acpx_ensure_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", sessions, ensure, --name, "{{sessionName}}"]
+      acpx_set_mode_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", set-mode, agent, -s, "{{sessionName}}"]
       acpx_prompt_args: [--cwd, "{{projectRoot}}", --format, json, --approve-all, "{{acpxAgent}}", prompt, -s, "{{sessionName}}", --file, "-"]
       acpx_event_mode: json
 

--- a/provider-catalog.yaml
+++ b/provider-catalog.yaml
@@ -101,6 +101,7 @@ providers:
       acpx_session_name: liza-{{agentID}}
       acpx_show_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", sessions, show, --name, "{{sessionName}}"]
       acpx_ensure_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", sessions, ensure, --name, "{{sessionName}}"]
+      acpx_set_mode_args: [--cwd, "{{projectRoot}}", "{{acpxAgent}}", set-mode, agent, -s, "{{sessionName}}"]
       acpx_prompt_args: [--cwd, "{{projectRoot}}", --format, json, --approve-all, "{{acpxAgent}}", prompt, -s, "{{sessionName}}", --file, "-"]
       acpx_event_mode: json
 


### PR DESCRIPTION
## Summary

Port of PR 50 of EE to liza.

- Add optional ACPX session mode configuration args to provider/runtime config
- Configure Cursor ACP to run `cursor set-mode agent -s <session>` after session ensure and before prompt
- Add regression coverage proving Cursor ACP runs `sessions ensure → set-mode agent → prompt` in order
- `BuiltInAgentTools` now merges embedded catalog as base with remote catalog additions via `agentToolsFromCatalogs`, so ACP config (including `acpx_set_mode_args`) is always available from the embedded catalog even when the remote catalog hasn't been refreshed

Conflict resolution: `catalog.go` preserves liza's `runtimeToolConfig(id, backend, rt)` refactoring from PR #100 while adding `ACPXSetModeArgs`. `catalog_test.go` checks `ACPXSetModeArgs` on the synthesized `cursor-acp` provider (not the base cursor CLI runtime, which doesn't have ACP fields after PR #100's refactoring).

Generated with [Devin](https://devin.ai)