### PR TITLE
fix(pre-commit): make GOPROXY file:// URLs portable to Git Bash on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,9 +70,13 @@ repos:
 
       # Codex sandbox cannot write the normal Go caches or use normal module
       # resolution here; use the writable local module cache intentionally.
+      # The file:// URL needs a native Windows path (C:/...) rather than the
+      # MSYS form ($HOME under Git Bash) — Go rejects the latter as missing a
+      # drive letter. cygpath -m only exists on Git-Bash/MSYS; elsewhere $HOME
+      # is already in the form file:// expects.
       - id: goimports
         name: goimports (format + imports)
-        entry: bash -c 'export PATH="/usr/local/go/bin:$PATH"; export GOPATH="${HOME}/.cache/go" GOMODCACHE="${HOME}/.cache/go/pkg/mod" GOCACHE="${HOME}/.cache/go/build" GOPROXY="file://${HOME}/.cache/go/pkg/mod/cache/download,off" GOSUMDB=off; mkdir -p "$GOPATH" "$GOMODCACHE" "$GOCACHE"; go run golang.org/x/tools/cmd/goimports@latest -w "$@"' --
+        entry: bash -c 'home_native="$HOME"; command -v cygpath >/dev/null 2>&1 && home_native="/$(cygpath -m "$HOME")"; export PATH="/usr/local/go/bin:$PATH"; export GOPATH="${HOME}/.cache/go" GOMODCACHE="${HOME}/.cache/go/pkg/mod" GOCACHE="${HOME}/.cache/go/build" GOPROXY="file://${home_native}/.cache/go/pkg/mod/cache/download,off" GOSUMDB=off; mkdir -p "$GOPATH" "$GOMODCACHE" "$GOCACHE"; go run golang.org/x/tools/cmd/goimports@latest -w "$@"' --
         language: system
         files: \.go$
 
@@ -85,7 +89,7 @@ repos:
 
       - id: staticcheck
         name: staticcheck (advanced static analysis)
-        entry: bash -c 'export PATH="/usr/local/go/bin:$PATH"; export GOPATH="${HOME}/.cache/go" GOMODCACHE="${HOME}/.cache/go/pkg/mod" GOCACHE="${HOME}/.cache/go/build" GOPROXY="file://${HOME}/.cache/go/pkg/mod/cache/download,off" GOSUMDB=off; mkdir -p "$GOPATH" "$GOMODCACHE" "$GOCACHE"; make sync-embedded && go run honnef.co/go/tools/cmd/staticcheck@latest ./...'
+        entry: bash -c 'home_native="$HOME"; command -v cygpath >/dev/null 2>&1 && home_native="/$(cygpath -m "$HOME")"; export PATH="/usr/local/go/bin:$PATH"; export GOPATH="${HOME}/.cache/go" GOMODCACHE="${HOME}/.cache/go/pkg/mod" GOCACHE="${HOME}/.cache/go/build" GOPROXY="file://${home_native}/.cache/go/pkg/mod/cache/download,off" GOSUMDB=off; mkdir -p "$GOPATH" "$GOMODCACHE" "$GOCACHE"; make sync-embedded && go run honnef.co/go/tools/cmd/staticcheck@latest ./...'
         language: system
         files: \.go$
         pass_filenames: false
@@ -99,7 +103,7 @@ repos:
 
       - id: go-mod-tidy
         name: go mod tidy (dependency cleanup)
-        entry: bash -c 'export PATH="/usr/local/go/bin:$PATH"; export GOPATH="${HOME}/.cache/go" GOMODCACHE="${HOME}/.cache/go/pkg/mod" GOCACHE="${HOME}/.cache/go/build" GOPROXY="file://${HOME}/.cache/go/pkg/mod/cache/download,off" GOSUMDB=off; mkdir -p "$GOPATH" "$GOMODCACHE" "$GOCACHE"; make sync-embedded && go mod tidy'
+        entry: bash -c 'home_native="$HOME"; command -v cygpath >/dev/null 2>&1 && home_native="/$(cygpath -m "$HOME")"; export PATH="/usr/local/go/bin:$PATH"; export GOPATH="${HOME}/.cache/go" GOMODCACHE="${HOME}/.cache/go/pkg/mod" GOCACHE="${HOME}/.cache/go/build" GOPROXY="file://${home_native}/.cache/go/pkg/mod/cache/download,off" GOSUMDB=off; mkdir -p "$GOPATH" "$GOMODCACHE" "$GOCACHE"; make sync-embedded && go mod tidy'
         language: system
         files: ^(go\.mod|go\.sum|.*\.go)$
         pass_filenames: false


### PR DESCRIPTION
Found while getting `.pre-commit-config.yaml` to run under Git Bash on Windows.

## The bug

`goimports`, `staticcheck`, and `go-mod-tidy` build a `GOPROXY` pointing at a local, writable module cache — deliberately offline-safe for environments (the Codex sandbox is named in the comment) that cannot reach the network or write the normal Go caches:

```
GOPROXY="file://${HOME}/.cache/go/pkg/mod/cache/download,off"
```

Under Git Bash on Windows, `$HOME` is in MSYS form (`/c/Users/...`). Go's `file://` proxy handler parses that as a host-relative path with no drive letter and rejects it outright:

```
go: golang.org/x/tools/cmd/goimports@latest: module lookup disabled by GOPROXY=off
```

(earlier, before a partial fix already on `main`, the message was `file URL missing drive letter`). This fires on every invocation of these three hooks, regardless of whether anything is actually cached — so they never work locally on Windows/Git Bash.

## The fix

Derive a native Windows path (`C:/Users/...`) via `cygpath -m` when it's available (Git Bash/MSYS only) before building the `file://` URL. Everywhere else `$HOME` is already in the form the URL expects, so the fallback is a no-op — verified the three-slash form (`file:///C:/...`) is what Go actually accepts; a plain `file://C:/...` is rejected as an "invalid file:// proxy URL with non-path elements" (the `C:` is parsed as a URL host).

## Validation

- `pre-commit run --files .pre-commit-config.yaml internal/pairingindex/hooks.go` on Windows/Git Bash: `goimports` now **Passed** (previously failed on the URL every time).
- `go-vet`/`staticcheck`/`go-mod-tidy` still surface unrelated, pre-existing issues on this machine (a `syscall.Kill` Windows-portability gap in `internal/agent`, and an incompletely-seeded local hermetic cache) — neither caused by or fixed by this change, both outside its scope.

## Not in scope

The `syscall.Kill` compile error in `internal/agent/supervisor_lifecycle_test.go` surfaced while validating this — a genuine pre-existing Windows gap, not touched here.
