### PR TITLE
fix: keep managed git hooks intact and derive the build version from git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,12 @@ BRAND_CHECKSUM_BASE_URL?=$(BRAND_RELEASE_BASE_URL)
 BINARY_NAME?=$(BRAND_BINARY_NAME)
 
 # Build variables
-VERSION?=0.2.0
+# Derived from git rather than pinned, because a pinned default goes stale and
+# then lies: the binary claimed 0.2.0 long after 0.8.0 shipped. The fallback is
+# deliberately not semver — a hand-built binary is not a release, and the
+# updater only considers a valid semver current version, so a source build is
+# left alone instead of being offered a release to overwrite itself with.
+VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X 'github.com/liza-mas/liza/internal/embedded.Version=$(VERSION)' \

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,15 @@ BINARY_NAME?=$(BRAND_BINARY_NAME)
 
 # Build variables
 # Derived from git rather than pinned, because a pinned default goes stale and
-# then lies: the binary claimed 0.2.0 long after 0.8.0 shipped. The fallback is
-# deliberately not semver — a hand-built binary is not a release, and the
-# updater only considers a valid semver current version, so a source build is
-# left alone instead of being offered a release to overwrite itself with.
-VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# then lies: the binary claimed 0.2.0 long after 0.8.0 shipped. Only an exact,
+# clean tag produces the semver value — anything else (commits past the tag, a
+# dirty tree, no tags, no git) is the non-semver "dev-<sha>". A prerelease-style
+# value like "v0.8.0-3-gabc123" would still be valid semver but would sort
+# *below* the v0.8.0 release, so the updater would offer to replace a newer
+# dev build with an older one. Non-semver keeps the updater's "valid semver
+# current version required" gate closed, so a source build is left alone
+# instead of being offered a release to overwrite itself with.
+VERSION?=$(shell tag=$$(git describe --tags --exact-match 2>/dev/null); if [ -n "$$tag" ] && [ -z "$$(git status --porcelain 2>/dev/null)" ]; then printf '%s' "$$tag"; else printf 'dev-%s' "$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"; fi)
 GIT_COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X 'github.com/liza-mas/liza/internal/embedded.Version=$(VERSION)' \

--- a/internal/pairingindex/hooks.go
+++ b/internal/pairingindex/hooks.go
@@ -955,8 +955,17 @@ func installManagedHook(hookPath, hook string) (HookAction, error) {
 	// or an elevated shell, and filesystems that do not support them. The
 	// wrapper fallback then sees no file, reinstalls from scratch and reports
 	// "installed" on every run instead of "verified" or "updated".
-	staged := hookPath + ".tmp"
-	if err := os.Remove(staged); err != nil && !os.IsNotExist(err) {
+	//
+	// The staging name is unique per invocation (rather than a fixed
+	// "<hook>.tmp") so this never deletes a file it did not create itself.
+	dir := filepath.Dir(hookPath)
+	stagingFile, err := os.CreateTemp(dir, filepath.Base(hookPath)+".tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("stage %s hook: %w", hook, err)
+	}
+	staged := stagingFile.Name()
+	stagingFile.Close()
+	if err := os.Remove(staged); err != nil {
 		return "", fmt.Errorf("clear staged %s hook: %w", hook, err)
 	}
 	if err := os.Symlink(hookDispatcherName(), staged); err != nil {
@@ -1022,6 +1031,7 @@ if [ -z "$repo_root" ]; then
 fi
 
 hook_name="${%s:-$(basename "$0")}"
+unset %s
 if [ "$hook_name" = "post-checkout" ] && [ "${3:-}" = "0" ]; then
 	exit 0
 fi
@@ -1040,7 +1050,7 @@ fi
 
 cd "$repo_root"
 "$script"
-`, ManagedHookMarker, hookNameEnvVar, scriptName())
+`, ManagedHookMarker, hookNameEnvVar, hookNameEnvVar, scriptName())
 }
 
 func looksLikeLegacyHookDispatcher(content string) bool {

--- a/internal/pairingindex/hooks.go
+++ b/internal/pairingindex/hooks.go
@@ -23,6 +23,15 @@ const ManagedIndexScriptMarker = "# PAIRING-INDEX-SCRIPT: managed"
 
 const legacyManagedIndexScriptMarker = "# LIZA-PAIRING-INDEX-SCRIPT: managed"
 
+// hookNameEnvVar carries the git hook name from the wrapper to the dispatcher.
+//
+// When the hook is a symlink to the dispatcher, the dispatcher reads the name
+// from $0. The wrapper installed where symlinks are unavailable execs the
+// dispatcher by its own name, so $0 says "liza-index-hook.sh" and the
+// post-checkout file-checkout short-circuit would never fire. The wrapper
+// therefore states the name explicitly.
+const hookNameEnvVar = "PAIRING_INDEX_HOOK_NAME"
+
 const stacklitArtifactName = "stacklit.json"
 const stacklitInsightsArtifactName = "stacklit-insights.json"
 const stacklitArchitectureArtifactName = "stacklit-architecture.json"
@@ -938,11 +947,26 @@ func installManagedHook(hookPath, hook string) (HookAction, error) {
 	if !managed {
 		return "", fmt.Errorf("%s at %s already exists and is not managed by %s", hook, hookPath, brand.NameTitle)
 	}
-	if err := os.Remove(hookPath); err != nil {
-		return "", fmt.Errorf("replace %s hook wrapper: %w", hook, err)
+
+	// Build the symlink beside the hook and move it into place, rather than
+	// removing the hook first. os.Symlink cannot overwrite an existing file, but
+	// removing before knowing whether the link can be created destroys a working
+	// wrapper wherever symlinks are unavailable — Windows without Developer Mode
+	// or an elevated shell, and filesystems that do not support them. The
+	// wrapper fallback then sees no file, reinstalls from scratch and reports
+	// "installed" on every run instead of "verified" or "updated".
+	staged := hookPath + ".tmp"
+	if err := os.Remove(staged); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("clear staged %s hook: %w", hook, err)
 	}
-	if err := os.Symlink(hookDispatcherName(), hookPath); err != nil {
+	if err := os.Symlink(hookDispatcherName(), staged); err != nil {
 		return installManagedHookWrapper(hookPath, hook)
+	}
+	if err := os.Rename(staged, hookPath); err != nil {
+		if removeErr := os.Remove(staged); removeErr != nil && !os.IsNotExist(removeErr) {
+			return "", fmt.Errorf("replace %s hook: %w (and clearing %s failed: %v)", hook, err, staged, removeErr)
+		}
+		return "", fmt.Errorf("replace %s hook: %w", hook, err)
 	}
 	return HookActionUpdated, nil
 }
@@ -981,10 +1005,10 @@ func managedHookContent(hook string) string {
 hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 0
 dispatcher="$hook_dir/%s"
 if [ -x "$dispatcher" ]; then
-	"$dispatcher" "$@"
+	%s=%s "$dispatcher" "$@"
 fi
 exit 0
-		`, ManagedHookMarker, hook, hookDispatcherName())
+		`, ManagedHookMarker, hook, hookDispatcherName(), hookNameEnvVar, shellQuote(hook))
 }
 
 func managedHookDispatcherContent() string {
@@ -997,7 +1021,7 @@ if [ -z "$repo_root" ]; then
 	exit 0
 fi
 
-hook_name="$(basename "$0")"
+hook_name="${%s:-$(basename "$0")}"
 if [ "$hook_name" = "post-checkout" ] && [ "${3:-}" = "0" ]; then
 	exit 0
 fi
@@ -1016,7 +1040,7 @@ fi
 
 cd "$repo_root"
 "$script"
-`, ManagedHookMarker, scriptName())
+`, ManagedHookMarker, hookNameEnvVar, scriptName())
 }
 
 func looksLikeLegacyHookDispatcher(content string) bool {

--- a/internal/pairingindex/hooks_test.go
+++ b/internal/pairingindex/hooks_test.go
@@ -173,6 +173,41 @@ func TestInstallLifecycleHooksRefreshesStaleManagedHook(t *testing.T) {
 	}
 }
 
+func TestInstallLifecycleHooksRefreshPreservesUnrelatedStagingFile(t *testing.T) {
+	repo := initGitRepo(t)
+	hooksDir := filepath.Join(repo, ".git", "hooks")
+	hookPath := filepath.Join(hooksDir, "post-merge")
+	staleContent := ManagedHookMarker + "\n# stale wrapper from an older Liza release\n"
+	if err := os.WriteFile(hookPath, []byte(staleContent), 0644); err != nil {
+		t.Fatalf("write stale managed hook: %v", err)
+	}
+
+	unrelatedStaged := hookPath + ".tmp"
+	unrelatedContent := "not managed by liza\n"
+	if err := os.WriteFile(unrelatedStaged, []byte(unrelatedContent), 0644); err != nil {
+		t.Fatalf("write unrelated %s: %v", unrelatedStaged, err)
+	}
+
+	result, err := InstallLifecycleHooks(InstallHooksOptions{RepoRoot: repo})
+	if err != nil {
+		t.Fatalf("InstallLifecycleHooks() error = %v", err)
+	}
+
+	index := slices.IndexFunc(result.Hooks, func(got HookInstallResult) bool {
+		return got.Hook == "post-merge"
+	})
+	if index == -1 {
+		t.Fatalf("missing post-merge result: %#v", result.Hooks)
+	}
+	if result.Hooks[index].Action != HookActionUpdated {
+		t.Fatalf("post-merge action = %q, want %q", result.Hooks[index].Action, HookActionUpdated)
+	}
+	got := readFile(t, unrelatedStaged)
+	if got != unrelatedContent {
+		t.Fatalf("unrelated staging file %s was modified: got %q, want %q", unrelatedStaged, got, unrelatedContent)
+	}
+}
+
 func TestManagedHookDispatcherInvokesLocalIndexScriptWithoutLifecycleArguments(t *testing.T) {
 	repo := initGitRepo(t)
 	result, err := InstallLifecycleHooks(InstallHooksOptions{
@@ -231,6 +266,55 @@ func TestManagedHookDispatcherSkipsPostCheckoutFileCheckout(t *testing.T) {
 	}
 	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
 		t.Fatalf("liza-index.sh ran for file checkout; stat err=%v", err)
+	}
+}
+
+func TestManagedHookWrapperPassesHookNameToDispatcherForPostCheckoutFileCheckout(t *testing.T) {
+	repo := initGitRepo(t)
+	hooksDir := filepath.Join(repo, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+
+	dispatcherPath := filepath.Join(hooksDir, hookDispatcherName())
+	if err := os.WriteFile(dispatcherPath, []byte(managedHookDispatcherContent()), 0755); err != nil {
+		t.Fatalf("write dispatcher fixture: %v", err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "args.log")
+	scriptPath := filepath.Join(hooksDir, scriptName())
+	script := "#!/bin/sh\nprintf 'ran\\n' > \"$LIZA_TEST_HOOK_LOG\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write liza-index.sh fixture: %v", err)
+	}
+
+	wrapper := managedHookContent("post-checkout")
+	if !strings.Contains(wrapper, hookNameEnvVar+"="+shellQuote("post-checkout")) {
+		t.Fatalf("wrapper does not pass %s to the dispatcher:\n%s", hookNameEnvVar, wrapper)
+	}
+	wrapperPath := filepath.Join(hooksDir, "post-checkout")
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+		t.Fatalf("write wrapper fixture: %v", err)
+	}
+
+	runWrapper := func(flag string) {
+		t.Helper()
+		cmd := exec.Command(wrapperPath, "old", "new", flag)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "LIZA_TEST_HOOK_LOG="+logPath)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("wrapper hook (flag=%s) failed: %v\n%s", flag, err, output)
+		}
+	}
+
+	runWrapper("0")
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("liza-index.sh ran through the wrapper for a file checkout; stat err=%v", err)
+	}
+
+	runWrapper("1")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("liza-index.sh did not run through the wrapper for a branch checkout: %v", err)
 	}
 }
 


### PR DESCRIPTION
Two independent defects, both found while getting the suite to run on Windows, neither specific to it. Sending them separately from the Windows work so they can be judged on their own.

Follows up on #104.

## 1. A managed git hook is destroyed before its replacement exists

`installManagedHook` removes the existing hook before calling `os.Symlink`, because `os.Symlink` cannot overwrite. When the symlink then fails, the wrapper fallback finds nothing where the hook used to be, reinstalls from scratch, and reports `installed` — every run.

Two consequences:

- A hook the user may have been running for months is deleted and recreated rather than verified.
- `verified` and `updated` never appear on that path, so the report is wrong about what happened.

The link is now created beside the hook and renamed over it. A failure to create it leaves the existing hook untouched, and the fallback sees the real previous state.

**The wrapper also loses the hook name.** It execs the dispatcher under the dispatcher's own name, so `basename "$0"` is never the hook that ran, and the dispatcher's post-checkout short-circuit — skip indexing when `$3` is `0`, a file checkout rather than a branch switch — cannot fire. Every `git checkout -- <file>` triggers a full re-index. The wrapper now passes the name in `PAIRING_INDEX_HOOK_NAME`; the dispatcher prefers it and falls back to `basename $0` for hooks installed as symlinks.

Existing installations migrate on the next run: the dispatcher content differs from the rendered one, carries the managed marker, and is rewritten as `updated`.

This path is reached wherever `os.Symlink` fails consistently. On Windows that is the default, which is how I ran into it, but nothing in the fix is Windows-specific.

## 2. Every source build claims version 0.2.0

`VERSION?=0.2.0` is pinned in the Makefile, so `make build` has reported 0.2.0 since long after 0.8.0 shipped.

That is not only cosmetic. The updater compares the running version against the latest release, so a binary reporting 0.2.0 believes it is several minor versions behind and offers to replace itself with the published release. The check is opt-in, so nothing fires by default, but the behaviour is armed for anyone who enables it.

`VERSION` now comes from git. Only an exact, clean tag — HEAD untouched since that tag, no local changes — reports the real version. Everywhere else (commits past the tag, a dirty tree, no tags, no git at all) reports the non-semver `dev-<short-sha>` (`dev-unknown` without git). An earlier version of this fix used `git describe --tags --always --dirty` directly, which reports a valid-but-prerelease semver value like `v0.8.0-3-gabc123` for any commit past a tag — `semver.Compare` sorts a prerelease below the release it precedes, so `lookupCandidate` judged that as *older* than the last release and would still offer to replace a newer dev build with an older one, which is the exact regression this fix exists to prevent. The exact-tag-only form closes that. Release builds are unaffected: GoReleaser passes its own version from the tag and never reads this variable.

## Change map

| File | What |
|------|------|
| `internal/pairingindex/hooks.go` | Stage the symlink and rename it over the hook; pass the hook name to the dispatcher |
| `Makefile` | Derive `VERSION` from git |

## Validation

- `go build ./...` and `go vet ./internal/pairingindex/` clean.
- `internal/pairingindex` on windows/amd64: 19 failures on `main` alone, the same 19 with these two commits, compared by test name. No regression. Those 19 are the pre-existing Windows symlink and PATHEXT problems, which are not addressed here.
- I could not exercise the Unix symlink path locally — this machine has neither Developer Mode nor the privilege — so CI is the check that matters for the happy path.

## Risks

The hook change alters the order of operations on a path that is exercised on every `init`. On a host where `os.Symlink` succeeds, the observable outcome is the same symlink as before, created through a rename over a per-invocation-unique staging name (via `os.CreateTemp`) rather than a fixed `<hook>.tmp` — an earlier version of this fix used the fixed name, which could delete an unrelated file that happened to exist there. The rename protects the existing hook if creating the new symlink fails; `os.Rename` is not documented as atomic on non-Unix platforms even within one directory, so this is not a portable atomic-replacement guarantee — only that a failed replacement leaves the previous hook in place.

## Not in scope

Native Windows support itself. That is a much larger change — portability, test equivalents, CI, packaging — and I would rather send it once it is green than drag these two fixes behind it.

